### PR TITLE
feat(tally): add prometheus metrics reporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
+	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type (
 		SLA            SLAConfig            `mapstructure:"sla"`
 		FunctionalTest FunctionalTestConfig `mapstructure:"functional_test"`
 		StatsD         *StatsDConfig        `mapstructure:"statsd"`
+		Prometheus     *PrometheusConfig    `mapstructure:"prometheus"`
 
 		namespace string
 		env       Env
@@ -416,6 +417,24 @@ type (
 	StatsDConfig struct {
 		Address string `mapstructure:"address" validate:"required"`
 		Prefix  string `mapstructure:"prefix"`
+	}
+
+	PrometheusConfig struct {
+		// Port is the port to listen on for the metrics server.
+		Port int `mapstructure:"port" validate:"required"`
+		// MetricsPath is the path to listen on for the metrics server.
+		MetricsPath string `mapstructure:"metrics_path"`
+		// Namespace is the namespace for the metrics.
+		Namespace string `mapstructure:"namespace"`
+		// GlobalLabels are labels that are applied to all metrics.
+		GlobalLabels map[string]string `mapstructure:"global_labels"`
+		// DefaultHistogramBuckets are the default buckets for histogram metrics
+		// if not specified in HistogramBuckets.
+		DefaultHistogramBuckets []float64 `mapstructure:"default_histogram_buckets"`
+		// HistogramBuckets are custom buckets for specific histogram metrics.
+		// This allows for more granular control over the histogram buckets on a
+		// per-metric basis.
+		HistogramBuckets map[string][]float64 `mapstructure:"histogram_buckets"`
 	}
 
 	ConfigOption func(options *configOptions)

--- a/internal/tally/prometheus_reporter.go
+++ b/internal/tally/prometheus_reporter.go
@@ -1,0 +1,469 @@
+package tally
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/uber-go/tally/v4"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+)
+
+var defaultBuckets = []float64{
+	0.1, 0.2, 0.3, 0.5, 0.7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+	12, 15, 20, 25, 30, 40, 50, 75, 100, 200, 300, 500, 750,
+	1000, 2000, 3000, 5000, 7000, 10000,
+}
+
+type prometheusReporter struct {
+	stats *prometheusStats
+}
+
+func newPrometheusReporter(
+	cfg *config.PrometheusConfig,
+	lifecycle fx.Lifecycle,
+	logger *zap.Logger,
+) tally.StatsReporter {
+	opts := []prometheusStatsOption{}
+	if cfg.Namespace != "" {
+		opts = append(opts, withPrometheusNamespace(cfg.Namespace))
+	}
+	if len(cfg.GlobalLabels) > 0 {
+		opts = append(opts, withPrometheusLabels(cfg.GlobalLabels))
+	}
+	if len(cfg.DefaultHistogramBuckets) > 0 {
+		opts = append(opts, withDefaultPrometheusHistogramBuckets(defaultBuckets))
+	}
+	if len(cfg.HistogramBuckets) > 0 {
+		opts = append(opts, withPrometheusHistogramBuckets(cfg.HistogramBuckets))
+	}
+
+	s := newPrometheusStats(logger, opts...)
+
+	mux := http.NewServeMux()
+
+	metricsPath := "/metrics"
+	if cfg.MetricsPath != "" {
+		metricsPath = cfg.MetricsPath
+	}
+	mux.Handle(metricsPath, s.MetricsHandler())
+
+	addr := fmt.Sprintf(":%d", cfg.Port)
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	lifecycle.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			logger.Info("prometheus metrics server starting", zap.String("address", addr))
+
+			go func() {
+				if err := srv.ListenAndServe(); err != nil {
+					if err != http.ErrServerClosed {
+						logger.Error("prometheus metrics server failed to start", zap.Error(err))
+					}
+				}
+			}()
+
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			logger.Info("prometheus metrics server stopping", zap.String("address", addr))
+			return srv.Shutdown(ctx)
+		},
+	})
+
+	return &prometheusReporter{
+		stats: s,
+	}
+}
+
+func (p *prometheusReporter) labels() prometheus.Labels {
+	return p.stats.Labels()
+}
+
+func (p *prometheusReporter) Capabilities() tally.Capabilities {
+	return p
+}
+
+func (p *prometheusReporter) Reporting() bool {
+	return true
+}
+
+func (p *prometheusReporter) Tagging() bool {
+	return true
+}
+
+func (p *prometheusReporter) Flush() {
+	// no-op
+}
+
+func (p *prometheusReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	p.stats.Count(name, value, p.tags(tags))
+}
+
+func (p *prometheusReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	p.stats.Gauge(name, value, p.tags(tags))
+}
+
+func (p *prometheusReporter) ReportHistogramDurationSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound time.Duration,
+	bucketUpperBound time.Duration,
+	samples int64,
+) {
+	panic("unimplemented")
+}
+
+func (p *prometheusReporter) ReportHistogramValueSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound float64,
+	bucketUpperBound float64,
+	samples int64,
+) {
+	panic("unimplemented")
+}
+
+func (p *prometheusReporter) ReportTimer(
+	name string,
+	tags map[string]string,
+	interval time.Duration,
+) {
+	p.stats.Timing(name, interval, p.tags(tags))
+}
+
+func (p *prometheusReporter) tags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return p.labels()
+	}
+
+	m := make(map[string]string)
+	maps.Copy(m, p.labels())
+	maps.Copy(m, tags)
+
+	return m
+}
+
+type prometheusStats struct {
+	mux    sync.RWMutex
+	logger *zap.Logger
+
+	counters         map[string]*prometheus.CounterVec
+	gauges           map[string]*prometheus.GaugeVec
+	histograms       map[string]*prometheus.HistogramVec
+	histogramBuckets map[string][]float64
+	defaultBuckets   []float64
+	reg              *prometheus.Registry
+
+	globalLabels prometheus.Labels
+	namespace    string
+}
+
+type prometheusStatsOption func(*prometheusStats)
+
+func withPrometheusNamespace(namespace string) prometheusStatsOption {
+	return func(s *prometheusStats) {
+		s.namespace = namespace
+	}
+}
+
+func withPrometheusLabels(labels map[string]string) prometheusStatsOption {
+	return func(s *prometheusStats) {
+		for k, v := range labels {
+			s.globalLabels[k] = v
+		}
+	}
+}
+
+func withPrometheusHistogramBuckets(buckets map[string][]float64) prometheusStatsOption {
+	return func(s *prometheusStats) {
+		for k, v := range buckets {
+			s.histogramBuckets[k] = v
+		}
+	}
+}
+
+func withDefaultPrometheusHistogramBuckets(buckets []float64) prometheusStatsOption {
+	return func(s *prometheusStats) {
+		s.defaultBuckets = buckets
+	}
+}
+
+func newPrometheusStats(logger *zap.Logger, opts ...prometheusStatsOption) *prometheusStats {
+	s := &prometheusStats{
+		logger:           logger,
+		counters:         make(map[string]*prometheus.CounterVec),
+		gauges:           make(map[string]*prometheus.GaugeVec),
+		histograms:       make(map[string]*prometheus.HistogramVec),
+		histogramBuckets: make(map[string][]float64),
+		defaultBuckets:   defaultBuckets,
+		globalLabels:     make(prometheus.Labels),
+		namespace:        "",
+		reg:              prometheus.NewRegistry(),
+	}
+
+	// Add go runtime metrics and process collectors.
+	s.reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+func (c *prometheusStats) Labels() prometheus.Labels {
+	return c.globalLabels
+}
+
+func (c *prometheusStats) MetricsHandler() http.Handler {
+	return promhttp.HandlerFor(c.reg, promhttp.HandlerOpts{Registry: c.reg})
+}
+
+func (c *prometheusStats) Count(key string, n interface{}, tags map[string]string) {
+	v, err := toFloat64(n)
+	if err != nil {
+		return
+	}
+
+	op, err := c.loadCount(key, tags)
+	if err != nil {
+		c.logger.Warn("prometheus.count.error", zap.Error(err))
+		return
+	}
+	op.With(labels(tags)).Add(v)
+}
+
+func (c *prometheusStats) Inc(key string, tags map[string]string) {
+	op, err := c.loadGauge(key, tags)
+	if err != nil {
+		c.logger.Warn("prometheus.inc.error", zap.Error(err))
+		return
+	}
+	op.With(labels(tags)).Inc()
+}
+
+func (c *prometheusStats) Dec(key string, tags map[string]string) {
+	op, err := c.loadGauge(key, tags)
+	if err != nil {
+		c.logger.Warn("prometheus.dec.error", zap.Error(err))
+		return
+	}
+	op.With(labels(tags)).Dec()
+}
+
+func (c *prometheusStats) Gauge(key string, n interface{}, tags map[string]string) {
+	v, err := toFloat64(n)
+	if err != nil {
+		return
+	}
+
+	op, err := c.loadGauge(key, tags)
+	if err != nil {
+		c.logger.Warn("prometheus.gauge.error", zap.Error(err))
+		return
+	}
+	op.With(labels(tags)).Set(v)
+}
+
+func (c *prometheusStats) Histogram(key string, n interface{}, tags map[string]string) {
+	v, err := toFloat64(n)
+	if err != nil {
+		return
+	}
+
+	op, err := c.loadHistogram(key, tags)
+	if err != nil {
+		c.logger.Warn("prometheus.histogram.error", zap.Error(err))
+		return
+	}
+	op.With(labels(tags)).Observe(v)
+}
+
+func (c *prometheusStats) Timing(key string, t time.Duration, tags map[string]string) {
+	op, err := c.loadHistogram(key, tags)
+	if err != nil {
+		c.logger.Warn("prometheus.timing.error", zap.Error(err))
+		return
+	}
+
+	op.With(labels(tags)).Observe(float64(t) / float64(time.Millisecond))
+}
+
+func (c *prometheusStats) loadGauge(key string, tags map[string]string) (*prometheus.GaugeVec, error) {
+	key = c.key(key)
+	id, labelNames := labelKey(key, tags)
+
+	c.mux.RLock()
+	gauge, ok := c.gauges[id]
+	c.mux.RUnlock()
+	if ok {
+		return gauge, nil
+	}
+
+	c.mux.Lock()
+	gauge, err := registerMetric(c.reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   c.namespace,
+		Name:        key,
+		ConstLabels: c.globalLabels,
+	}, labelNames))
+	if err != nil {
+		c.mux.Unlock()
+		return nil, err
+	}
+	c.gauges[id] = gauge
+	c.mux.Unlock()
+
+	return gauge, nil
+}
+
+func (c *prometheusStats) loadCount(key string, tags map[string]string) (*prometheus.CounterVec, error) {
+	key = c.key(key)
+	id, labelNames := labelKey(key, tags)
+
+	c.mux.RLock()
+	counter, ok := c.counters[id]
+	c.mux.RUnlock()
+	if ok {
+		return counter, nil
+	}
+
+	c.mux.Lock()
+	counter, err := registerMetric(c.reg, prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   c.namespace,
+		Name:        key,
+		ConstLabels: c.globalLabels,
+	}, labelNames))
+	if err != nil {
+		c.mux.Unlock()
+		return nil, err
+	}
+	c.counters[id] = counter
+	c.mux.Unlock()
+
+	return counter, nil
+}
+
+func labelKey(key string, tags map[string]string) (id string, labelNames []string) {
+	for k := range labels(tags) {
+		labelNames = append(labelNames, k)
+	}
+
+	sort.Strings(labelNames)
+	newKey := strings.Join(append([]string{key}, labelNames...), ".")
+
+	return newKey, labelNames
+}
+
+func (c *prometheusStats) loadHistogram(key string, tags map[string]string) (*prometheus.HistogramVec, error) {
+	key = c.key(key)
+	id, labelNames := labelKey(key, tags)
+
+	c.mux.RLock()
+	histogram, registered := c.histograms[id]
+	histogramBuckets, hasBuckets := c.histogramBuckets[key]
+	c.mux.RUnlock()
+
+	if registered {
+		return histogram, nil
+	}
+
+	if !hasBuckets {
+		histogramBuckets = defaultBuckets
+	}
+
+	c.mux.Lock()
+	histogram, err := registerMetric(c.reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   c.namespace,
+		Name:        key,
+		ConstLabels: c.globalLabels,
+		Buckets:     histogramBuckets,
+	}, labelNames))
+	if err != nil {
+		c.mux.Unlock()
+		return nil, err
+	}
+	c.histograms[id] = histogram
+	c.mux.Unlock()
+
+	return histogram, nil
+}
+
+func (c *prometheusStats) key(key string) string {
+	return strings.ReplaceAll(key, ".", "_")
+}
+
+func labels(tags map[string]string) prometheus.Labels {
+	if len(tags) > 0 {
+		return prometheus.Labels(tags)
+	}
+	return prometheus.Labels{}
+}
+
+func registerMetric[T prometheus.Collector](
+	reg prometheus.Registerer,
+	metric T,
+) (T, error) {
+	var err error
+	if reg != nil {
+		err = reg.Register(metric)
+	} else {
+		err = prometheus.Register(metric)
+	}
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			existing, ok := are.ExistingCollector.(T)
+			if !ok {
+				return metric, fmt.Errorf("metric with different type already exists")
+			}
+
+			return existing, nil
+		}
+	}
+
+	return metric, err
+}
+
+func toFloat64(n interface{}) (float64, error) {
+	var v float64
+	switch n := n.(type) {
+	case float64:
+		v = n
+	case float32:
+		v = float64(n)
+	case int:
+		v = float64(n)
+	case int8:
+		v = float64(n)
+	case int16:
+		v = float64(n)
+	case int32:
+		v = float64(n)
+	case int64:
+		v = float64(n)
+	default:
+		// NaN
+		return math.NaN(), errors.New("failed to convert value to float64")
+	}
+	return v, nil
+}

