### PR TITLE
fix: make Bitcoin RPC method timeouts configurable via chain config

### DIFF
--- a/config/chainstorage/bitcoincash/mainnet/base.yml
+++ b/config/chainstorage/bitcoincash/mainnet/base.yml
@@ -59,6 +59,7 @@ chain:
     http_timeout: 0s
     master:
       endpoint_group: ""
+    rpc_timeout_get_block: 30s
     rpc_timeout_get_raw_tx: 60s
     slave:
       endpoint_group: ""

--- a/config/chainstorage/bitcoincash/mainnet/base.yml
+++ b/config/chainstorage/bitcoincash/mainnet/base.yml
@@ -59,6 +59,7 @@ chain:
     http_timeout: 0s
     master:
       endpoint_group: ""
+    rpc_timeout_get_raw_tx: 60s
     slave:
       endpoint_group: ""
     tx_batch_size: 100

--- a/config_templates/config/chainstorage/bitcoincash/mainnet/base.template.yml
+++ b/config_templates/config/chainstorage/bitcoincash/mainnet/base.template.yml
@@ -8,6 +8,7 @@ aws:
 chain:
   client:
     tx_batch_size: 100
+    rpc_timeout_get_block: 30s
     rpc_timeout_get_raw_tx: 60s
   block_tag:
     latest: 2

--- a/config_templates/config/chainstorage/bitcoincash/mainnet/base.template.yml
+++ b/config_templates/config/chainstorage/bitcoincash/mainnet/base.template.yml
@@ -8,6 +8,7 @@ aws:
 chain:
   client:
     tx_batch_size: 100
+    rpc_timeout_get_raw_tx: 60s
   block_tag:
     latest: 2
     stable: 2

--- a/internal/blockchain/client/bitcoin/bitcoin.go
+++ b/internal/blockchain/client/bitcoin/bitcoin.go
@@ -125,6 +125,24 @@ func newRPCMethods(overrides ...rpcMethodsOverride) rpcMethods {
 	return methods
 }
 
+// rpcMethodsOverrideFromConfig builds an rpcMethodsOverride from configurable
+// timeout values in ClientConfig. Zero-value durations are skipped, preserving
+// the compiled defaults.
+func rpcMethodsOverrideFromConfig(cfg *config.Config) rpcMethodsOverride {
+	override := make(rpcMethodsOverride)
+	clientCfg := cfg.Chain.Client
+	if clientCfg.RpcTimeoutGetBlock > 0 {
+		override[rpcMethodGetBlockByHash] = &jsonrpc.RequestMethod{Name: "getblock", Timeout: clientCfg.RpcTimeoutGetBlock}
+	}
+	if clientCfg.RpcTimeoutGetRawTx > 0 {
+		override[rpcMethodGetRawTransaction] = &jsonrpc.RequestMethod{Name: "getrawtransaction", Timeout: clientCfg.RpcTimeoutGetRawTx}
+	}
+	if clientCfg.RpcTimeoutGetBlockHash > 0 {
+		override[rpcMethodGetBlockHash] = &jsonrpc.RequestMethod{Name: "getblockhash", Timeout: clientCfg.RpcTimeoutGetBlockHash}
+	}
+	return override
+}
+
 func NewBitcoinClientFactory(params internal.JsonrpcClientParams) internal.ClientFactory {
 	return internal.NewJsonrpcClientFactory(params, func(client jsonrpc.Client) internal.Client {
 		logger := log.WithPackage(params.Logger)
@@ -133,7 +151,7 @@ func NewBitcoinClientFactory(params internal.JsonrpcClientParams) internal.Clien
 			logger:   logger,
 			client:   client,
 			validate: validator.New(),
-			methods:  newRPCMethods(),
+			methods:  newRPCMethods(rpcMethodsOverrideFromConfig(params.Config)),
 		}
 	})
 }

