### PR TITLE
fix(megaeth): tolerate duplicate-tx-hash receipt index mismatch

### DIFF
--- a/internal/blockchain/parser/ethereum/ethereum_native.go
+++ b/internal/blockchain/parser/ethereum/ethereum_native.go
@@ -238,23 +238,36 @@ type (
 		Output  EthereumHexString `json:"output"`
 	}
 
+	// receiptIndexMismatchTolerator decides whether a receipt/transaction TransactionIndex
+	// mismatch (when hash/blockHash/blockNumber already match) is acceptable for a given chain.
+	// The default parser has none (strict). Chains with known data quirks inject one via
+	// WithReceiptIndexMismatchTolerator to keep their special-case knowledge out of this file.
+	receiptIndexMismatchTolerator func(
+		transaction *api.EthereumTransaction,
+		receipt *api.EthereumTransactionReceipt,
+		transactions []*api.EthereumTransaction,
+		txHashCounts map[string]int,
+	) bool
+
 	ethereumNativeParserImpl struct {
-		Logger        *zap.Logger
-		validate      *validator.Validate
-		nodeType      types.EthereumNodeType
-		traceType     types.TraceType
-		config        *config.Config
-		metrics       *ethereumNativeParserMetrics
-		src20Parser   SRC20TokenTransferParser // Optional, only Seismic sets this
-		timestampInMs bool                     // If true, raw timestamps are in milliseconds and need to be converted to seconds
+		Logger                        *zap.Logger
+		validate                      *validator.Validate
+		nodeType                      types.EthereumNodeType
+		traceType                     types.TraceType
+		config                        *config.Config
+		metrics                       *ethereumNativeParserMetrics
+		src20Parser                   SRC20TokenTransferParser      // Optional, only Seismic sets this
+		timestampInMs                 bool                          // If true, raw timestamps are in milliseconds and need to be converted to seconds
+		receiptIndexMismatchTolerator receiptIndexMismatchTolerator // Optional, only chains with duplicate-tx quirks (e.g. MegaETH) set this
 	}
 
 	ethereumParserOptions struct {
-		nodeType        types.EthereumNodeType
-		traceType       types.TraceType
-		checksumAddress bool
-		src20Parser     SRC20TokenTransferParser
-		timestampInMs   bool
+		nodeType                      types.EthereumNodeType
+		traceType                     types.TraceType
+		checksumAddress               bool
+		src20Parser                   SRC20TokenTransferParser
+		timestampInMs                 bool
+		receiptIndexMismatchTolerator receiptIndexMismatchTolerator
 	}
 
 	nestedParityTrace struct {
@@ -462,6 +475,8 @@ func NewEthereumNativeParser(params internal.ParserParams, opts ...internal.Pars
 		metrics:       newEthereumNativeParserMetrics(params.Metrics),
 		src20Parser:   options.src20Parser,
 		timestampInMs: options.timestampInMs,
+
+		receiptIndexMismatchTolerator: options.receiptIndexMismatchTolerator,
 	}, nil
 }
 
@@ -518,6 +533,17 @@ func WithTimestampInMs() internal.ParserFactoryOption {
 	}
 }
 
