### PR TITLE
chore(ci): use latest tag for cipherowl/circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build_and_test:
     docker:
-      - image: ${CIPHEROWL_ECR_URL}/cipherowl/circleci:46f1d6a4caf201933914e8813b9c32b2f746d5f8
+      - image: ${CIPHEROWL_ECR_URL}/cipherowl/circleci:latest
     working_directory: ~/chainstorage
     steps:
       - checkout
@@ -40,7 +40,7 @@ jobs:
               -e CHAINSTORAGE_AWS_POSTGRES_USER=postgres \
               -e CHAINSTORAGE_AWS_POSTGRES_PASSWORD=postgres \
               -e CHAINSTORAGE_AWS_POSTGRES_DATABASE=postgres \
-              ${CIPHEROWL_ECR_URL}/cipherowl/circleci:46f1d6a4caf201933914e8813b9c32b2f746d5f8 \
+              ${CIPHEROWL_ECR_URL}/cipherowl/circleci:latest \
               /bin/bash -c "sudo chown -R circleci:circleci ~/ && make bootstrap && \
                 echo '🔧 Test databases already set up by init script' && \
                 TEST_TYPE=integration go test ./... -v -p=1 -parallel=1 -timeout=15m -failfast -run=TestIntegration"
@@ -53,7 +53,7 @@ jobs:
             # docker run --network chainstorage_default \
             #  --volumes-from chainstorage \
             #  -w /home/circleci/chainstorage \
-            #  ${CIPHEROWL_ECR_URL}/cipherowl/circleci:46f1d6a4caf201933914e8813b9c32b2f746d5f8 \
+            #  ${CIPHEROWL_ECR_URL}/cipherowl/circleci:latest \
             #  /bin/bash -c "sudo chown -R circleci:circleci ~/ && make bootstrap && TEST_TYPE=functional go test ./... -v -p=1 -parallel=1 -timeout=45m -failfast -run=TestIntegration"
             
             docker compose -f docker-compose-testing.yml down


### PR DESCRIPTION
## Summary

Pin the CircleCI build image to the `latest` tag instead of a fixed commit SHA.

## Changes

- Replace `cipherowl/circleci:46f1d6a4caf201933914e8813b9c32b2f746d5f8` with `cipherowl/circleci:latest` in `.circleci/config.yml` (build image, integration-test runner, and the commented-out functional-test runner).

## Benefits

CI always picks up the most recent CircleCI base image without needing to bump the SHA manually.

## Test Plan

1. Push triggers CircleCI `build_and_test`.
2. Confirm the job pulls `cipherowl/circleci:latest` and unit + integration tests pass.

## Risk & Impact

low: only changes the CI base image tag. `latest` is less reproducible than a pinned SHA, but matches the requested behavior.

## Checklist

- [x] Code builds locally
- [ ] Tests pass
- [ ] Docs updated
- [x] No breaking changes