### PR TITLE
Fix/tron tx type

### DIFF
--- a/internal/blockchain/client/ethereum/tron.go
+++ b/internal/blockchain/client/ethereum/tron.go
@@ -52,11 +52,6 @@ type tronBlockNumRequestData struct {
 	Num uint64 `json:"num"`
 }
 
-type tronBlock struct {
-	BlockNumber  uint64   `json:"blockNumber"`
-	Transactions [][]byte `json:"transactions"`
-}
-
 var tronTxInfoMethod = &restapi.RequestMethod{
 	Name:       "GetTransactionInfoByBlockNum",
 	ParamsPath: "/wallet/gettransactioninfobyblocknum", // No parameter URls

--- a/internal/blockchain/client/ethereum/tron_test.go
+++ b/internal/blockchain/client/ethereum/tron_test.go
@@ -48,10 +48,10 @@ const (
 			"receipt": {
 				"net_usage": 268
 			},
-			"id": "0xbaa42c87b7c764c548fa37e61e9764415fd4a79d7e073d4f92a456698002016b"
+			"id": "baa42c87b7c764c548fa37e61e9764415fd4a79d7e073d4f92a456698002016b"
 		},
 		{
-			"id": "0xf5365847bff6e48d0c6bc23eee276343d2987efd9876c3c1bf597225e3d69991",
+			"id": "f5365847bff6e48d0c6bc23eee276343d2987efd9876c3c1bf597225e3d69991",
 			"blockNumber": 11322000,
 			"internal_transactions": [
 				{
@@ -77,6 +77,87 @@ const (
 			]
 		}
 	]
+	`
+	fixtureBlockTxResponse = `
+	{
+		"blockID": "000000000408a36cd32a8e674045e96f895b7708b85fa5141f3c8fd92eb497a8",
+		"block_header": {
+			"raw_data": {
+				"number": 67674988,
+				"txTrieRoot": "08203d3094277ae2bfc9981bde29400a87ab5bc6b9aa807ce42d96a2de5ea109",
+				"witness_address": "417f5e5aca5332ce5e18414d7f85bb62097cefa453",
+				"parentHash": "000000000408a36b033d241520fd155cb0351a27bce043ddb7799ec2790ca1ee",
+				"version": 31,
+				"timestamp": 1733675346000
+			},
+			"witness_signature": "241ea0cb69f7e3dd1436c03c557f2b4a005f6ca315d968a11c1115324f795f2875883db4c91e74a0638c9100a4ced4196080fdaf6077881936636e6169d0fbb801"
+		},
+		"transactions": [
+			{
+				"ret": [
+					{
+						"contractRet": "SUCCESS"
+					}
+				],
+				"signature": [
+					"e93160d1df484382923db34f02ca196a7dbbd7342948214a739fdf4b96896cfc2ca4d9b706c2393c3f83d269f31901aee43ae8e50a04579b6636c03c321da8e000"
+				],
+				"txID": "0xbaa42c87b7c764c548fa37e61e9764415fd4a79d7e073d4f92a456698002016b",
+				"raw_data": {
+					"contract": [
+						{
+							"parameter": {
+								"value": {
+									"amount": 6,
+									"owner_address": "4174d7980a2a3e48e3a863365542e92ab8d646e0aa",
+									"to_address": "41c3d34597fb01e25d4d8e7ef34ccdd0f05bf85473"
+								},
+								"type_url": "type.googleapis.com/protocol.TransferContract"
+							},
+							"type": "TransferContract"
+						}
+					],
+					"ref_block_bytes": "a358",
+					"ref_block_hash": "c773a99ac91938c6",
+					"expiration": 1733675400000,
+					"timestamp": 1733675342465
+				},
+				"raw_data_hex": "0a02a3582208c773a99ac91938c640c0f6ecb8ba325a65080112610a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412300a154174d7980a2a3e48e3a863365542e92ab8d646e0aa121541c3d34597fb01e25d4d8e7ef34ccdd0f05bf8547318067081b5e9b8ba32"
+			},
+			{
+				"ret": [
+					{
+						"contractRet": "SUCCESS"
+					}
+				],
+				"signature": [
+					"27a73675483a50fa52972e7c5ffe33e931ffad1a037a79c3ff2ab97cf08315b557a723d3fc87d5a1e81165775fdfba4b14c7aab31ccd74d06d36bcdd4615f18a1c"
+				],
+				"txID": "f5365847bff6e48d0c6bc23eee276343d2987efd9876c3c1bf597225e3d69991",
+				"raw_data": {
+					"contract": [
+						{
+							"parameter": {
+								"value": {
+									"balance": 248167143,
+									"receiver_address": "414c614b77e81392450d88f9e339481843abae0e34",
+									"owner_address": "410611d6c1d784930f53979f06f10306251919e1ea"
+								},
+								"type_url": "type.googleapis.com/protocol.UnDelegateResourceContract"
+							},
+							"type": "UnDelegateResourceContract"
+						}
+					],
+					"ref_block_bytes": "a343",
+					"ref_block_hash": "92d31415885cc680",
+					"expiration": 1733761442497,
+					"fee_limit": 30000000,
+					"timestamp": 1733675342497
+				},
+				"raw_data_hex": "0a02a343220892d31415885cc68040c1c5f0e1ba325a72083a126e0a37747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e556e44656c65676174655265736f75726365436f6e747261637412330a15410611d6c1d784930f53979f06f10306251919e1ea18e7f5aa762215414c614b77e81392450d88f9e339481843abae0e3470a1b5e9b8ba3290018087a70e"
+			}
+		]
+	}
 	`
 )
 
@@ -186,10 +267,16 @@ func (s *tronClientTestSuite) TestTronClient_GetBlockByHeight() {
 	).Return(receiptResponse, nil)
 
 	// mock BlockTxInfo restapi request --------------------
-	blockTxInfoPostData := TronBlockTxInfoRequestData{Num: ethereumHeight}
+	blockTxInfoPostData := tronBlockNumRequestData{Num: ethereumHeight}
 	postData, _ := json.Marshal(blockTxInfoPostData)
 	txr := json.RawMessage(fixtureBlockTxInfoResponse)
 	s.restClient.EXPECT().Call(gomock.Any(), tronTxInfoMethod, postData).Return(txr, nil)
+
+	// mock BlockTx restapi request --------------------
+	blockTxPostData := tronBlockNumRequestData{Num: ethereumHeight}
+	postData, _ = json.Marshal(blockTxPostData)
+	txr = json.RawMessage(fixtureBlockTxResponse)
+	s.restClient.EXPECT().Call(gomock.Any(), tronBlockTxMethod, postData).Return(txr, nil)
 
 	block, err := s.client.GetBlockByHeight(context.Background(), tronTestTag, tronTestHeight)
 	require.NoError(err)

--- a/internal/blockchain/parser/ethereum/tron_native_test.go
+++ b/internal/blockchain/parser/ethereum/tron_native_test.go
@@ -218,12 +218,12 @@ func (s *tronParserTestSuite) TestParseTronBlock() {
 			},
 		},
 		{
-			Type:             "CALL",
+			Type:             "UNDELEGATERESOURCEOFENERGY",
 			From:             "TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5",
 			To:               "TGzjkw66CtL49eKiQFDwJDuXG9HSQd69p2",
 			Value:            "822996311610",
-			TraceType:        "CALL",
-			CallType:         "CALL",
+			TraceType:        "UNDELEGATERESOURCEOFENERGY",
+			CallType:         "",
 			TraceId:          "14526162e31d969ef0dca9b902d51ecc0ffab87dc936dce62022f368119043af",
 			Status:           1,
 			BlockHash:        "0000000004034f5cd8946001c721db6457608ad887b3734c825d55826c3c3c87",
@@ -283,6 +283,7 @@ func (s *tronParserTestSuite) TestParseTronBlock() {
 			From:  "TDQFomPihdhP8Jzr2LMpdcXgg9qxKfZZmD",
 			To:    "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 			Index: 0,
+			Type:  1,
 			Receipt: &api.EthereumTransactionReceipt{
 				TransactionHash:   "d581afa9158fbed69fb10d6a2245ad45d912a3da03ff24d59f3d2f6df6fd9529",
 				BlockHash:         "0000000004034f5cd8946001c721db6457608ad887b3734c825d55826c3c3c87",
@@ -330,6 +331,7 @@ func (s *tronParserTestSuite) TestParseTronBlock() {
 			From:  "TNXC2YCSxhdxsVqhqu3gYZYme6n4i6T1C1",
 			To:    "TU2MJ5Veik1LRAgjeSzEdvmDYx7mefJZvd",
 			Index: 69,
+			Type:  2,
 			Receipt: &api.EthereumTransactionReceipt{
 				TransactionHash:   "e14935e6144007163609bb49292897ba81bf7ee93bf28ba4cc5ebd0d6b95f4b9",
 				BlockHash:         "0000000004034f5cd8946001c721db6457608ad887b3734c825d55826c3c3c87",
@@ -457,7 +459,7 @@ func (s *tronParserTestSuite) TestParseTronBlock() {
 		require.Equal(expected_tx.From, tx.From)
 		require.Equal(expected_tx.To, tx.To)
 		require.Equal(expected_tx.Index, tx.Index)
-
+		require.Equal(expected_tx.Type, tx.Type)
 		require.Equal(expected_tx.Receipt.From, tx.Receipt.From)
 		require.Equal(expected_tx.Receipt.To, tx.Receipt.To)
 		require.Equal(expected_tx.Receipt.TransactionHash, tx.Receipt.TransactionHash)

--- a/internal/utils/fixtures/parser/tron/raw_block_trace_tx_info.json
+++ b/internal/utils/fixtures/parser/tron/raw_block_trace_tx_info.json
@@ -1,5 +1,6 @@
 [
-    {
+    {   
+        "type": "TransferContract",
         "log": [
             {
                 "address": "a614f803b6fd780986a42c78ec9c7f77e6ded13c",
@@ -26,7 +27,8 @@
         "id": "d581afa9158fbed69fb10d6a2245ad45d912a3da03ff24d59f3d2f6df6fd9529",
         "contract_address": "41a614f803b6fd780986a42c78ec9c7f77e6ded13c"
     },
-    {
+    {   
+        "type": "TransferAssetContract",
         "log": [
             {
                 "address": "c60a6f5c81431c97ed01b61698b6853557f3afd4",


### PR DESCRIPTION
### What changed? Why?
fix Tron data issues

#### 1. Missing transaction type info (TRX vs TRC10, etc.)
Add an additional HTTP call to /wallet/getblockbynum to retrieve the contract_type as transaction_type — this allows us to distinguish between TRX transfers, TRC10, and other transaction types,
And mapped them into int:
```
var TronContractTypeMap = map[string]uint64{
	"AccountCreateContract":           0,
	"TransferContract":                1,
	"TransferAssetContract":           2,
	"VoteAssetContract":               3,
	"VoteWitnessContract":             4,
	"WitnessCreateContract":           5,
	"AssetIssueContract":              6,
	"WitnessUpdateContract":           8,
	"ParticipateAssetIssueContract":   9,
	"AccountUpdateContract":           10,
	"FreezeBalanceContract":           11,
	"UnfreezeBalanceContract":         12,
	"WithdrawBalanceContract":         13,
	"UnfreezeAssetContract":           14,
	"UpdateAssetContract":             15,
	"ProposalCreateContract":          16,
	"ProposalApproveContract":         17,
	"ProposalDeleteContract":          18,
	"SetAccountIdContract":            19,
	"CustomContract":                  20,
	"CreateSmartContract":             30,
	"TriggerSmartContract":            31,
	"GetContract":                     32,
	"UpdateSettingContract":           33,
	"ExchangeCreateContract":          41,
	"ExchangeInjectContract":          42,
	"ExchangeWithdrawContract":        43,
	"ExchangeTransactionContract":     44,
	"UpdateEnergyLimitContract":       45,
	"AccountPermissionUpdateContract": 46,
	"ClearABIContract":                48,
	"UpdateBrokerageContract":         49,
	"ShieldedTransferContract":        51,
	"MarketSellAssetContract":         52,
	"MarketCancelOrderContract":       53,
	"FreezeBalanceV2Contract":         54,
	"UnfreezeBalanceV2Contract":       55,
	"WithdrawExpireUnfreezeContract":  56,
	"DelegateResourceContract":        57,
	"UnDelegateResourceContract":      58,
	"CancelAllUnfreezeV2Contract":     59,
}
```
#### 2. Inaccurate CALL type parsing
Improve parsing for CALL types by extracting the call type from internal_transaction.note.

>The examples of internal transactions
>note: instruction type, such as call, create, suicide, freezeBalanceV2ForEnergy, freezeBalanceV2ForBandwidth, unfreezeBalanceV2ForBandwidth, etc.

### How did you test the change?

- unit test

```
make test
--- fmt
--- lint
go vet -printfuncs=wrapf,statusf,warnf,infof,debugf,failf,equalf,containsf,fprintf,sprintf ./...
errcheck -ignoretests -ignoregenerated ./...
ineffassign ./...
--- test
TEST_TYPE=unit go test ./... -run=.
?       github.com/coinbase/chainstorage/cmd/admin      [no test files]
ok      github.com/coinbase/chainstorage/cmd/api        (cached)
ok      github.com/coinbase/chainstorage/cmd/cron       (cached)
?       github.com/coinbase/chainstorage/config [no test files]
?       github.com/coinbase/chainstorage/examples/batch [no test files]
?       github.com/coinbase/chainstorage/examples/batch-consumer        [no test files]
?       github.com/coinbase/chainstorage/examples/block_parser  [no test files]
?       github.com/coinbase/chainstorage/examples/stream        [no test files]
?       github.com/coinbase/chainstorage/examples/batchpull     [no test files]
ok      github.com/coinbase/chainstorage/cmd/server     (cached)
ok      github.com/coinbase/chainstorage/cmd/worker     (cached)
?       github.com/coinbase/chainstorage/examples/unified       [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain    [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain/bootstrap  [no test files]
ok      github.com/coinbase/chainstorage/internal/aws   (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client/aptos       (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client/bitcoin     (cached)
?       github.com/coinbase/chainstorage/internal/blockchain/client/mocks       [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/client/ethereum    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client/ethereum/beacon     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client/internal    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client/rosetta     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/client/solana      (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/endpoints  (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/aptos     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/arbitrum  (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/base      (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/bitcoin   (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/bsc       (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/ethereum  (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/fantom    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/optimism  (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/polygon   (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/rosetta   (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/integration_test/solana    (cached)
?       github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks      [no test files]
?       github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum/types      [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/jsonrpc    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/aptos       (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/bitcoin     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum/beacon     (cached)
?       github.com/coinbase/chainstorage/internal/blockchain/parser/mocks       [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/internal    (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/rosetta     (cached)
ok      github.com/coinbase/chainstorage/internal/blockchain/parser/solana      (cached)
?       github.com/coinbase/chainstorage/internal/blockchain/restapi/mocks      [no test files]
?       github.com/coinbase/chainstorage/internal/cadence       [no test files]
?       github.com/coinbase/chainstorage/internal/dlq   [no test files]
?       github.com/coinbase/chainstorage/internal/dlq/firestore [no test files]
?       github.com/coinbase/chainstorage/internal/dlq/internal  [no test files]
ok      github.com/coinbase/chainstorage/internal/blockchain/restapi    (cached)
ok      github.com/coinbase/chainstorage/internal/config        (cached)
ok      github.com/coinbase/chainstorage/internal/cron  (cached)
?       github.com/coinbase/chainstorage/internal/dlq/mocks     [no test files]
?       github.com/coinbase/chainstorage/internal/gateway       [no test files]
?       github.com/coinbase/chainstorage/internal/s3/mocks      [no test files]
?       github.com/coinbase/chainstorage/internal/storage       [no test files]
?       github.com/coinbase/chainstorage/internal/storage/blobstorage   [no test files]
ok      github.com/coinbase/chainstorage/internal/dlq/sqs       (cached)
ok      github.com/coinbase/chainstorage/internal/s3    (cached)
ok      github.com/coinbase/chainstorage/internal/server        (cached)
?       github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader/mocks  [no test files]
ok      github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader        (cached)
?       github.com/coinbase/chainstorage/internal/storage/blobstorage/internal  [no test files]
?       github.com/coinbase/chainstorage/internal/storage/blobstorage/mocks     [no test files]
?       github.com/coinbase/chainstorage/internal/storage/internal/errors       [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage   [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/dynamodb/mocks    [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/dynamodb/model    [no test files]
ok      github.com/coinbase/chainstorage/internal/storage/blobstorage/gcs       (cached)
ok      github.com/coinbase/chainstorage/internal/storage/blobstorage/s3        (cached)
ok      github.com/coinbase/chainstorage/internal/storage/metastorage/dynamodb  (cached)
?       github.com/coinbase/chainstorage/internal/storage/metastorage/internal  [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/model     [no test files]
?       github.com/coinbase/chainstorage/internal/storage/metastorage/mocks     [no test files]
ok      github.com/coinbase/chainstorage/internal/storage/metastorage/firestore (cached)
ok      github.com/coinbase/chainstorage/internal/storage/utils (cached)
?       github.com/coinbase/chainstorage/internal/utils/consts  [no test files]
?       github.com/coinbase/chainstorage/internal/utils/finalizer       [no test files]
?       github.com/coinbase/chainstorage/internal/utils/fxparams        [no test files]
?       github.com/coinbase/chainstorage/internal/utils/log     [no test files]
ok      github.com/coinbase/chainstorage/internal/tally (cached)
ok      github.com/coinbase/chainstorage/internal/tracer        (cached)
ok      github.com/coinbase/chainstorage/internal/utils/fixtures        (cached)
ok      github.com/coinbase/chainstorage/internal/utils/instrument      (cached)
?       github.com/coinbase/chainstorage/internal/utils/pointer [no test files]
?       github.com/coinbase/chainstorage/internal/utils/testapp [no test files]
?       github.com/coinbase/chainstorage/internal/utils/timesource      [no test files]
ok      github.com/coinbase/chainstorage/internal/utils/picker  (cached)
ok      github.com/coinbase/chainstorage/internal/utils/ratelimiter     (cached)
ok      github.com/coinbase/chainstorage/internal/utils/retry   (cached)
ok      github.com/coinbase/chainstorage/internal/utils/syncgroup       (cached)
ok      github.com/coinbase/chainstorage/internal/utils/testutil        (cached)
ok      github.com/coinbase/chainstorage/internal/utils/utils   (cached)
ok      github.com/coinbase/chainstorage/internal/workflow      (cached)
?       github.com/coinbase/chainstorage/internal/workflow/activity/errors      [no test files]
?       github.com/coinbase/chainstorage/internal/workflow/instrument   [no test files]
ok      github.com/coinbase/chainstorage/internal/workflow/activity     (cached)
ok      github.com/coinbase/chainstorage/internal/workflow/integration_test     (cached)
ok      github.com/coinbase/chainstorage/protos/coinbase/c3/common      (cached)
?       github.com/coinbase/chainstorage/protos/coinbase/chainstorage/mocks     [no test files]
?       github.com/coinbase/chainstorage/sdk/mocks      [no test files]
?       github.com/coinbase/chainstorage/sdk/services   [no test files]
ok      github.com/coinbase/chainstorage/protos/coinbase/chainstorage   (cached)
ok      github.com/coinbase/chainstorage/protos/coinbase/crypto/rosetta/types   (cached)
ok      github.com/coinbase/chainstorage/sdk    (cached)
ok      github.com/coinbase/chainstorage/sdk/integration_test   (cached)
ok      github.com/coinbase/chainstorage/tools/config_gen       (cached)
```