+// WithReceiptIndexMismatchTolerator installs a chain-specific policy that decides whether a
+// receipt/transaction TransactionIndex mismatch is acceptable. Used by chains whose nodes can
+// return blocks that break positional receipt/tx index pairing (e.g. MegaETH duplicate tx hashes).
+func WithReceiptIndexMismatchTolerator(tolerator receiptIndexMismatchTolerator) internal.ParserFactoryOption {
+	return func(options any) {
+		if v, ok := options.(*ethereumParserOptions); ok {
+			v.receiptIndexMismatchTolerator = tolerator
+		}
+	}
+}
+
 func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api.Block, opts ...internal.ParseOption) (*api.NativeBlock, error) {
 	metadata := rawBlock.GetMetadata()
 	if metadata == nil {
@@ -549,13 +575,15 @@ func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 			return nil, xerrors.Errorf("unexpected number of transaction receipts: expected=%v actual=%v", numTransactions, len(transactionReceipts))
 		}
 
-		// MegaETH can list the same tx hash multiple times in one block; see
-		// isMegaethDuplicateReceiptIndex for why this breaks positional receipt/tx index matching.
-		txHashCounts := make(map[string]int, len(transactions))
-		for _, t := range transactions {
-			txHashCounts[t.Hash]++
+		// txHashCounts is only needed by a chain-specific tolerator (see
+		// WithReceiptIndexMismatchTolerator); the default strict path skips the allocation.
+		var txHashCounts map[string]int
+		if p.receiptIndexMismatchTolerator != nil {
+			txHashCounts = make(map[string]int, len(transactions))
+			for _, t := range transactions {
+				txHashCounts[t.Hash]++
+			}
 		}
-		isMegaeth := p.config.Chain.Blockchain == common.Blockchain_BLOCKCHAIN_MEGAETH
 
 		for i, transactionReceipt := range transactionReceipts {
 			transaction := transactions[i]
@@ -565,8 +593,9 @@ func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 				transactionReceipt.BlockNumber != header.Number
 			indexMismatch := transactionReceipt.TransactionIndex != transaction.Index
 
-			tolerable := isMegaeth && indexMismatch && !hashOrBlockMismatch &&
-				isMegaethDuplicateReceiptIndex(transaction, transactionReceipt, transactions, txHashCounts)
+			tolerable := indexMismatch && !hashOrBlockMismatch &&
+				p.receiptIndexMismatchTolerator != nil &&
+				p.receiptIndexMismatchTolerator(transaction, transactionReceipt, transactions, txHashCounts)
 
 			if hashOrBlockMismatch || (indexMismatch && !tolerable) {
 				return nil, xerrors.Errorf("unexpected transaction receipt: transactionReceipt={%+v} transaction={%+v} block={%+v}", transactionReceipt, transaction, header)
@@ -577,7 +606,7 @@ func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 				if transactionReceipt.TransactionIndex < uint64(len(transactions)) {
 					receiptPointsToHash = transactions[transactionReceipt.TransactionIndex].Hash
 				}
-				p.Logger.Warn("megaeth: tolerating receipt/tx index mismatch caused by duplicate tx hash in block",
+				p.Logger.Warn("tolerating receipt/tx index mismatch by chain-specific policy",
 					zap.String("blockchain", p.config.Chain.Blockchain.String()),
 					zap.String("transaction_hash", transaction.Hash),
 					zap.Uint64("block_number", header.Number),
@@ -719,38 +748,6 @@ func (p *ethereumNativeParserImpl) toTimestamp(rawTimestamp int64) *timestamp.Ti
 		return utils.ToTimestampFromMs(rawTimestamp)
 	}
 	return utils.ToTimestamp(rawTimestamp)
-}
-
-// isMegaethDuplicateReceiptIndex reports whether a receipt/transaction TransactionIndex
-// mismatch is explained by the same tx hash appearing multiple times in the block. On
-// MegaETH a block can list one tx hash at several indices; eth_getTransactionReceipt then
-// returns the single canonical receipt (one index) for every occurrence, so positional
-// pairing disagrees on index even though the receipt is correct. Caller has already
-// confirmed hash/blockHash/blockNumber match.
-//
-// The receipt is intentionally NOT mutated: the node only has one receipt for the duplicated
-// hash, so the canonical index is the honest value. As a result, for the duplicated tx the
-// flattened transaction's TransactionIndex (its block position) may differ from the
-// receipt/event-log/token-transfer TransactionIndex (the node's canonical index).
-func isMegaethDuplicateReceiptIndex(
-	transaction *api.EthereumTransaction,
-	receipt *api.EthereumTransactionReceipt,
-	transactions []*api.EthereumTransaction,
-	txHashCounts map[string]int,
-) bool {
-	// (a) The hash must genuinely be duplicated in this block (position-independent).
-	if txHashCounts[transaction.Hash] <= 1 {
-		return false
-	}
-	// (b) The receipt's index must point at a real slot that holds the SAME hash —
-	//     i.e. the canonical occurrence — not an arbitrary/garbage index. Compare in
-	//     uint64 BEFORE converting to int to avoid a 64->int overflow producing a
-	//     negative/wrapped index.
-	if receipt.TransactionIndex >= uint64(len(transactions)) {
-		return false
-	}
-	idx := int(receipt.TransactionIndex)
-	return transactions[idx].Hash == transaction.Hash
 }
 
 func (p *ethereumNativeParserImpl) parseHeader(data []byte) (*api.EthereumHeader, []*api.EthereumTransaction, error) {

--- a/internal/blockchain/parser/ethereum/ethereum_native.go
+++ b/internal/blockchain/parser/ethereum/ethereum_native.go
@@ -549,14 +549,42 @@ func (p *ethereumNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 			return nil, xerrors.Errorf("unexpected number of transaction receipts: expected=%v actual=%v", numTransactions, len(transactionReceipts))
 		}
 
+		// MegaETH can list the same tx hash multiple times in one block; see
+		// isMegaethDuplicateReceiptIndex for why this breaks positional receipt/tx index matching.
+		txHashCounts := make(map[string]int, len(transactions))
+		for _, t := range transactions {
+			txHashCounts[t.Hash]++
+		}
+		isMegaeth := p.config.Chain.Blockchain == common.Blockchain_BLOCKCHAIN_MEGAETH
+
 		for i, transactionReceipt := range transactionReceipts {
 			transaction := transactions[i]
 
-			if transactionReceipt.TransactionHash != transaction.Hash ||
-				transactionReceipt.TransactionIndex != transaction.Index ||
+			hashOrBlockMismatch := transactionReceipt.TransactionHash != transaction.Hash ||
 				transactionReceipt.BlockHash != header.Hash ||
-				transactionReceipt.BlockNumber != header.Number {
+				transactionReceipt.BlockNumber != header.Number
+			indexMismatch := transactionReceipt.TransactionIndex != transaction.Index
+
+			tolerable := isMegaeth && indexMismatch && !hashOrBlockMismatch &&
+				isMegaethDuplicateReceiptIndex(transaction, transactionReceipt, transactions, txHashCounts)
+
+			if hashOrBlockMismatch || (indexMismatch && !tolerable) {
 				return nil, xerrors.Errorf("unexpected transaction receipt: transactionReceipt={%+v} transaction={%+v} block={%+v}", transactionReceipt, transaction, header)
+			}
+
+			if tolerable {
+				receiptPointsToHash := ""
+				if transactionReceipt.TransactionIndex < uint64(len(transactions)) {
+					receiptPointsToHash = transactions[transactionReceipt.TransactionIndex].Hash
+				}
+				p.Logger.Warn("megaeth: tolerating receipt/tx index mismatch caused by duplicate tx hash in block",
+					zap.String("blockchain", p.config.Chain.Blockchain.String()),
+					zap.String("transaction_hash", transaction.Hash),
+					zap.Uint64("block_number", header.Number),
+					zap.Uint64("expected_transaction_index", transaction.Index),
+					zap.Uint64("receipt_transaction_index", transactionReceipt.TransactionIndex),
+					zap.String("receipt_points_to_transaction_hash", receiptPointsToHash),
+				)
 			}
 		}
 	} else {
@@ -691,6 +719,38 @@ func (p *ethereumNativeParserImpl) toTimestamp(rawTimestamp int64) *timestamp.Ti
 		return utils.ToTimestampFromMs(rawTimestamp)
 	}
 	return utils.ToTimestamp(rawTimestamp)
+}
+
+// isMegaethDuplicateReceiptIndex reports whether a receipt/transaction TransactionIndex
+// mismatch is explained by the same tx hash appearing multiple times in the block. On
+// MegaETH a block can list one tx hash at several indices; eth_getTransactionReceipt then
+// returns the single canonical receipt (one index) for every occurrence, so positional
+// pairing disagrees on index even though the receipt is correct. Caller has already
+// confirmed hash/blockHash/blockNumber match.
+//
+// The receipt is intentionally NOT mutated: the node only has one receipt for the duplicated
+// hash, so the canonical index is the honest value. As a result, for the duplicated tx the
+// flattened transaction's TransactionIndex (its block position) may differ from the
+// receipt/event-log/token-transfer TransactionIndex (the node's canonical index).
+func isMegaethDuplicateReceiptIndex(
+	transaction *api.EthereumTransaction,
+	receipt *api.EthereumTransactionReceipt,
+	transactions []*api.EthereumTransaction,
+	txHashCounts map[string]int,
+) bool {
+	// (a) The hash must genuinely be duplicated in this block (position-independent).
+	if txHashCounts[transaction.Hash] <= 1 {
+		return false
+	}
+	// (b) The receipt's index must point at a real slot that holds the SAME hash —
+	//     i.e. the canonical occurrence — not an arbitrary/garbage index. Compare in
+	//     uint64 BEFORE converting to int to avoid a 64->int overflow producing a
+	//     negative/wrapped index.
+	if receipt.TransactionIndex >= uint64(len(transactions)) {
+		return false
+	}
+	idx := int(receipt.TransactionIndex)
+	return transactions[idx].Hash == transaction.Hash
 }
 
 func (p *ethereumNativeParserImpl) parseHeader(data []byte) (*api.EthereumHeader, []*api.EthereumTransaction, error) {

--- a/internal/blockchain/parser/ethereum/ethereum_native_test.go
+++ b/internal/blockchain/parser/ethereum/ethereum_native_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -2380,6 +2381,166 @@ func TestParseEthereumBlock_InvalidTransactionReceipt(t *testing.T) {
 	_, err := parser.ParseNativeBlock(context.Background(), block)
 	require.Error(err)
 	require.Contains(err.Error(), "unexpected transaction receipt")
+}
+
+// TestParseMegaethBlock_DuplicateTransactionReceiptIndex covers the MegaETH-only relaxation
+// for blocks that list the same tx hash multiple times (e.g. mainnet block 10004831). The
+// node returns one canonical receipt (single transactionIndex) for every occurrence, so the
+// positional receipt/tx index check disagrees even though the receipt is correct. The
+// relaxation is scoped strictly: MegaETH only, hash must still match, and the mismatch must be
+// a genuine duplicate-hash artifact.
+func TestParseMegaethBlock_DuplicateTransactionReceiptIndex(t *testing.T) {
+	const (
+		blockHash   = ethereumHash
+		dupTxHash   = "0xe67071db25331ea3a92a4e28b516c95f2d5b62b68329b70386c19e00807f51d8"
+		otherTxHash = "0x7422d3f183f198a4645d60deae5bebb6cd44f12df2c2e24b813ddd1c58da62c3"
+	)
+
+	type txSpec struct {
+		hash  string
+		index string
+	}
+
+	buildBlock := func(blockchain common.Blockchain, network common.Network, txs []txSpec, receipts []txSpec) *api.Block {
+		txJSON := func(s txSpec) string {
+			return fmt.Sprintf(`{
+				"blockHash": "%s",
+				"blockNumber": "0xacc290",
+				"from": "0x4823cc90c145fd6a16ab7668043dbba5ce79cdfc",
+				"gas": "0x15f90",
+				"gasPrice": "0x22cee4f700",
+				"hash": "%s",
+				"input": "0x",
+				"nonce": "0x1f0",
+				"to": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+				"transactionIndex": "%s",
+				"type": "0x0",
+				"value": "0xa"
+			}`, blockHash, s.hash, s.index)
+		}
+		receiptJSON := func(s txSpec) []byte {
+			return []byte(fmt.Sprintf(`{
+				"transactionHash": "%s",
+				"transactionIndex": "%s",
+				"blockHash": "%s",
+				"blockNumber": "0xacc290",
+				"from": "0x98265d92b016df8758f361fb8d2f9a813c82494a",
+				"to": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
+				"cumulativeGasUsed": "0xbca58c",
+				"gasUsed": "0x1b889",
+				"logsBloom": "0x00",
+				"logs": [],
+				"status": "0x1",
+				"type": "0x0"
+			}`, s.hash, s.index, blockHash))
+		}
+		traceJSON := []byte(`{
+			"type": "CALL",
+			"from": "0x4823cc90c145fd6a16ab7668043dbba5ce79cdfc",
+			"to": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+			"value": "0x0",
+			"gas": "0x10b1c",
+			"gasUsed": "0x4c91",
+			"input": "0x",
+			"output": "0x"
+		}`)
+
+		txsJSON := make([]string, len(txs))
+		for i, s := range txs {
+			txsJSON[i] = txJSON(s)
+		}
+		header := []byte(fmt.Sprintf(`{
+			"hash": "%s",
+			"parentHash": "%s",
+			"number": "0xacc290",
+			"timestamp": "0x5fbd2fb9",
+			"transactions": [%s]
+		}`, blockHash, ethereumParentHash, strings.Join(txsJSON, ",")))
+
+		rawReceipts := make([][]byte, len(receipts))
+		for i, s := range receipts {
+			rawReceipts[i] = receiptJSON(s)
+		}
+		rawTraces := make([][]byte, len(txs))
+		for i := range txs {
+			rawTraces[i] = traceJSON
+		}
+
+		return &api.Block{
+			Blockchain: blockchain,
+			Network:    network,
+			Metadata:   ethereumMetadata,
+			Blobdata: &api.Block_Ethereum{
+				Ethereum: &api.EthereumBlobdata{
+					Header:              header,
+					TransactionReceipts: rawReceipts,
+					TransactionTraces:   rawTraces,
+				},
+			},
+		}
+	}
+
+	newParser := func(t *testing.T, blockchain common.Blockchain, network common.Network) (internal.Parser, func()) {
+		var parser internal.Parser
+		app := testapp.New(
+			t,
+			Module,
+			internal.Module,
+			testapp.WithBlockchainNetwork(blockchain, network),
+			fx.Populate(&parser),
+		)
+		return parser, app.Close
+	}
+
+	t.Run("megaeth duplicate hash is tolerated", func(t *testing.T) {
+		require := testutil.Require(t)
+		// Same hash at index 0 and 1; the node returns the canonical receipt (index 1) for both.
+		block := buildBlock(
+			common.Blockchain_BLOCKCHAIN_MEGAETH,
+			common.Network_NETWORK_MEGAETH_MAINNET,
+			[]txSpec{{dupTxHash, "0x0"}, {dupTxHash, "0x1"}},
+			[]txSpec{{dupTxHash, "0x1"}, {dupTxHash, "0x1"}},
+		)
+		parser, cleanup := newParser(t, common.Blockchain_BLOCKCHAIN_MEGAETH, common.Network_NETWORK_MEGAETH_MAINNET)
+		defer cleanup()
+
+		nativeBlock, err := parser.ParseNativeBlock(context.Background(), block)
+		require.NoError(err)
+		require.NotNil(nativeBlock)
+	})
+
+	t.Run("ethereum with identical data still fails", func(t *testing.T) {
+		require := testutil.Require(t)
+		block := buildBlock(
+			common.Blockchain_BLOCKCHAIN_ETHEREUM,
+			common.Network_NETWORK_ETHEREUM_MAINNET,
+			[]txSpec{{dupTxHash, "0x0"}, {dupTxHash, "0x1"}},
+			[]txSpec{{dupTxHash, "0x1"}, {dupTxHash, "0x1"}},
+		)
+		parser, cleanup := newParser(t, common.Blockchain_BLOCKCHAIN_ETHEREUM, common.Network_NETWORK_ETHEREUM_MAINNET)
+		defer cleanup()
+
+		_, err := parser.ParseNativeBlock(context.Background(), block)
+		require.Error(err)
+		require.Contains(err.Error(), "unexpected transaction receipt")
+	})
+
+	t.Run("megaeth non-duplicate index mismatch still fails", func(t *testing.T) {
+		require := testutil.Require(t)
+		// Two distinct hashes: the index mismatch is NOT a duplicate-hash artifact, so it must fail.
+		block := buildBlock(
+			common.Blockchain_BLOCKCHAIN_MEGAETH,
+			common.Network_NETWORK_MEGAETH_MAINNET,
+			[]txSpec{{dupTxHash, "0x0"}, {otherTxHash, "0x1"}},
+			[]txSpec{{dupTxHash, "0x1"}, {otherTxHash, "0x1"}},
+		)
+		parser, cleanup := newParser(t, common.Blockchain_BLOCKCHAIN_MEGAETH, common.Network_NETWORK_MEGAETH_MAINNET)
+		defer cleanup()
+
+		_, err := parser.ParseNativeBlock(context.Background(), block)
+		require.Error(err)
+		require.Contains(err.Error(), "unexpected transaction receipt")
+	})
 }
 
 func TestParseEthereumBlock_PostLondon(t *testing.T) {

--- a/internal/blockchain/parser/ethereum/megaeth_native.go
+++ b/internal/blockchain/parser/ethereum/megaeth_native.go
@@ -2,9 +2,44 @@ package ethereum
 
 import (
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
 func NewMegaethNativeParser(params internal.ParserParams, opts ...internal.ParserFactoryOption) (internal.NativeParser, error) {
-	// Reuse the Ethereum native parser since its an EVM chain.
+	// Reuse the Ethereum native parser since its an EVM chain, but tolerate MegaETH's
+	// duplicate-tx-hash quirk in receipt/tx index validation (see below).
+	opts = append(opts, WithReceiptIndexMismatchTolerator(tolerateMegaethDuplicateReceiptIndex))
 	return NewEthereumNativeParser(params, opts...)
+}
+
+// tolerateMegaethDuplicateReceiptIndex reports whether a receipt/transaction TransactionIndex
+// mismatch is explained by the same tx hash appearing multiple times in a MegaETH block (e.g.
+// mainnet block 10004831). A MegaETH block can list one tx hash at several indices;
+// eth_getTransactionReceipt then returns the single canonical receipt (one index) for every
+// occurrence, so positional receipt/tx pairing disagrees on index even though the receipt is
+// correct. The caller has already confirmed hash/blockHash/blockNumber match.
+//
+// The receipt is intentionally NOT mutated: the node only has one receipt for the duplicated
+// hash, so the canonical index is the honest value. As a result, for the duplicated tx the
+// flattened transaction's TransactionIndex (its block position) may differ from the
+// receipt/event-log/token-transfer TransactionIndex (the node's canonical index).
+func tolerateMegaethDuplicateReceiptIndex(
+	transaction *api.EthereumTransaction,
+	receipt *api.EthereumTransactionReceipt,
+	transactions []*api.EthereumTransaction,
+	txHashCounts map[string]int,
+) bool {
+	// (a) The hash must genuinely be duplicated in this block (position-independent).
+	if txHashCounts[transaction.Hash] <= 1 {
+		return false
+	}
+	// (b) The receipt's index must point at a real slot that holds the SAME hash —
+	//     i.e. the canonical occurrence — not an arbitrary/garbage index. Compare in
+	//     uint64 BEFORE converting to int to avoid a 64->int overflow producing a
+	//     negative/wrapped index.
+	if receipt.TransactionIndex >= uint64(len(transactions)) {
+		return false
+	}
+	idx := int(receipt.TransactionIndex)
+	return transactions[idx].Hash == transaction.Hash
 }


### PR DESCRIPTION
## Problem

`admin block --blockchain megaeth --network mainnet --height 10004831` failed with `unexpected transaction receipt`.

Root cause: **MegaETH mainnet block 10004831 lists the same transaction hash twice** (`0x23e22168…` at block index 67 and again at 69). The parser pairs receipts with transactions positionally and asserts `receipt.TransactionIndex == transaction.Index`. Receipts are fetched per hash via `eth_getTransactionReceipt`, which returns the single canonical receipt (`transactionIndex=69`) for every occurrence — so at position 67 the receipt index (69) disagrees with the tx index (67) even though the hash matches, and validation aborts.

This is anomalous upstream data unique to MegaETH (an OP-stack L2). On normal EVM chains a tx hash is unique per block, so the strict check must stay for them.

## Change

Two commits:

1. **Fix** — relax *only* the `TransactionIndex` equality check, *only* for MegaETH, and *only* when the mismatch is provably a duplicate-hash artifact (the hash occurs >1× in the block **and** the receipt's index points at another slot holding the same hash). `hash`/`blockHash`/`blockNumber` remain strict for all chains. The receipt is **not** mutated (the node only has one receipt for the duplicated hash), so by design the flattened tx index (position, 67) may differ from the receipt/log index (canonical, 69) — documented in code.

2. **Refactor** — decouple the MegaETH special-case from the shared `ethereum_native.go`. The tolerance now lives behind an injectable policy (`WithReceiptIndexMismatchTolerator`), mirroring the existing `WithSRC20Parser` (Seismic) option pattern. The shared parser is chain-agnostic again — no `BLOCKCHAIN_MEGAETH` check, no megaeth-named helper; the duplicate-hash logic lives in `megaeth_native.go`. `txHashCounts` is only built when a tolerator is set, so the default Ethereum path keeps zero extra allocation.

> Pre-existing inline chain checks for Arbitrum/Polygon/Tron are intentionally left untouched — decoupling those is a separate cleanup, out of scope here.

## Tests

`TestParseMegaethBlock_DuplicateTransactionReceiptIndex` (black-box, via `NewMegaethNativeParser` + DI) covers three cases:
- MegaETH duplicate hash → parses successfully
- Ethereum, identical data → still fails (relaxation is MegaETH-only)
- MegaETH, non-duplicate index mismatch → still fails (not a duplicate-hash artifact)

## Verification

- `go build ./...`, `go vet`, full `internal/blockchain/parser/ethereum/...` package — pass
- e2e: `admin block … --height 10004831` now succeeds, writes the block, and emits one tolerance WARN per duplicate occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)