--- a/internal/tally/stats_reporter.go
+++ b/internal/tally/stats_reporter.go
@@ -1,10 +1,6 @@
 package tally
 
 import (
-	"context"
-	"time"
-
-	smirastatsd "github.com/smira/go-statsd"
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -19,97 +15,15 @@ type (
 		Logger    *zap.Logger
 		Config    *config.Config
 	}
-
-	reporter struct {
-		client *smirastatsd.Client
-	}
-)
-
-const (
-	reportingInterval = time.Second
-)
-
-var (
-	// hardcoding this to be datadog format
-	// we need think about whats the best way to set it up in config such that
-	// when we switch reporter impl, config will still be backward compatible
-	tagFormat = smirastatsd.TagFormatDatadog
 )
 
 func NewStatsReporter(params StatsReporterParams) tally.StatsReporter {
-	if params.Config.StatsD == nil {
+	switch {
+	case params.Config.StatsD != nil:
+		return newStatsDReporter(params.Config.StatsD, params.Lifecycle, params.Logger)
+	case params.Config.Prometheus != nil:
+		return newPrometheusReporter(params.Config.Prometheus, params.Lifecycle, params.Logger)
+	default:
 		return tally.NullStatsReporter
 	}
-	cfg := params.Config.StatsD
-	client := smirastatsd.NewClient(
-		cfg.Address,
-		smirastatsd.MetricPrefix(cfg.Prefix),
-		smirastatsd.TagStyle(tagFormat),
-		smirastatsd.ReportInterval(reportingInterval),
-	)
-	params.Logger.Info("initialized statsd client")
-	params.Lifecycle.Append(fx.Hook{
-		OnStop: func(ctx context.Context) error {
-			return client.Close()
-		},
-	})
-	return &reporter{
-		client: client,
-	}
-}
-
-func convertTags(tagsMap map[string]string) []smirastatsd.Tag {
-	tags := make([]smirastatsd.Tag, 0, len(tagsMap))
-	for key, value := range tagsMap {
-		tags = append(tags, smirastatsd.StringTag(key, value))
-	}
-	return tags
-}
-
-func (r *reporter) ReportCounter(name string, tags map[string]string, value int64) {
-	r.client.Incr(name, value, convertTags(tags)...)
-}
-
-func (r *reporter) ReportGauge(name string, tags map[string]string, value float64) {
-	r.client.FGauge(name, value, convertTags(tags)...)
-}
-
-func (r *reporter) ReportTimer(name string, tags map[string]string, value time.Duration) {
-	r.client.PrecisionTiming(name, value, convertTags(tags)...)
-}
-
-func (r *reporter) ReportHistogramValueSamples(
-	name string,
-	tags map[string]string,
-	buckets tally.Buckets,
-	bucketLowerBound,
-	bucketUpperBound float64,
-	samples int64) {
-	panic("no implemented")
-}
-
-func (r *reporter) ReportHistogramDurationSamples(
-	name string,
-	tags map[string]string,
-	buckets tally.Buckets,
-	bucketLowerBound,
-	bucketUpperBound time.Duration,
-	samples int64) {
-	panic("no implemented")
-}
-
-func (r *reporter) Capabilities() tally.Capabilities {
-	return r
-}
-
-func (r *reporter) Reporting() bool {
-	return true
-}
-
-func (r *reporter) Tagging() bool {
-	return true
-}
-
-func (r *reporter) Flush() {
-	// no-op
 }

--- a/internal/tally/stats_reporter_test.go
+++ b/internal/tally/stats_reporter_test.go
@@ -47,3 +47,28 @@ func TestNewReporterDefaultWithStatsD(t *testing.T) {
 		require.Equal(true, reporter.Capabilities().Tagging())
 	})
 }
