### PR TITLE
Add nft header

### DIFF
--- a/internal/gateway/rest_client.go
+++ b/internal/gateway/rest_client.go
@@ -237,6 +237,7 @@ func (c *restClient) makeRequest(ctx context.Context, method string, request pro
 		httpRequest.Header.Set("Accept", "application/json")
 		if c.authHeader != "" && c.authToken != "" {
 			httpRequest.Header.Set(c.authHeader, c.authToken)
+			httpRequest.Header.Set("cb-nft-api-token", c.authToken)
 		}
 
 		c.logger.Debug(


### PR DESCRIPTION
### What changed? Why?
Add a new header `cb-nft-api-token` to access coinbase endpoint.

### How did you test the change?
- [x] unit test
- [x] integration test
- [x] functional test
- [x] adhoc test (described below)
