### PR TITLE
fix overwrite bug in Tron Nativate Parser

### DIFF
--- a/internal/blockchain/parser/ethereum/ethereum_native.go
+++ b/internal/blockchain/parser/ethereum/ethereum_native.go
@@ -583,7 +583,6 @@ func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 	if p.config.Blockchain() == common.Blockchain_BLOCKCHAIN_TRON {
 		if err := postProcessTronBlock(
 			blobdata,
-			metadata,
 			header,
 			transactions,
 			transactionReceipts,
@@ -620,8 +619,8 @@ func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 		Blockchain:      rawBlock.Blockchain,
 		Network:         rawBlock.Network,
 		Tag:             metadata.Tag,
-		Hash:            metadata.Hash,
-		ParentHash:      metadata.ParentHash,
+		Hash:            header.Hash,
+		ParentHash:      header.ParentHash,
 		Height:          metadata.Height,
 		ParentHeight:    metadata.ParentHeight,
 		Timestamp:       header.Timestamp,

--- a/internal/blockchain/parser/ethereum/tron_native.go
+++ b/internal/blockchain/parser/ethereum/tron_native.go
@@ -236,7 +236,6 @@ func convertTokenTransfer(data *api.EthereumTokenTransfer) {
 
 func postProcessTronBlock(
 	blobData *api.EthereumBlobdata,
-	metaData *api.BlockMetadata,
 	header *api.EthereumHeader,
 	transactions []*api.EthereumTransaction,
 	txReceipts []*api.EthereumTransactionReceipt,
@@ -246,8 +245,6 @@ func postProcessTronBlock(
 	if err := parseTronTxInfo(blobData, header, transactionToFlattenedTracesMap, txReceipts); err != nil {
 		return xerrors.Errorf("failed to parse transaction parity traces: %w", err)
 	}
-	metaData.Hash = toTronHash(metaData.Hash)
-	metaData.ParentHash = toTronHash(metaData.ParentHash)
 
 	header.Hash = toTronHash(header.Hash)
 	header.ParentHash = toTronHash(header.ParentHash)


### PR DESCRIPTION
### What changed? Why?
fix overwriting bug of block hash in metadata after postprocess of Tron Native Parser

### How did you test the change?
- unit test
```
--- fmt
./internal/workflow/replicator.go
./internal/workflow/activity/replicator.go
./internal/workflow/activity/latest_block.go
--- lint
go vet -printfuncs=wrapf,statusf,warnf,infof,debugf,failf,equalf,containsf,fprintf,sprintf ./...
errcheck -ignoretests -ignoregenerated ./...
ineffassign ./...
--- test
TEST_TYPE=unit go test ./... -run=.
?       github.com/coinbase/chainstorage/cmd/admin      [no test files]
?       github.com/coinbase/chainstorage/config [no test files]
?       github.com/coinbase/chainstorage/examples/batch [no test files]
?       github.com/coinbase/chainstorage/examples/batch-consumer        [no test files]
?       github.com/coinbase/chainstorage/examples/batchpull     [no test files]
?       github.com/coinbase/chainstorage/examples/stream        [no test files]
?       github.com/coinbase/chainstorage/examples/unified       [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain    [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain/bootstrap  [no test files]
ok      github.com/coinbase/chainstorage/cmd/api        2.667s
ok      github.com/coinbase/chainstorage/cmd/cron       4.114s
ok      github.com/coinbase/chainstorage/cmd/server     1.447s
ok      github.com/coinbase/chainstorage/cmd/worker     5.023s
ok      github.com/coinbase/chainstorage/internal/aws   (cached)
?       github.com/coinbase/chainstorage/internal/blockchain/client/mocks       [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/client     2.628s
ok      github.com/coinbase/chainstorage/internal/blockchain/client/aptos       3.047s
ok      github.com/coinbase/chainstorage/internal/blockchain/client/bitcoin     4.141s
?       github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks      [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/client/ethereum    18.268s
ok      github.com/coinbase/chainstorage/internal/blockchain/client/ethereum/beacon 11.280s
ok      github.com/coinbase/chainstorage/internal/blockchain/client/internal    5.618s
ok      github.com/coinbase/chainstorage/internal/blockchain/client/rosetta     4.831s
ok      github.com/coinbase/chainstorage/internal/blockchain/client/solana      5.312s
ok      github.com/coinbase/chainstorage/internal/blockchain/endpoints  (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/aptos 4.749s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/arbitrum       4.805s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/base  5.533s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/bitcoin4.032s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/bsc   4.055s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/ethereum       4.001s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/fantom3.965s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/optimism       3.654s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/polygon4.378s
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/rosetta3.346s
?       github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum/types  [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain/parser/mocks       [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain/restapi/mocks      [no test files]
?       github.com/coinbase/chainstorage/internal/cadence       [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/solana4.689s
ok      github.com/coinbase/chainstorage/internal/blockchain/jsonrpc    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser     3.876s
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/aptos       (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/bitcoin     (cached)
?       github.com/coinbase/chainstorage/internal/dlq   [no test files]
?       github.com/coinbase/chainstorage/internal/dlq/firestore [no test files]
?       github.com/coinbase/chainstorage/internal/dlq/internal  [no test files]
?       github.com/coinbase/chainstorage/internal/dlq/mocks     [no test files]
?       github.com/coinbase/chainstorage/internal/gateway       [no test files]
?       github.com/coinbase/chainstorage/internal/s3/mocks      [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum    4.683s
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum/beacon (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/internal    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/rosetta     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/solana      (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/restapi    (cached)
ok      github.com/coinbase/chainstorage/internal/config        (cached)
ok      github.com/coinbase/chainstorage/internal/cron  1.113s
ok      github.com/coinbase/chainstorage/internal/dlq/sqs       (cached)
ok      github.com/coinbase/chainstorage/internal/s3    (cached)
?       github.com/coinbase/chainstorage/internal/storage       [no test files]
?       github.com/coinbase/chainstorage/internal/storage/blobstorage   [no test files]
?       github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader/mocks       [no test files]
?       github.com/coinbase/chainstorage/internal/storage/blobstorage/internal  [no test files]
?       github.com/coinbase/chainstorage/internal/storage/blobstorage/mocks     [no test files]
?       github.com/coinbase/chainstorage/internal/storage/internal/errors       [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage   [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/dynamodb/mocks[no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/dynamodb/model[no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/internal  [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/mocks     [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/model     [no test files]
?       github.com/coinbase/chainstorage/internal/utils/consts  [no test files]
?       github.com/coinbase/chainstorage/internal/utils/finalizer       [no test files]
?       github.com/coinbase/chainstorage/internal/utils/fxparams        [no test files]
?       github.com/coinbase/chainstorage/internal/utils/log     [no test files]
?       github.com/coinbase/chainstorage/internal/utils/pointer [no test files]
?       github.com/coinbase/chainstorage/internal/utils/testapp [no test files]
?       github.com/coinbase/chainstorage/internal/utils/timesource      [no test files]
?       github.com/coinbase/chainstorage/internal/workflow/activity/errors      [no test files]
?       github.com/coinbase/chainstorage/internal/workflow/instrument   [no test files]
?       github.com/coinbase/chainstorage/protos/coinbase/chainstorage/mocks     [no test files]
?       github.com/coinbase/chainstorage/sdk/mocks      [no test files]
?       github.com/coinbase/chainstorage/sdk/services   [no test files]
ok      github.com/coinbase/chainstorage/internal/server        32.520s
ok      github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader    (cached)
ok      github.com/coinbase/chainstorage/internal/storage/blobstorage/gcs       (cached)
ok      github.com/coinbase/chainstorage/internal/storage/blobstorage/s3        (cached)
ok      github.com/coinbase/chainstorage/internal/storage/metastorage/dynamodb  2.640s
ok      github.com/coinbase/chainstorage/internal/storage/metastorage/firestore 2.039s
ok      github.com/coinbase/chainstorage/internal/storage/utils (cached)
ok      github.com/coinbase/chainstorage/internal/tally (cached)
ok      github.com/coinbase/chainstorage/internal/tracer        (cached)
ok      github.com/coinbase/chainstorage/internal/utils/fixtures        (cached)
ok      github.com/coinbase/chainstorage/internal/utils/instrument      (cached)
ok      github.com/coinbase/chainstorage/internal/utils/picker  (cached)
ok      github.com/coinbase/chainstorage/internal/utils/ratelimiter     (cached)
ok      github.com/coinbase/chainstorage/internal/utils/retry   (cached)
ok      github.com/coinbase/chainstorage/internal/utils/syncgroup       (cached)
ok      github.com/coinbase/chainstorage/internal/utils/testutil        (cached)
ok      github.com/coinbase/chainstorage/internal/utils/utils   (cached)
ok      github.com/coinbase/chainstorage/internal/workflow      1.945s
ok      github.com/coinbase/chainstorage/internal/workflow/activity     2.834s
ok      github.com/coinbase/chainstorage/internal/workflow/integration_test     3.238s
ok      github.com/coinbase/chainstorage/protos/coinbase/c3/common      (cached)
ok      github.com/coinbase/chainstorage/protos/coinbase/chainstorage   (cached)
ok      github.com/coinbase/chainstorage/protos/coinbase/crypto/rosetta/types   (cached)
ok      github.com/coinbase/chainstorage/sdk    6.851s
ok      github.com/coinbase/chainstorage/sdk/integration_test   2.621s
ok      github.com/coinbase/chainstorage/tools/config_gen       (cached)
```