--- a/internal/blockchain/client/bitcoin/bitcoin.go
+++ b/internal/blockchain/client/bitcoin/bitcoin.go
@@ -132,13 +132,13 @@ func rpcMethodsOverrideFromConfig(cfg *config.Config) rpcMethodsOverride {
 	override := make(rpcMethodsOverride)
 	clientCfg := cfg.Chain.Client
 	if clientCfg.RpcTimeoutGetBlock > 0 {
-		override[rpcMethodGetBlockByHash] = &jsonrpc.RequestMethod{Name: "getblock", Timeout: clientCfg.RpcTimeoutGetBlock}
+		override[rpcMethodGetBlockByHash] = &jsonrpc.RequestMethod{Name: defaultGetBlockByHash.Name, Timeout: clientCfg.RpcTimeoutGetBlock}
 	}
 	if clientCfg.RpcTimeoutGetRawTx > 0 {
-		override[rpcMethodGetRawTransaction] = &jsonrpc.RequestMethod{Name: "getrawtransaction", Timeout: clientCfg.RpcTimeoutGetRawTx}
+		override[rpcMethodGetRawTransaction] = &jsonrpc.RequestMethod{Name: defaultGetRawTransaction.Name, Timeout: clientCfg.RpcTimeoutGetRawTx}
 	}
 	if clientCfg.RpcTimeoutGetBlockHash > 0 {
-		override[rpcMethodGetBlockHash] = &jsonrpc.RequestMethod{Name: "getblockhash", Timeout: clientCfg.RpcTimeoutGetBlockHash}
+		override[rpcMethodGetBlockHash] = &jsonrpc.RequestMethod{Name: defaultGetBlockHash.Name, Timeout: clientCfg.RpcTimeoutGetBlockHash}
 	}
 	return override
 }

--- a/internal/blockchain/client/bitcoin/bitcoin_test.go
+++ b/internal/blockchain/client/bitcoin/bitcoin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
+	"github.com/coinbase/chainstorage/internal/config"
 	jsonrpcmocks "github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks"
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/blockchain/restapi"
@@ -128,6 +130,39 @@ type bitcoinClientTestSuite struct {
 	testapp   testapp.TestApp
 	rpcClient *jsonrpcmocks.MockClient
 	client    internal.Client
+}
+
+func TestRpcMethodsOverrideFromConfig(t *testing.T) {
+	t.Run("NoOverrides", func(t *testing.T) {
+		require := testutil.Require(t)
+		cfg := &config.Config{}
+		methods := newRPCMethods(rpcMethodsOverrideFromConfig(cfg))
+		require.Equal(defaultGetBlockByHash.Timeout, methods.getBlockByHash.Timeout)
+		require.Equal(defaultGetRawTransaction.Timeout, methods.getRawTransaction.Timeout)
+		require.Equal(defaultGetBlockHash.Timeout, methods.getBlockHash.Timeout)
+	})
+
+	t.Run("OverrideGetRawTx", func(t *testing.T) {
+		require := testutil.Require(t)
+		cfg := &config.Config{}
+		cfg.Chain.Client.RpcTimeoutGetRawTx = 60 * time.Second
+		methods := newRPCMethods(rpcMethodsOverrideFromConfig(cfg))
+		require.Equal(60*time.Second, methods.getRawTransaction.Timeout)
+		require.Equal(defaultGetBlockByHash.Timeout, methods.getBlockByHash.Timeout)
+		require.Equal(defaultGetBlockHash.Timeout, methods.getBlockHash.Timeout)
+	})
+
+	t.Run("OverrideAll", func(t *testing.T) {
+		require := testutil.Require(t)
+		cfg := &config.Config{}
+		cfg.Chain.Client.RpcTimeoutGetBlock = 20 * time.Second
+		cfg.Chain.Client.RpcTimeoutGetRawTx = 60 * time.Second
+		cfg.Chain.Client.RpcTimeoutGetBlockHash = 10 * time.Second
+		methods := newRPCMethods(rpcMethodsOverrideFromConfig(cfg))
+		require.Equal(20*time.Second, methods.getBlockByHash.Timeout)
+		require.Equal(60*time.Second, methods.getRawTransaction.Timeout)
+		require.Equal(10*time.Second, methods.getBlockHash.Timeout)
+	})
 }
 
 func TestBitcoinClientTestSuite(t *testing.T) {

--- a/internal/blockchain/client/bitcoin/dash.go
+++ b/internal/blockchain/client/bitcoin/dash.go
@@ -16,7 +16,7 @@ func NewDashClientFactory(params internal.JsonrpcClientParams) internal.ClientFa
 			logger:                       logger,
 			client:                       client,
 			validate:                     validator.New(),
-			methods:                      newRPCMethods(),
+			methods:                      newRPCMethods(rpcMethodsOverrideFromConfig(params.Config)),
 			preserveRawInputTransactions: true,
 		}
 	})