+
+func TestNewReporterDefaultWithPrometheus(t *testing.T) {
+	testapp.TestAllConfigs(t, func(t *testing.T, cfg *config.Config) {
+		require := testutil.Require(t)
+		cfg.Prometheus = &config.PrometheusConfig{
+			// use any available port
+			Port: 0,
+		}
+
+		var reporter tally.StatsReporter
+		app := testapp.New(
+			t,
+			testapp.WithConfig(cfg),
+			fx.Provide(NewStatsReporter),
+			fx.Populate(&reporter),
+		)
+
+		// close app after the test so that the port is released
+		t.Cleanup(app.Close)
+
+		require.NotEqual(tally.NullStatsReporter, reporter)
+		require.Equal(true, reporter.Capabilities().Reporting())
+		require.Equal(true, reporter.Capabilities().Tagging())
+	})
+}

--- a/internal/tally/statsd_reporter.go
+++ b/internal/tally/statsd_reporter.go
@@ -1,0 +1,103 @@
+package tally
+
+import (
+	"context"
+	"time"
+
+	smirastatsd "github.com/smira/go-statsd"
+	"github.com/uber-go/tally/v4"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	"github.com/coinbase/chainstorage/internal/config"
+)
+
+type statsDReporter struct {
+	client *smirastatsd.Client
+}
+
+func newStatsDReporter(
+	cfg *config.StatsDConfig,
+	lifecycle fx.Lifecycle,
+	logger *zap.Logger,
+) tally.StatsReporter {
+	// hardcoding this to be datadog format
+	// we need think about whats the best way to set it up in config such that
+	// when we switch reporter impl, config will still be backward compatible
+	tagFormat := smirastatsd.TagFormatDatadog
+
+	client := smirastatsd.NewClient(
+		cfg.Address,
+		smirastatsd.MetricPrefix(cfg.Prefix),
+		smirastatsd.TagStyle(tagFormat),
+		smirastatsd.ReportInterval(reportingInterval),
+	)
+	logger.Info("initialized statsd client")
+	lifecycle.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			return client.Close()
+		},
+	})
+
+	return &statsDReporter{
+		client: client,
+	}
+}
+
+func (r *statsDReporter) convertTags(tagsMap map[string]string) []smirastatsd.Tag {
+	tags := make([]smirastatsd.Tag, 0, len(tagsMap))
+	for key, value := range tagsMap {
+		tags = append(tags, smirastatsd.StringTag(key, value))
+	}
+	return tags
+}
+
+func (r *statsDReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	r.client.Incr(name, value, r.convertTags(tags)...)
+}
+
+func (r *statsDReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	r.client.FGauge(name, value, r.convertTags(tags)...)
+}
+
+func (r *statsDReporter) ReportTimer(name string, tags map[string]string, value time.Duration) {
+	r.client.PrecisionTiming(name, value, r.convertTags(tags)...)
+}
+
+func (r *statsDReporter) ReportHistogramValueSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound float64,
+	samples int64,
+) {
+	panic("no implemented")
+}
+
+func (r *statsDReporter) ReportHistogramDurationSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound time.Duration,
+	samples int64,
+) {
+	panic("no implemented")
+}
+
+func (r *statsDReporter) Capabilities() tally.Capabilities {
+	return r
+}
+
+func (r *statsDReporter) Reporting() bool {
+	return true
+}
+
+func (r *statsDReporter) Tagging() bool {
+	return true
+}
+
+func (r *statsDReporter) Flush() {
+	// no-op
+}

