### PR TITLE
Remove the default streamer block start height config

### DIFF
--- a/config/chainstorage/arbitrum/mainnet/development.yml
+++ b/config/chainstorage/arbitrum/mainnet/development.yml
@@ -4,8 +4,6 @@ aws:
   bucket: example-chainstorage-arbitrum-mainnet-dev
 cadence:
   address: temporal-dev.example.com:7233
-chain:
-  block_start_height: 15000000
 sdk:
   chainstorage_address: https://nft-api.coinbase.com/api/exp/chainstorage/arbitrum/mainnet/v1
 server:

--- a/config/chainstorage/optimism/mainnet/development.yml
+++ b/config/chainstorage/optimism/mainnet/development.yml
@@ -4,8 +4,6 @@ aws:
   bucket: example-chainstorage-optimism-mainnet-dev
 cadence:
   address: temporal-dev.example.com:7233
-chain:
-  block_start_height: 37000000
 sdk:
   chainstorage_address: https://nft-api.coinbase.com/api/exp/chainstorage/optimism/mainnet/v1
 server:


### PR DESCRIPTION
### What changed? Why?
The block_start_height config is in the development environment, and this config impacts the job running in chainsformer.
 
