### PR TITLE
Resolve CircleCI build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build_and_test:
     docker:
-      - image: ${CIPHEROWL_ECR_URL}/cipherowl/circleci:0f132f714d9f0eb2d8ac3cf12b02cd45507f1f74
+      - image: ${CIPHEROWL_ECR_URL}/cipherowl/circleci:1d37a87f73dd5dfb2c36b6ad25ab48ada1768717
     working_directory: ~/chainstorage
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
             docker run --network chainstorage_default \
               --volumes-from chainstorage \
               -w /home/circleci/chainstorage \
-              ${CIPHEROWL_ECR_URL}/cipherowl/circleci:0f132f714d9f0eb2d8ac3cf12b02cd45507f1f74 \
+              ${CIPHEROWL_ECR_URL}/cipherowl/circleci:1d37a87f73dd5dfb2c36b6ad25ab48ada1768717 \
               /bin/bash -c "sudo chown -R circleci:circleci ~/ && make bootstrap && TEST_TYPE=integration go test ./... -v -p=1 -parallel=1 -timeout=15m -failfast -run=TestIntegration"
       - run:
           name: Run functional tests
@@ -46,7 +46,7 @@ jobs:
             # docker run --network chainstorage_default \
             #  --volumes-from chainstorage \
             #  -w /home/circleci/chainstorage \
-            #  ${CIPHEROWL_ECR_URL}/cipherowl/circleci:0f132f714d9f0eb2d8ac3cf12b02cd45507f1f74 \
+            #  ${CIPHEROWL_ECR_URL}/cipherowl/circleci:1d37a87f73dd5dfb2c36b6ad25ab48ada1768717 \
             #  /bin/bash -c "sudo chown -R circleci:circleci ~/ && make bootstrap && TEST_TYPE=functional go test ./... -v -p=1 -parallel=1 -timeout=45m -failfast -run=TestIntegration"
             
             docker-compose -f docker-compose-testing.yml down


### PR DESCRIPTION
### What changed? Why?
The CircleCI build workflow failed after upgrading the Go version from 1.20 to 1.22.
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/e6e1af61-c653-49af-8624-b8da27998172" />
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/c444d028-11ff-4c08-811b-5b93c889b4d0" />

 
### How did you test the change?
- [x] unit test
- [x] integration test
- [x] functional test
