### PR TITLE
chore: expand dependabot config to cover gomod and docker

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,73 @@
 version: 2
+
+# Policy: ignore semver-major for version updates to reduce noise.
+# Security *alerts* still fire — triage manually when only a major bump fixes it.
+# Ref: aligned with monorepo dependabot policy.
+
 updates:
-  # Maintain dependencies for GitHub Actions
+  # ─── Go modules ───────────────────────────────────────────
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown: &cooldown-policy
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      go_modules:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "go"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # ─── GitHub Actions ───────────────────────────────────────
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown: *cooldown-policy
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # ─── Docker ───────────────────────────────────────────────
+  # Only tracks Dockerfiles; docker-compose-*.yml is not monitored by design.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown: *cooldown-policy
+    groups:
+      docker:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+      # Pin golang base image to current major.minor.
+      # Upgrading Go affects other services' dependencies and must be
+      # coordinated manually across the org.
+      - dependency-name: "golang"
+        versions: [">= 1.25"]


### PR DESCRIPTION
## Summary
- Add `gomod` and `docker` ecosystems alongside existing `github-actions` coverage
- Apply shared `cooldown` policy (3/7/14 days for patch/minor/major) across all ecosystems via YAML anchor
- Ignore semver-major updates org-wide to reduce PR noise; security alerts still fire for manual triage
- Pin `golang` base image to current major.minor (`>= 1.25` blocked) — Go upgrades need cross-service coordination
- Change GitHub Actions cadence from `daily` to `weekly`
- Aligned with the monorepo dependabot policy

## Test plan
- [ ] After merge, check GitHub → Insights → Dependency graph → Dependabot that all 3 ecosystems run without YAML parse errors
- [ ] Confirm the first batch of PRs respects grouping (one grouped PR per ecosystem, not one-per-dep)
- [ ] Verify no `golang` base image bump PRs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)