--- a/internal/blockchain/client/bitcoin/zcash.go
+++ b/internal/blockchain/client/bitcoin/zcash.go
@@ -14,11 +14,14 @@ func NewZcashClientFactory(params internal.JsonrpcClientParams) internal.ClientF
 	return internal.NewJsonrpcClientFactory(params, func(client jsonrpc.Client) internal.Client {
 		logger := log.WithPackage(params.Logger)
 		return &bitcoinClient{
-			config:                       params.Config,
-			logger:                       logger,
-			client:                       client,
-			validate:                     validator.New(),
-			methods:                      newRPCMethods(rpcMethodsOverride{rpcMethodGetRawTransaction: &jsonrpc.RequestMethod{Name: "getrawtransaction", Timeout: 10 * time.Second}}),
+			config:   params.Config,
+			logger:   logger,
+			client:   client,
+			validate: validator.New(),
+			methods: newRPCMethods(
+				rpcMethodsOverrideFromConfig(params.Config),
+				rpcMethodsOverride{rpcMethodGetRawTransaction: &jsonrpc.RequestMethod{Name: "getrawtransaction", Timeout: 10 * time.Second}},
+			),
 			preserveRawInputTransactions: true,
 			getRawTxParams: func(txid string, _ string) jsonrpc.Params {
 				return jsonrpc.Params{txid, 1}

--- a/internal/blockchain/client/bitcoin/zcash.go
+++ b/internal/blockchain/client/bitcoin/zcash.go
@@ -19,8 +19,8 @@ func NewZcashClientFactory(params internal.JsonrpcClientParams) internal.ClientF
 			client:   client,
 			validate: validator.New(),
 			methods: newRPCMethods(
+				rpcMethodsOverride{rpcMethodGetRawTransaction: &jsonrpc.RequestMethod{Name: defaultGetRawTransaction.Name, Timeout: 10 * time.Second}},
 				rpcMethodsOverrideFromConfig(params.Config),
-				rpcMethodsOverride{rpcMethodGetRawTransaction: &jsonrpc.RequestMethod{Name: "getrawtransaction", Timeout: 10 * time.Second}},
 			),
 			preserveRawInputTransactions: true,
 			getRawTxParams: func(txid string, _ string) jsonrpc.Params {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,14 +76,17 @@ type (
 	}
 
 	ClientConfig struct {
-		Master      JSONRPCConfig     `mapstructure:"master"`
-		Slave       JSONRPCConfig     `mapstructure:"slave"`
-		Validator   JSONRPCConfig     `mapstructure:"validator"`
-		Consensus   JSONRPCConfig     `mapstructure:"consensus"`
-		Additional  JSONRPCConfig     `mapstructure:"additional"`
-		Retry       ClientRetryConfig `mapstructure:"retry"`
-		HttpTimeout time.Duration     `mapstructure:"http_timeout"`
-		TxBatchSize int               `mapstructure:"tx_batch_size"`
+		Master                 JSONRPCConfig     `mapstructure:"master"`
+		Slave                  JSONRPCConfig     `mapstructure:"slave"`
+		Validator              JSONRPCConfig     `mapstructure:"validator"`
+		Consensus              JSONRPCConfig     `mapstructure:"consensus"`
+		Additional             JSONRPCConfig     `mapstructure:"additional"`
+		Retry                  ClientRetryConfig `mapstructure:"retry"`
+		HttpTimeout            time.Duration     `mapstructure:"http_timeout"`
+		TxBatchSize            int               `mapstructure:"tx_batch_size"`
+		RpcTimeoutGetBlock     time.Duration     `mapstructure:"rpc_timeout_get_block"`
+		RpcTimeoutGetRawTx     time.Duration     `mapstructure:"rpc_timeout_get_raw_tx"`
+		RpcTimeoutGetBlockHash time.Duration     `mapstructure:"rpc_timeout_get_block_hash"`
 	}
 
 	JSONRPCConfig struct {


### PR DESCRIPTION
## Summary
- Adds configurable RPC timeout fields (`rpc_timeout_get_block`, `rpc_timeout_get_raw_tx`, `rpc_timeout_get_block_hash`) to `ClientConfig`, allowing any Bitcoin-family chain to override default RPC timeouts via YAML config
- Sets BCH mainnet `getrawtransaction` timeout to 60s (up from hardcoded 30s)
- Wires config overrides into all Bitcoin-family client factories (Bitcoin, Dash, Zcash)

## Context
BCH mainnet poller was failing on blocks 946488 and 946490 because `getrawtransaction` batch calls (89-100 txs per batch) to the NowNodes endpoint consistently exceeded the hardcoded 30s timeout, causing `context deadline exceeded`. After exhausting all retries (jsonrpc 4x, syncer 2x, Temporal activity 3x), the poller workflow terminated and the streamer got stuck at height 946485.

## Test plan
- [x] `TestRpcMethodsOverrideFromConfig` — verifies no-override (defaults preserved), partial override, and full override scenarios
- [x] Full bitcoin client test suite passes (17/17)
- [x] Config validation tests pass for BCH
- [x] `make config` regenerates correctly
- [ ] Deploy and verify poller recovers on BCH mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)