--- a/internal/tally/tally.go
+++ b/internal/tally/tally.go
@@ -2,12 +2,17 @@ package tally
 
 import (
 	"context"
+	"time"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/fx"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/consts"
+)
+
+const (
+	reportingInterval = time.Second
 )
 
 type (
@@ -25,7 +30,7 @@ func NewRootScope(params MetricParams) tally.Scope {
 		Reporter: params.Reporter,
 		Tags:     params.Config.GetCommonTags(),
 	}
-	//report interval will be set on reporter
+	// report interval will be set on reporter
 	scope, closer := tally.NewRootScope(opts, reportingInterval)
 	params.Lifecycle.Append(fx.Hook{
 		OnStop: func(ctx context.Context) error {


### PR DESCRIPTION
### What changed? Why?

This PR adds support for a Prometheus Tally Reporter which can be used in place of the current `statsd` reporter. A full example configuration might look like this:

```yaml
prometheus:
  port: 9091
  metrics_path: /mymetrics
  namespace: mymetrics
  global_labels:
    some-new-feature: enabled
  default_histogram_buckets:
    - 1.0
    - 5.0
    - 10.0
    - 25.0
    - 50.0
    - 75.0
    - 100.0
  histogram_buckets:
    chainstorage_temporal_request_latency:
      - 1.0
      - 5.0
      - 10.0
      - 25.0
      - 50.0
      - 75.0
      - 100.0
```

The Prometheus reporter has been added in order to support both push and pull methods of collecting metrics.

### How did you test the change?

- [x] unit test
- [ ] integration test
- [ ] functional test
- [x] adhoc test (described below)

This has been validated locally using localstack. Below you will find example metrics from running chainstorage locally:
<details>

```
# HELP chainstorage_chainstorage_block_storage_get_blocks_by_height_range 
# TYPE chainstorage_chainstorage_block_storage_get_blocks_by_height_range counter
chainstorage_chainstorage_block_storage_get_blocks_by_height_range{blockchain="ethereum",network="ethereum-mainnet",result_type="success",sidechain="none",storage_type="dynamodb",tier="1"} 4
# HELP chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency 
# TYPE chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency histogram
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.1"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.2"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.3"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.5"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.7"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="4"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="6"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="8"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="9"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="12"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="15"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="20"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="25"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="30"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="40"} 0
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="50"} 1
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="75"} 3
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="100"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="200"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="300"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="500"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="750"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1000"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2000"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3000"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5000"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7000"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10000"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="+Inf"} 4
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_sum{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 244.187
chainstorage_chainstorage_block_storage_get_blocks_by_height_range_latency_count{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 4
# HELP chainstorage_chainstorage_block_storage_get_latest_block 
# TYPE chainstorage_chainstorage_block_storage_get_latest_block counter
chainstorage_chainstorage_block_storage_get_latest_block{blockchain="ethereum",network="ethereum-mainnet",result_type="error",sidechain="none",storage_type="dynamodb",tier="1"} 2
chainstorage_chainstorage_block_storage_get_latest_block{blockchain="ethereum",network="ethereum-mainnet",result_type="success",sidechain="none",storage_type="dynamodb",tier="1"} 5
# HELP chainstorage_chainstorage_block_storage_get_latest_block_latency 
# TYPE chainstorage_chainstorage_block_storage_get_latest_block_latency histogram
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.1"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.2"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.3"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.5"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.7"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="4"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="6"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="8"} 0
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="9"} 1
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10"} 3
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="12"} 3
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="15"} 4
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="20"} 4
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="25"} 4
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="30"} 6
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="40"} 6
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="50"} 6
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="75"} 6
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="100"} 6
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="200"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="300"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="500"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="750"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1000"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2000"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3000"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5000"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7000"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10000"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="+Inf"} 7
chainstorage_chainstorage_block_storage_get_latest_block_latency_sum{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 226.79766700000005
chainstorage_chainstorage_block_storage_get_latest_block_latency_count{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 7
# HELP chainstorage_chainstorage_event_storage_get_events_after_event_id 
# TYPE chainstorage_chainstorage_event_storage_get_events_after_event_id counter
chainstorage_chainstorage_event_storage_get_events_after_event_id{blockchain="ethereum",network="ethereum-mainnet",result_type="error",sidechain="none",storage_type="dynamodb",tier="1"} 2
# HELP chainstorage_chainstorage_event_storage_get_events_after_event_id_latency 
# TYPE chainstorage_chainstorage_event_storage_get_events_after_event_id_latency histogram
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.1"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.2"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.3"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.5"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.7"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="4"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="6"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="8"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="9"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10"} 0
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="12"} 1
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="15"} 1
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="20"} 1
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="25"} 1
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="30"} 1
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="40"} 1
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="50"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="75"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="100"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="200"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="300"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="500"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="750"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1000"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2000"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3000"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5000"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7000"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10000"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="+Inf"} 2
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_sum{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 56.669917
chainstorage_chainstorage_event_storage_get_events_after_event_id_latency_count{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 2
# HELP chainstorage_chainstorage_event_storage_get_max_event_id 
# TYPE chainstorage_chainstorage_event_storage_get_max_event_id counter
chainstorage_chainstorage_event_storage_get_max_event_id{blockchain="ethereum",network="ethereum-mainnet",result_type="error",sidechain="none",storage_type="dynamodb",tier="1"} 2
# HELP chainstorage_chainstorage_event_storage_get_max_event_id_latency 
# TYPE chainstorage_chainstorage_event_storage_get_max_event_id_latency histogram
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.1"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.2"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.3"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.5"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="0.7"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="4"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="6"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="8"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="9"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10"} 0
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="12"} 1
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="15"} 1
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="20"} 1
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="25"} 1
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="30"} 1
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="40"} 1
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="50"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="75"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="100"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="200"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="300"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="500"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="750"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="1000"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="2000"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="3000"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="5000"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="7000"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="10000"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_bucket{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1",le="+Inf"} 2
chainstorage_chainstorage_event_storage_get_max_event_id_latency_sum{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 56.548083
chainstorage_chainstorage_event_storage_get_max_event_id_latency_count{blockchain="ethereum",network="ethereum-mainnet",sidechain="none",storage_type="dynamodb",tier="1"} 2
# HELP chainstorage_chainstorage_server_blocks_served 
# TYPE chainstorage_chainstorage_server_blocks_served counter
chainstorage_chainstorage_server_blocks_served{blockchain="ethereum",clientID="unknown",format="file",network="ethereum-mainnet",sidechain="none",tier="1"} 40
# HELP chainstorage_chainstorage_server_error 
# TYPE chainstorage_chainstorage_server_error counter
chainstorage_chainstorage_server_error{blockchain="ethereum",method="GetLatestBlock",network="ethereum-mainnet",sidechain="none",status="NotFound",tier="1"} 2
chainstorage_chainstorage_server_error{blockchain="ethereum",method="StreamChainEvents",network="ethereum-mainnet",sidechain="none",status="Internal",tier="1"} 2
# HELP chainstorage_chainstorage_server_request 
# TYPE chainstorage_chainstorage_server_request counter
chainstorage_chainstorage_server_request{blockchain="ethereum",clientID="unknown",method="GetBlockFilesByRange",network="ethereum-mainnet",service="coinbase.chainstorage.ChainStorage",sidechain="none",status="OK",tier="1"} 4
chainstorage_chainstorage_server_request{blockchain="ethereum",clientID="unknown",method="GetLatestBlock",network="ethereum-mainnet",service="coinbase.chainstorage.ChainStorage",sidechain="none",status="NotFound",tier="1"} 2
chainstorage_chainstorage_server_request{blockchain="ethereum",clientID="unknown",method="GetLatestBlock",network="ethereum-mainnet",service="coinbase.chainstorage.ChainStorage",sidechain="none",status="OK",tier="1"} 1
chainstorage_chainstorage_server_request{blockchain="ethereum",clientID="unknown",method="ServerReflectionInfo",network="ethereum-mainnet",service="grpc.reflection.v1.ServerReflection",sidechain="none",status="OK",tier="1"} 9
chainstorage_chainstorage_server_request{blockchain="ethereum",clientID="unknown",method="StreamChainEvents",network="ethereum-mainnet",service="coinbase.chainstorage.ChainStorage",sidechain="none",status="Internal",tier="1"} 2
# HELP chainstorage_chainstorage_temporal_request 
# TYPE chainstorage_chainstorage_temporal_request counter
chainstorage_chainstorage_temporal_request{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none"} 1
# HELP chainstorage_chainstorage_temporal_request_attempt 
# TYPE chainstorage_chainstorage_temporal_request_attempt counter
chainstorage_chainstorage_temporal_request_attempt{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none"} 1
# HELP chainstorage_chainstorage_temporal_request_latency 
# TYPE chainstorage_chainstorage_temporal_request_latency histogram
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.1"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.2"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.3"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.5"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.7"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="1"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="2"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="3"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="4"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="5"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="6"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="7"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="8"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="9"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="10"} 0
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="12"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="15"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="20"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="25"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="30"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="40"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="50"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="75"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="100"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="200"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="300"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="500"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="750"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="1000"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="2000"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="3000"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="5000"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="7000"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="10000"} 1
chainstorage_chainstorage_temporal_request_latency_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="+Inf"} 1
chainstorage_chainstorage_temporal_request_latency_sum{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none"} 11.848833
chainstorage_chainstorage_temporal_request_latency_count{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none"} 1
# HELP chainstorage_chainstorage_temporal_request_latency_attempt 
# TYPE chainstorage_chainstorage_temporal_request_latency_attempt histogram
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.1"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.2"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.3"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.5"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="0.7"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="1"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="2"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="3"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="4"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="5"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="6"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="7"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="8"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="9"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="10"} 0
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="12"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="15"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="20"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="25"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="30"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="40"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="50"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="75"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="100"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="200"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="300"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="500"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="750"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="1000"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="2000"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="3000"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="5000"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="7000"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="10000"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_bucket{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none",le="+Inf"} 1
chainstorage_chainstorage_temporal_request_latency_attempt_sum{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none"} 11.802375
chainstorage_chainstorage_temporal_request_latency_attempt_count{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",operation="GetSystemInfo",sidechain="none",task_queue="none",tier="1",worker_type="none",workflow_type="none"} 1
# HELP chainstorage_chainstorage_temporal_worker_task_slots_available 
# TYPE chainstorage_chainstorage_temporal_worker_task_slots_available gauge
chainstorage_chainstorage_temporal_worker_task_slots_available{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",sidechain="none",task_queue="default",tier="1",worker_type="ActivityWorker",workflow_type="none"} 1000
chainstorage_chainstorage_temporal_worker_task_slots_available{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",sidechain="none",task_queue="default",tier="1",worker_type="LocalActivityWorker",workflow_type="none"} 1000
chainstorage_chainstorage_temporal_worker_task_slots_available{activity_type="none",blockchain="ethereum",client_name="temporal_go",namespace="chainstorage-ethereum-mainnet",network="ethereum-mainnet",sidechain="none",task_queue="default",tier="1",worker_type="WorkflowWorker",workflow_type="none"} 1000
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 8.0458e-05
go_gc_duration_seconds{quantile="0.25"} 0.000211167
go_gc_duration_seconds{quantile="0.5"} 0.000436875
go_gc_duration_seconds{quantile="0.75"} 0.001483666
go_gc_duration_seconds{quantile="1"} 0.001501917
go_gc_duration_seconds_sum 0.0046805
go_gc_duration_seconds_count 8
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 31
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.22.0"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.4694808e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 3.2792376e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.464324e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 252128
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 3.839576e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.4694808e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.750784e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.8284544e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 70009
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 2.883584e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 2.4035328e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.746551905283527e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 322137
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 9600
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 276960
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 293760
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 2.681616e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 1.924668e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.081344e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.081344e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 3.26546e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 13
# HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
# TYPE promhttp_metric_handler_errors_total counter
promhttp_metric_handler_errors_total{cause="encoding"} 0
promhttp_metric_handler_errors_total{cause="gathering"} 0
```

</details>

