### PR TITLE
Fix chain continuity errors during reorg in RDS metadata storage

### DIFF
--- a/internal/workflow/replicator.go
+++ b/internal/workflow/replicator.go
@@ -269,9 +269,15 @@ func (w *Replicator) execute(ctx workflow.Context, request *ReplicatorRequest) e
 							zap.Error(err))
 
 						// Calculate the new start height by going back by irreversible_distance
-						newStartHeight := startHeight
-						if startHeight > cfg.IrreversibleDistance {
-							newStartHeight = startHeight - cfg.IrreversibleDistance
+						// Ensure we go back at least 1 block, even if IrreversibleDistance is 0
+						var newStartHeight uint64
+						reorgDistance := cfg.IrreversibleDistance
+						if reorgDistance == 0 {
+							reorgDistance = 1 // Go back at least 1 block
+						}
+
+						if startHeight > reorgDistance {
+							newStartHeight = startHeight - reorgDistance
 						} else {
 							newStartHeight = 0
 						}

--- a/internal/workflow/replicator.go
+++ b/internal/workflow/replicator.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
+	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
@@ -259,6 +260,32 @@ func (w *Replicator) execute(ctx workflow.Context, request *ReplicatorRequest) e
 					BlockHeight:   endHeight - 1,
 				})
 				if err != nil {
+					// Check if the error is due to chain discontinuity (reorg)
+					if xerrors.Is(err, parser.ErrInvalidChain) {
+						// Reorg detected - restart from a safe point
+						logger.Warn("Chain discontinuity detected, likely due to reorg. Restarting from earlier height",
+							zap.Uint64("currentStartHeight", startHeight),
+							zap.Uint64("irreversibleDistance", cfg.IrreversibleDistance),
+							zap.Error(err))
+
+						// Calculate the new start height by going back by irreversible_distance
+						newStartHeight := startHeight
+						if startHeight > cfg.IrreversibleDistance {
+							newStartHeight = startHeight - cfg.IrreversibleDistance
+						} else {
+							newStartHeight = 0
+						}
+
+						// Create a new request starting from the safe point
+						newRequest := *request
+						newRequest.StartHeight = newStartHeight
+						logger.Info("Restarting replicator workflow after reorg",
+							zap.Uint64("newStartHeight", newStartHeight),
+							zap.Uint64("endHeight", request.EndHeight))
+
+						// Continue as new workflow to handle the reorg
+						return workflow.NewContinueAsNewError(ctx, w.name, &newRequest)
+					}
 					return xerrors.Errorf("failed to update watermark: %w", err)
 				}
 			}


### PR DESCRIPTION
## Summary
This PR fixes chain continuity errors that occur when the replicator encounters a reorganization while using RDS metadata storage.

## Problem
When a blockchain reorganization happens and affects block at height N:
- The next replicator batch starts at height N+1
- Block N+1 references the NEW block N hash from the reorg
- But the `canonical_blocks` table still contains the OLD block N
- This causes `UpdateWatermark` to fail with "chain is not continuous" error
- The workflow fails and cannot recover automatically

Example error:
```
failed to validate chain: chain is not continuous 
(last={tag:1 hash:"0x42fb..." parent_hash:"0xd5fd..." height:23040207}, 
 curr={tag:1 hash:"0x949c..." parent_hash:"0x3ced..." height:23040208})
```

## Solution
Modified the replicator workflow to detect and recover from chain continuity errors:

1. **Detection**: Catch `parser.ErrInvalidChain` during the UpdateWatermark phase
2. **Recovery**: When detected, restart the workflow from `current_height - irreversible_distance`
3. **Re-sync**: This allows the replicator to re-fetch the reorged blocks and update the canonical chain properly

## Changes
- Modified `/internal/workflow/replicator.go` to handle `ErrInvalidChain`
- Added logic to calculate safe restart height using `irreversible_distance`
- Use `workflow.NewContinueAsNewError` to restart from the safe point
- Added logging for reorg detection and recovery tracking

## Test Plan
- [x] Unit tests pass (`go test ./internal/workflow/...`)
- [x] Code compiles without errors
- [ ] Manual testing with a reorg scenario
- [ ] Verify automatic recovery when chain discontinuity is detected

This ensures the replicator can automatically recover from reorgs without manual intervention, preventing data corruption in the canonical chain.

🤖 Generated with [Claude Code](https://claude.ai/code)