### PR TITLE
feat(INF-906): add CSCB server range reader

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -40,7 +40,6 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/consts"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/log"
-	"github.com/coinbase/chainstorage/internal/utils/syncgroup"
 	"github.com/coinbase/chainstorage/internal/utils/utils"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 	"github.com/coinbase/chainstorage/sdk/services"
@@ -853,27 +852,11 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 }
 
 func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.Block, error) {
-	result := make([]*api.Block, len(blocks))
-	group, ctx := syncgroup.New(ctx, syncgroup.WithThrottling(int(s.config.Api.NumWorkers)))
-	for i := range blocks {
-		i := i
-		group.Go(func() error {
-			input := blocks[i]
-			output, err := s.blobStorage.Download(ctx, input)
-			if err != nil {
-				return xerrors.Errorf("failed to download from blob storage (input={%+v}): %w", input, err)
-			}
-
-			result[i] = output
-			return nil
-		})
-	}
-
-	if err := group.Wait(); err != nil {
+	output, err := s.blobStorage.DownloadMany(ctx, blocks)
+	if err != nil {
 		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
 	}
-
-	return result, nil
+	return output, nil
 }
 
 func (s *Server) newAuthContext(ctx context.Context) context.Context {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -642,11 +642,16 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_StableTag() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
-			func(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
-				block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
-				require.True(ok)
-				return block, nil
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+				require.Len(metadatas, numBlocks)
+				output := make([]*api.Block, len(metadatas))
+				for i, metadata := range metadatas {
+					block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
+					require.True(ok)
+					output[i] = block
+				}
+				return output, nil
 			},
 		),
 	)
@@ -694,11 +699,16 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_LatestTag() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
-			func(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
-				block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
-				require.True(ok)
-				return block, nil
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+				require.Len(metadatas, numBlocks)
+				output := make([]*api.Block, len(metadatas))
+				for i, metadata := range metadatas {
+					block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
+					require.True(ok)
+					output[i] = block
+				}
+				return output, nil
 			},
 		),
 	)
@@ -748,14 +758,18 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_DownloadError() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
-			func(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
-				block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
-				require.True(ok)
-				if block.Metadata.Height == failedHeight {
-					return nil, fmt.Errorf("mock download error")
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+				output := make([]*api.Block, len(metadatas))
+				for i, metadata := range metadatas {
+					block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
+					require.True(ok)
+					if block.Metadata.Height == failedHeight {
+						return nil, fmt.Errorf("mock download error")
+					}
+					output[i] = block
 				}
-				return block, nil
+				return output, nil
 			},
 		),
 	)
@@ -793,8 +807,8 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_DownloadCancelError() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
-			func(_ context.Context, _ *api.BlockMetadata) (*api.Block, error) {
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(_ context.Context, _ []*api.BlockMetadata) ([]*api.Block, error) {
 				return nil, storage.ErrRequestCanceled
 			},
 		),
@@ -896,11 +910,16 @@ func (s *handlerTestSuite) TestGetNativeBlocksByRange() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
-			func(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
-				block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
-				require.True(ok)
-				return block, nil
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+				require.Len(metadatas, numBlocks)
+				output := make([]*api.Block, len(metadatas))
+				for i, metadata := range metadatas {
+					block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
+					require.True(ok)
+					output[i] = block
+				}
+				return output, nil
 			},
 		),
 		s.parser.EXPECT().ParseNativeBlock(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
@@ -1053,11 +1072,16 @@ func (s *handlerTestSuite) TestGetRosettaBlocksByRange() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
-			func(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
-				block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
-				require.True(ok)
-				return block, nil
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+				require.Len(metadatas, numBlocks)
+				output := make([]*api.Block, len(metadatas))
+				for i, metadata := range metadatas {
+					block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
+					require.True(ok)
+					output[i] = block
+				}
+				return output, nil
 			},
 		),
 		s.parser.EXPECT().ParseRosettaBlock(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
@@ -1132,11 +1156,16 @@ func (s *handlerTestSuite) TestGetRosettaBlocksByRange_NotImplemented() {
 				return testutil.MakeBlockMetadata(10000, tag), nil
 			},
 		),
-		s.blobStorage.EXPECT().Download(gomock.Any(), gomock.Any()).Times(numBlocks).DoAndReturn(
-			func(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
-				block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
-				require.True(ok)
-				return block, nil
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+				require.Len(metadatas, numBlocks)
+				output := make([]*api.Block, len(metadatas))
+				for i, metadata := range metadatas {
+					block, ok := blocksByObjectKey[metadata.ObjectKeyMain]
+					require.True(ok)
+					output[i] = block
+				}
+				return output, nil
 			},
 		),
 	)
@@ -2643,8 +2672,8 @@ func (s *handlerTestSuite) TestGetNativeTransaction() {
 			GetBlocksByHeights(gomock.Any(), stableTag, gomock.Any()).
 			Return([]*api.BlockMetadata{blockMetadata}, nil),
 		s.blobStorage.EXPECT().
-			Download(gomock.Any(), gomock.Any()).
-			Return(rawBlock, nil),
+			DownloadMany(gomock.Any(), []*api.BlockMetadata{blockMetadata}).
+			Return([]*api.Block{rawBlock}, nil),
 		s.parser.EXPECT().
 			ParseNativeBlock(gomock.Any(), rawBlock).
 			Return(nativeBlock, nil),

--- a/internal/storage/blobstorage/cscb/encoder.go
+++ b/internal/storage/blobstorage/cscb/encoder.go
@@ -36,7 +36,10 @@ const (
 	fileSuffixGzip = ".cscb.gzip"
 	fileSuffixZstd = ".cscb.zstd"
 
-	defaultMemoryBudgetBytes = 256 * 1024 * 1024
+	MaxZstdLongDistanceWindowLog = 29
+
+	defaultMemoryBudgetBytes  = 256 * 1024 * 1024
+	maxZstdDecoderMemoryBytes = 1 << MaxZstdLongDistanceWindowLog
 )
 
 var (
@@ -342,8 +345,8 @@ func validateConfig(cfg EncodeConfig) error {
 	}
 	if cfg.Codec == api.Compression_ZSTD && cfg.ZstdLongDistanceWindowLog != nil {
 		windowLog := *cfg.ZstdLongDistanceWindowLog
-		if windowLog < 10 || windowLog > 29 {
-			return xerrors.Errorf("zstd_long_distance_window_log must be between 10 and 29, got %d", windowLog)
+		if windowLog < 10 || windowLog > MaxZstdLongDistanceWindowLog {
+			return xerrors.Errorf("zstd_long_distance_window_log must be between 10 and %d, got %d", MaxZstdLongDistanceWindowLog, windowLog)
 		}
 	}
 	if cfg.CompressionChunkBlocks == 0 {

--- a/internal/storage/blobstorage/cscb/reader.go
+++ b/internal/storage/blobstorage/cscb/reader.go
@@ -1,0 +1,411 @@
+package cscb
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"hash/crc32"
+
+	"golang.org/x/xerrors"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type (
+	Header struct {
+		Codec                     api.Compression
+		BlockCount                uint64
+		ChunkCount                uint64
+		StartHeight               uint64
+		EndHeight                 uint64
+		EnvelopeOffset            uint64
+		EnvelopeLength            uint64
+		EnvelopeCRC32             uint32
+		BlockIndexRecordSize      uint32
+		ChunkIndexRecordSize      uint32
+		PayloadOffset             uint64
+		PayloadCompressedLength   uint64
+		PayloadUncompressedLength uint64
+		PayloadCRC32              uint32
+	}
+
+	Index struct {
+		Header Header
+		Blocks []BlockDescriptor
+		Chunks []ChunkDescriptor
+
+		blocksByHeight map[uint64]int
+	}
+
+	BlockDescriptor struct {
+		Height               uint64
+		LogicalPayloadOffset uint64
+		PayloadLength        uint64
+		PayloadCRC32         uint32
+		ChunkIndex           uint32
+		ChunkRelativeOffset  uint64
+		HashSHA256           [32]byte
+		MetadataID           uint64
+	}
+
+	ChunkDescriptor struct {
+		Index                   uint32
+		StartHeight             uint64
+		EndHeight               uint64
+		CompressedPayloadOffset uint64
+		CompressedLength        uint64
+		UncompressedOffset      uint64
+		UncompressedLength      uint64
+		ChunkCRC32              uint32
+		BlockCount              uint32
+	}
+)
+
+func HeaderEnvelopeLength(data []byte) (uint64, error) {
+	header, err := ParseHeader(data)
+	if err != nil {
+		return 0, err
+	}
+	length, err := checkedAdd(header.EnvelopeOffset, header.EnvelopeLength)
+	if err != nil {
+		return 0, err
+	}
+	return length, nil
+}
+
+func ParseHeader(data []byte) (*Header, error) {
+	if len(data) < HeaderSize {
+		return nil, xerrors.Errorf("CSCB header requires %d bytes, got %d", HeaderSize, len(data))
+	}
+	if !bytes.Equal(data[0:4], magic[:]) {
+		return nil, xerrors.New("invalid CSCB magic")
+	}
+	if version := data[4]; version != formatVersion {
+		return nil, xerrors.Errorf("unsupported CSCB format version: %d", version)
+	}
+	codec, err := parseCodec(data[5])
+	if err != nil {
+		return nil, err
+	}
+	if scope := data[6]; scope != compressionScopeChunked {
+		return nil, xerrors.Errorf("unsupported CSCB compression scope: %d", scope)
+	}
+
+	header := &Header{
+		Codec:                     codec,
+		BlockCount:                uint64(binary.LittleEndian.Uint32(data[8:12])),
+		ChunkCount:                uint64(binary.LittleEndian.Uint32(data[12:16])),
+		StartHeight:               binary.LittleEndian.Uint64(data[16:24]),
+		EndHeight:                 binary.LittleEndian.Uint64(data[24:32]),
+		EnvelopeOffset:            binary.LittleEndian.Uint64(data[32:40]),
+		EnvelopeLength:            binary.LittleEndian.Uint64(data[40:48]),
+		EnvelopeCRC32:             binary.LittleEndian.Uint32(data[48:52]),
+		BlockIndexRecordSize:      binary.LittleEndian.Uint32(data[52:56]),
+		ChunkIndexRecordSize:      binary.LittleEndian.Uint32(data[56:60]),
+		PayloadOffset:             binary.LittleEndian.Uint64(data[60:68]),
+		PayloadCompressedLength:   binary.LittleEndian.Uint64(data[68:76]),
+		PayloadUncompressedLength: binary.LittleEndian.Uint64(data[76:84]),
+		PayloadCRC32:              binary.LittleEndian.Uint32(data[84:88]),
+	}
+	if header.BlockCount == 0 {
+		return nil, xerrors.New("CSCB header has zero blocks")
+	}
+	if header.ChunkCount == 0 {
+		return nil, xerrors.New("CSCB header has zero chunks")
+	}
+	if header.EnvelopeOffset != HeaderSize {
+		return nil, xerrors.Errorf("unexpected CSCB envelope offset: got %d want %d", header.EnvelopeOffset, HeaderSize)
+	}
+	if header.BlockIndexRecordSize != BlockIndexRecordSize {
+		return nil, xerrors.Errorf("unexpected CSCB block record size: got %d want %d", header.BlockIndexRecordSize, BlockIndexRecordSize)
+	}
+	if header.ChunkIndexRecordSize != ChunkIndexRecordSize {
+		return nil, xerrors.Errorf("unexpected CSCB chunk record size: got %d want %d", header.ChunkIndexRecordSize, ChunkIndexRecordSize)
+	}
+	expectedPayloadOffset, err := checkedAdd(header.EnvelopeOffset, header.EnvelopeLength)
+	if err != nil {
+		return nil, err
+	}
+	if header.PayloadOffset != expectedPayloadOffset {
+		return nil, xerrors.Errorf("unexpected CSCB payload offset: got %d want %d", header.PayloadOffset, expectedPayloadOffset)
+	}
+	return header, nil
+}
+
+func ParseIndex(data []byte) (*Index, error) {
+	header, err := ParseHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	required, err := HeaderEnvelopeLength(data)
+	if err != nil {
+		return nil, err
+	}
+	if required > uint64(len(data)) {
+		return nil, xerrors.Errorf("CSCB index requires %d bytes, got %d", required, len(data))
+	}
+
+	envelopeStart, err := toInt(header.EnvelopeOffset)
+	if err != nil {
+		return nil, err
+	}
+	envelopeLength, err := toInt(header.EnvelopeLength)
+	if err != nil {
+		return nil, err
+	}
+	envelope := data[envelopeStart : envelopeStart+envelopeLength]
+	if crc := crc32.ChecksumIEEE(envelope); crc != header.EnvelopeCRC32 {
+		return nil, xerrors.Errorf("CSCB envelope CRC mismatch: got %08x want %08x", crc, header.EnvelopeCRC32)
+	}
+	if len(envelope) < EnvelopeHeaderSize {
+		return nil, xerrors.Errorf("CSCB envelope requires %d bytes, got %d", EnvelopeHeaderSize, len(envelope))
+	}
+	if !bytes.Equal(envelope[0:4], envelopeMagic[:]) {
+		return nil, xerrors.New("invalid CSCB envelope magic")
+	}
+
+	blockCount := binary.LittleEndian.Uint64(envelope[8:16])
+	chunkCount := binary.LittleEndian.Uint64(envelope[16:24])
+	if blockCount != header.BlockCount {
+		return nil, xerrors.Errorf("CSCB block count mismatch: header=%d envelope=%d", header.BlockCount, blockCount)
+	}
+	if chunkCount != header.ChunkCount {
+		return nil, xerrors.Errorf("CSCB chunk count mismatch: header=%d envelope=%d", header.ChunkCount, chunkCount)
+	}
+	if startHeight := binary.LittleEndian.Uint64(envelope[24:32]); startHeight != header.StartHeight {
+		return nil, xerrors.Errorf("CSCB start height mismatch: header=%d envelope=%d", header.StartHeight, startHeight)
+	}
+	if endHeight := binary.LittleEndian.Uint64(envelope[32:40]); endHeight != header.EndHeight {
+		return nil, xerrors.Errorf("CSCB end height mismatch: header=%d envelope=%d", header.EndHeight, endHeight)
+	}
+
+	blockIndexOffset := binary.LittleEndian.Uint64(envelope[40:48])
+	blockIndexLength := binary.LittleEndian.Uint64(envelope[48:56])
+	chunkIndexOffset := binary.LittleEndian.Uint64(envelope[56:64])
+	chunkIndexLength := binary.LittleEndian.Uint64(envelope[64:72])
+	if blockIndexOffset != EnvelopeHeaderSize {
+		return nil, xerrors.Errorf("unexpected CSCB block index offset: got %d want %d", blockIndexOffset, EnvelopeHeaderSize)
+	}
+	expectedBlockIndexLength, err := checkedMul(blockCount, BlockIndexRecordSize)
+	if err != nil {
+		return nil, err
+	}
+	if blockIndexLength != expectedBlockIndexLength {
+		return nil, xerrors.Errorf("unexpected CSCB block index length: got %d want %d", blockIndexLength, expectedBlockIndexLength)
+	}
+	expectedChunkIndexOffset, err := checkedAdd(blockIndexOffset, blockIndexLength)
+	if err != nil {
+		return nil, err
+	}
+	if chunkIndexOffset != expectedChunkIndexOffset {
+		return nil, xerrors.Errorf("unexpected CSCB chunk index offset: got %d want %d", chunkIndexOffset, expectedChunkIndexOffset)
+	}
+	expectedChunkIndexLength, err := checkedMul(chunkCount, ChunkIndexRecordSize)
+	if err != nil {
+		return nil, err
+	}
+	if chunkIndexLength != expectedChunkIndexLength {
+		return nil, xerrors.Errorf("unexpected CSCB chunk index length: got %d want %d", chunkIndexLength, expectedChunkIndexLength)
+	}
+	indexEnd, err := checkedAdd(chunkIndexOffset, chunkIndexLength)
+	if err != nil {
+		return nil, err
+	}
+	if indexEnd != header.EnvelopeLength {
+		return nil, xerrors.Errorf("unexpected CSCB envelope length: index_end=%d envelope_length=%d", indexEnd, header.EnvelopeLength)
+	}
+
+	blocks, err := parseBlockDescriptors(envelope, blockIndexOffset, blockCount)
+	if err != nil {
+		return nil, err
+	}
+	chunks, err := parseChunkDescriptors(envelope, chunkIndexOffset, chunkCount)
+	if err != nil {
+		return nil, err
+	}
+	index := &Index{
+		Header:         *header,
+		Blocks:         blocks,
+		Chunks:         chunks,
+		blocksByHeight: make(map[uint64]int, len(blocks)),
+	}
+	for i := range blocks {
+		if _, ok := index.blocksByHeight[blocks[i].Height]; ok {
+			return nil, xerrors.Errorf("duplicate CSCB block height: %d", blocks[i].Height)
+		}
+		index.blocksByHeight[blocks[i].Height] = i
+	}
+	return index, nil
+}
+
+func (i *Index) LookupBlock(metadata *api.BlockMetadata) (*BlockDescriptor, *ChunkDescriptor, error) {
+	if metadata == nil {
+		return nil, nil, xerrors.New("block metadata is required")
+	}
+	blockIndex, ok := i.blocksByHeight[metadata.GetHeight()]
+	if !ok {
+		return nil, nil, xerrors.Errorf("CSCB block height %d not found", metadata.GetHeight())
+	}
+	block := &i.Blocks[blockIndex]
+	if block.LogicalPayloadOffset != metadata.GetByteOffset() {
+		return nil, nil, xerrors.Errorf("CSCB block offset mismatch at height %d: index=%d metadata=%d", metadata.GetHeight(), block.LogicalPayloadOffset, metadata.GetByteOffset())
+	}
+	if block.PayloadLength != metadata.GetByteLength() {
+		return nil, nil, xerrors.Errorf("CSCB block length mismatch at height %d: index=%d metadata=%d", metadata.GetHeight(), block.PayloadLength, metadata.GetByteLength())
+	}
+	if metadata.GetUncompressedLength() != 0 && metadata.GetUncompressedLength() != block.PayloadLength {
+		return nil, nil, xerrors.Errorf("CSCB block uncompressed length mismatch at height %d: index=%d metadata=%d", metadata.GetHeight(), block.PayloadLength, metadata.GetUncompressedLength())
+	}
+	hashDigest := sha256.Sum256([]byte(metadata.GetHash()))
+	if hashDigest != block.HashSHA256 {
+		return nil, nil, xerrors.Errorf("CSCB block hash mismatch at height %d", metadata.GetHeight())
+	}
+	if int(block.ChunkIndex) >= len(i.Chunks) {
+		return nil, nil, xerrors.Errorf("CSCB chunk index %d out of range for height %d", block.ChunkIndex, metadata.GetHeight())
+	}
+	chunk := &i.Chunks[block.ChunkIndex]
+	if metadata.GetHeight() < chunk.StartHeight || metadata.GetHeight() >= chunk.EndHeight {
+		return nil, nil, xerrors.Errorf("CSCB block height %d outside chunk range [%d, %d)", metadata.GetHeight(), chunk.StartHeight, chunk.EndHeight)
+	}
+	return block, chunk, nil
+}
+
+func ValidateChunkPayload(chunkPayload []byte, chunk *ChunkDescriptor) error {
+	if chunk == nil {
+		return xerrors.New("CSCB chunk descriptor is required")
+	}
+	if uint64(len(chunkPayload)) != chunk.UncompressedLength {
+		return xerrors.Errorf("CSCB chunk length mismatch: got %d want %d", len(chunkPayload), chunk.UncompressedLength)
+	}
+	if crc := crc32.ChecksumIEEE(chunkPayload); crc != chunk.ChunkCRC32 {
+		return xerrors.Errorf("CSCB chunk CRC mismatch: got %08x want %08x", crc, chunk.ChunkCRC32)
+	}
+	return nil
+}
+
+func ExtractBlockPayload(chunkPayload []byte, block *BlockDescriptor) ([]byte, error) {
+	if block == nil {
+		return nil, xerrors.New("CSCB block descriptor is required")
+	}
+	end, err := checkedAdd(block.ChunkRelativeOffset, block.PayloadLength)
+	if err != nil {
+		return nil, err
+	}
+	if end > uint64(len(chunkPayload)) {
+		return nil, xerrors.Errorf("CSCB block payload exceeds chunk bounds: end=%d chunk_length=%d", end, len(chunkPayload))
+	}
+	startIndex, err := toInt(block.ChunkRelativeOffset)
+	if err != nil {
+		return nil, err
+	}
+	endIndex, err := toInt(end)
+	if err != nil {
+		return nil, err
+	}
+	payload := chunkPayload[startIndex:endIndex]
+	if crc := crc32.ChecksumIEEE(payload); crc != block.PayloadCRC32 {
+		return nil, xerrors.Errorf("CSCB block CRC mismatch: got %08x want %08x", crc, block.PayloadCRC32)
+	}
+	return payload, nil
+}
+
+func parseBlockDescriptors(envelope []byte, offset uint64, count uint64) ([]BlockDescriptor, error) {
+	start, err := toInt(offset)
+	if err != nil {
+		return nil, err
+	}
+	countInt, err := toInt(count)
+	if err != nil {
+		return nil, err
+	}
+	blocks := make([]BlockDescriptor, countInt)
+	for i := 0; i < countInt; i++ {
+		recordStart := start + i*BlockIndexRecordSize
+		recordEnd := recordStart + BlockIndexRecordSize
+		if recordEnd > len(envelope) {
+			return nil, xerrors.Errorf("CSCB block index record %d exceeds envelope length", i)
+		}
+		record := envelope[recordStart:recordEnd]
+		var hash [32]byte
+		copy(hash[:], record[48:80])
+		blocks[i] = BlockDescriptor{
+			Height:               binary.LittleEndian.Uint64(record[0:8]),
+			LogicalPayloadOffset: binary.LittleEndian.Uint64(record[8:16]),
+			PayloadLength:        binary.LittleEndian.Uint64(record[16:24]),
+			PayloadCRC32:         binary.LittleEndian.Uint32(record[24:28]),
+			ChunkIndex:           binary.LittleEndian.Uint32(record[28:32]),
+			ChunkRelativeOffset:  binary.LittleEndian.Uint64(record[32:40]),
+			HashSHA256:           hash,
+			MetadataID:           binary.LittleEndian.Uint64(record[80:88]),
+		}
+	}
+	return blocks, nil
+}
+
+func parseChunkDescriptors(envelope []byte, offset uint64, count uint64) ([]ChunkDescriptor, error) {
+	start, err := toInt(offset)
+	if err != nil {
+		return nil, err
+	}
+	countInt, err := toInt(count)
+	if err != nil {
+		return nil, err
+	}
+	chunks := make([]ChunkDescriptor, countInt)
+	for i := 0; i < countInt; i++ {
+		recordStart := start + i*ChunkIndexRecordSize
+		recordEnd := recordStart + ChunkIndexRecordSize
+		if recordEnd > len(envelope) {
+			return nil, xerrors.Errorf("CSCB chunk index record %d exceeds envelope length", i)
+		}
+		record := envelope[recordStart:recordEnd]
+		chunks[i] = ChunkDescriptor{
+			Index:                   binary.LittleEndian.Uint32(record[0:4]),
+			StartHeight:             binary.LittleEndian.Uint64(record[8:16]),
+			EndHeight:               binary.LittleEndian.Uint64(record[16:24]),
+			CompressedPayloadOffset: binary.LittleEndian.Uint64(record[24:32]),
+			CompressedLength:        binary.LittleEndian.Uint64(record[32:40]),
+			UncompressedOffset:      binary.LittleEndian.Uint64(record[40:48]),
+			UncompressedLength:      binary.LittleEndian.Uint64(record[48:56]),
+			ChunkCRC32:              binary.LittleEndian.Uint32(record[56:60]),
+			BlockCount:              binary.LittleEndian.Uint32(record[60:64]),
+		}
+		if chunks[i].Index != uint32(i) {
+			return nil, xerrors.Errorf("unexpected CSCB chunk index: got %d want %d", chunks[i].Index, i)
+		}
+	}
+	return chunks, nil
+}
+
+func parseCodec(id byte) (api.Compression, error) {
+	switch id {
+	case codecGzip:
+		return api.Compression_GZIP, nil
+	case codecZstd:
+		return api.Compression_ZSTD, nil
+	default:
+		return api.Compression_NONE, xerrors.Errorf("unsupported CSCB codec id: %d", id)
+	}
+}
+
+func checkedAdd(a uint64, b uint64) (uint64, error) {
+	if a > ^uint64(0)-b {
+		return 0, xerrors.Errorf("uint64 overflow: %d + %d", a, b)
+	}
+	return a + b, nil
+}
+
+func checkedMul(a uint64, b uint64) (uint64, error) {
+	if a != 0 && b > ^uint64(0)/a {
+		return 0, xerrors.Errorf("uint64 overflow: %d * %d", a, b)
+	}
+	return a * b, nil
+}
+
+func toInt(v uint64) (int, error) {
+	maxInt := uint64(^uint(0) >> 1)
+	if v > maxInt {
+		return 0, xerrors.Errorf("value %d exceeds max int %d", v, maxInt)
+	}
+	return int(v), nil
+}

--- a/internal/storage/blobstorage/cscb/reader.go
+++ b/internal/storage/blobstorage/cscb/reader.go
@@ -2,10 +2,13 @@ package cscb
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/binary"
 	"hash/crc32"
+	"io"
 
+	"github.com/klauspost/compress/zstd"
 	"golang.org/x/xerrors"
 
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
@@ -283,6 +286,43 @@ func ValidateChunkPayload(chunkPayload []byte, chunk *ChunkDescriptor) error {
 	return nil
 }
 
+func DecodeChunkFrame(frame io.Reader, codec api.Compression) ([]byte, error) {
+	reader, err := NewChunkDecompressor(frame, codec)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = reader.Close() }()
+	decoded, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to decompress CSCB chunk: %w", err)
+	}
+	return decoded, nil
+}
+
+func NewChunkDecompressor(frame io.Reader, codec api.Compression) (io.ReadCloser, error) {
+	switch codec {
+	case api.Compression_GZIP:
+		reader, err := gzip.NewReader(frame)
+		if err != nil {
+			return nil, xerrors.Errorf("gzip reader: %w", err)
+		}
+		return reader, nil
+	case api.Compression_ZSTD:
+		reader, err := zstd.NewReader(
+			frame,
+			zstd.WithDecoderConcurrency(1),
+			zstd.WithDecoderLowmem(true),
+			zstd.WithDecoderMaxMemory(maxZstdDecoderMemoryBytes),
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("zstd reader: %w", err)
+		}
+		return &zstdReadCloser{reader}, nil
+	default:
+		return nil, xerrors.Errorf("unsupported CSCB codec: %v", codec)
+	}
+}
+
 func ExtractBlockPayload(chunkPayload []byte, block *BlockDescriptor) ([]byte, error) {
 	if block == nil {
 		return nil, xerrors.New("CSCB block descriptor is required")
@@ -307,6 +347,15 @@ func ExtractBlockPayload(chunkPayload []byte, block *BlockDescriptor) ([]byte, e
 		return nil, xerrors.Errorf("CSCB block CRC mismatch: got %08x want %08x", crc, block.PayloadCRC32)
 	}
 	return payload, nil
+}
+
+type zstdReadCloser struct {
+	*zstd.Decoder
+}
+
+func (z *zstdReadCloser) Close() error {
+	z.Decoder.Close()
+	return nil
 }
 
 func parseBlockDescriptors(envelope []byte, offset uint64, count uint64) ([]BlockDescriptor, error) {

--- a/internal/storage/blobstorage/cscb/reader_test.go
+++ b/internal/storage/blobstorage/cscb/reader_test.go
@@ -1,0 +1,81 @@
+package cscb
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/coinbase/chainstorage/internal/utils/testutil"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+func TestParseIndexAndExtractBlockPayload(t *testing.T) {
+	require := testutil.Require(t)
+
+	object, err := Encode(context.Background(), testEncodeConfig(api.Compression_ZSTD), testPayloads())
+	require.NoError(err)
+	defer object.Close()
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := ParseIndex(data)
+	require.NoError(err)
+	require.Equal(api.Compression_ZSTD, index.Header.Codec)
+	require.Len(index.Blocks, 3)
+	require.Len(index.Chunks, 2)
+
+	metadata := &api.BlockMetadata{
+		Tag:                7,
+		Height:             101,
+		Hash:               "hash-101",
+		ObjectKeyMain:      object.Key,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteOffset:         object.Placements[1].ByteOffset,
+		ByteLength:         object.Placements[1].ByteLength,
+		UncompressedLength: object.Placements[1].UncompressedLength,
+	}
+	block, chunk, err := index.LookupBlock(metadata)
+	require.NoError(err)
+	require.Equal(uint32(0), chunk.Index)
+
+	frame := data[chunk.CompressedPayloadOffset : chunk.CompressedPayloadOffset+chunk.CompressedLength]
+	reader, err := zstd.NewReader(bytes.NewReader(frame))
+	require.NoError(err)
+	defer reader.Close()
+	chunkPayload, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	require.NoError(ValidateChunkPayload(chunkPayload, chunk))
+	payload, err := ExtractBlockPayload(chunkPayload, block)
+	require.NoError(err)
+	require.Equal([]byte("bravo-bravo"), payload)
+}
+
+func TestLookupBlockRejectsMismatchedMetadata(t *testing.T) {
+	require := testutil.Require(t)
+
+	object, err := Encode(context.Background(), testEncodeConfig(api.Compression_ZSTD), testPayloads())
+	require.NoError(err)
+	defer object.Close()
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := ParseIndex(data)
+	require.NoError(err)
+
+	_, _, err = index.LookupBlock(&api.BlockMetadata{
+		Tag:                7,
+		Height:             101,
+		Hash:               "wrong-hash",
+		ObjectKeyMain:      object.Key,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteOffset:         object.Placements[1].ByteOffset,
+		ByteLength:         object.Placements[1].ByteLength,
+		UncompressedLength: object.Placements[1].UncompressedLength,
+	})
+	require.Error(err)
+	require.Contains(err.Error(), "hash mismatch")
+}

--- a/internal/storage/blobstorage/cscb/reader_test.go
+++ b/internal/storage/blobstorage/cscb/reader_test.go
@@ -3,10 +3,8 @@ package cscb
 import (
 	"bytes"
 	"context"
-	"io"
+	"strings"
 	"testing"
-
-	"github.com/klauspost/compress/zstd"
 
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
@@ -42,10 +40,7 @@ func TestParseIndexAndExtractBlockPayload(t *testing.T) {
 	require.Equal(uint32(0), chunk.Index)
 
 	frame := data[chunk.CompressedPayloadOffset : chunk.CompressedPayloadOffset+chunk.CompressedLength]
-	reader, err := zstd.NewReader(bytes.NewReader(frame))
-	require.NoError(err)
-	defer reader.Close()
-	chunkPayload, err := io.ReadAll(reader)
+	chunkPayload, err := DecodeChunkFrame(bytes.NewReader(frame), index.Header.Codec)
 	require.NoError(err)
 
 	require.NoError(ValidateChunkPayload(chunkPayload, chunk))
@@ -78,4 +73,31 @@ func TestLookupBlockRejectsMismatchedMetadata(t *testing.T) {
 	})
 	require.Error(err)
 	require.Contains(err.Error(), "hash mismatch")
+}
+
+func TestDecodeChunkFrameSupportsMaxAllowedZstdWindow(t *testing.T) {
+	require := testutil.Require(t)
+
+	windowLog := MaxZstdLongDistanceWindowLog
+	cfg := testEncodeConfig(api.Compression_ZSTD)
+	cfg.ZstdLongDistanceWindowLog = &windowLog
+	payload := []byte(strings.Repeat("solana-block-payload-", 1024))
+	blocks := testPayloads()[:1]
+	blocks[0] = makePayload(7, 100, "hash-100", 9001, payload)
+	object, err := Encode(context.Background(), cfg, blocks)
+	require.NoError(err)
+	defer object.Close()
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := ParseIndex(data)
+	require.NoError(err)
+	require.Len(index.Chunks, 1)
+	chunk := &index.Chunks[0]
+	frame := data[chunk.CompressedPayloadOffset : chunk.CompressedPayloadOffset+chunk.CompressedLength]
+
+	chunkPayload, err := DecodeChunkFrame(bytes.NewReader(frame), index.Header.Codec)
+	require.NoError(err)
+	require.NoError(ValidateChunkPayload(chunkPayload, chunk))
+	require.Equal(payload, chunkPayload)
 }

--- a/internal/storage/blobstorage/gcs/blob_storage.go
+++ b/internal/storage/blobstorage/gcs/blob_storage.go
@@ -267,6 +267,18 @@ func (s *blobStorageImpl) Download(ctx context.Context, metadata *api.BlockMetad
 	})
 }
 
+func (s *blobStorageImpl) DownloadMany(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+	blocks := make([]*api.Block, len(metadatas))
+	for i, metadata := range metadatas {
+		block, err := s.Download(ctx, metadata)
+		if err != nil {
+			return nil, err
+		}
+		blocks[i] = block
+	}
+	return blocks, nil
+}
+
 // PreSign implements internal.BlobStorage.
 func (s *blobStorageImpl) PreSign(ctx context.Context, objectKey string) (string, error) {
 	fileUrl, err := s.client.Bucket(s.bucket).SignedURL(objectKey, &storage.SignedURLOptions{

--- a/internal/storage/blobstorage/gcs/blob_storage.go
+++ b/internal/storage/blobstorage/gcs/blob_storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/instrument"
 	"github.com/coinbase/chainstorage/internal/utils/log"
+	"github.com/coinbase/chainstorage/internal/utils/syncgroup"
 	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
@@ -269,14 +270,31 @@ func (s *blobStorageImpl) Download(ctx context.Context, metadata *api.BlockMetad
 
 func (s *blobStorageImpl) DownloadMany(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
 	blocks := make([]*api.Block, len(metadatas))
-	for i, metadata := range metadatas {
-		block, err := s.Download(ctx, metadata)
-		if err != nil {
-			return nil, err
-		}
-		blocks[i] = block
+	group, ctx := syncgroup.New(ctx, syncgroup.WithThrottling(s.downloadWorkerLimit()))
+	for i := range metadatas {
+		i := i
+		group.Go(func() error {
+			metadata := metadatas[i]
+			block, err := s.Download(ctx, metadata)
+			if err != nil {
+				return xerrors.Errorf("failed to download from GCS blob storage (input={%+v}): %w", metadata, err)
+			}
+			blocks[i] = block
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 	return blocks, nil
+}
+
+func (s *blobStorageImpl) downloadWorkerLimit() int {
+	limit := int(s.config.Api.NumWorkers)
+	if limit <= 0 {
+		return 1
+	}
+	return limit
 }
 
 // PreSign implements internal.BlobStorage.

--- a/internal/storage/blobstorage/internal/blobstorage.go
+++ b/internal/storage/blobstorage/internal/blobstorage.go
@@ -54,6 +54,7 @@ type (
 		UploadRaw(ctx context.Context, rawBlockData *RawBlockData) (string, error)
 		UploadConsolidated(ctx context.Context, blocks []ConsolidatedBlockPayload) (string, []BlockPlacement, error)
 		Download(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error)
+		DownloadMany(ctx context.Context, metadata []*api.BlockMetadata) ([]*api.Block, error)
 		PreSign(ctx context.Context, objectKey string) (string, error)
 	}
 

--- a/internal/storage/blobstorage/mocks/mocks.go
+++ b/internal/storage/blobstorage/mocks/mocks.go
@@ -56,6 +56,21 @@ func (mr *MockBlobStorageMockRecorder) Download(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockBlobStorage)(nil).Download), arg0, arg1)
 }
 
+// DownloadMany mocks base method.
+func (m *MockBlobStorage) DownloadMany(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadMany", arg0, arg1)
+	ret0, _ := ret[0].([]*chainstorage.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DownloadMany indicates an expected call of DownloadMany.
+func (mr *MockBlobStorageMockRecorder) DownloadMany(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadMany", reflect.TypeOf((*MockBlobStorage)(nil).DownloadMany), arg0, arg1)
+}
+
 // PreSign mocks base method.
 func (m *MockBlobStorage) PreSign(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/storage/blobstorage/s3/blob_storage.go
+++ b/internal/storage/blobstorage/s3/blob_storage.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -30,6 +31,7 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/instrument"
 	"github.com/coinbase/chainstorage/internal/utils/log"
+	"github.com/coinbase/chainstorage/internal/utils/syncgroup"
 	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
@@ -48,21 +50,33 @@ type (
 	}
 
 	blobStorageImpl struct {
-		logger              *zap.Logger
-		config              *config.Config
-		bucket              string
-		client              s3.Client
-		downloader          s3.Downloader
-		uploader            s3.Uploader
-		blobStorageMetrics  *blobStorageMetrics
-		instrumentUpload    instrument.InstrumentWithResult[string]
-		instrumentUploadRaw instrument.InstrumentWithResult[string]
-		instrumentDownload  instrument.InstrumentWithResult[*api.Block]
+		logger                 *zap.Logger
+		config                 *config.Config
+		bucket                 string
+		client                 s3.Client
+		downloader             s3.Downloader
+		uploader               s3.Uploader
+		blobStorageMetrics     *blobStorageMetrics
+		instrumentUpload       instrument.InstrumentWithResult[string]
+		instrumentUploadRaw    instrument.InstrumentWithResult[string]
+		instrumentDownload     instrument.InstrumentWithResult[*api.Block]
+		instrumentDownloadMany instrument.InstrumentWithResult[[]*api.Block]
 	}
 
 	blobStorageMetrics struct {
 		blobDownloadedSize tally.Timer
 		blobUploadedSize   tally.Timer
+	}
+
+	downloadRef struct {
+		index    int
+		metadata *api.BlockMetadata
+	}
+
+	cscbBlockDownload struct {
+		ref   downloadRef
+		block *cscb.BlockDescriptor
+		chunk *cscb.ChunkDescriptor
 	}
 )
 
@@ -78,6 +92,8 @@ const (
 	cscbMetadataUncompressedLength = "chainstorage-uncompressed-length"
 
 	maxSinglePutObjectSize = 5 * 1024 * 1024 * 1024
+
+	cscbInitialIndexReadSize = 64 * 1024
 )
 
 var _ internal.BlobStorage = (*blobStorageImpl)(nil)
@@ -96,16 +112,17 @@ func New(params BlobStorageParams) (internal.BlobStorage, error) {
 		"storage_type": "s3",
 	})
 	return &blobStorageImpl{
-		logger:              log.WithPackage(params.Logger),
-		config:              params.Config,
-		bucket:              params.Config.AWS.Bucket,
-		client:              params.Client,
-		downloader:          params.Downloader,
-		uploader:            params.Uploader,
-		blobStorageMetrics:  newBlobStorageMetrics(metrics),
-		instrumentUpload:    instrument.NewWithResult[string](metrics, "upload"),
-		instrumentUploadRaw: instrument.NewWithResult[string](metrics, "upload_raw"),
-		instrumentDownload:  instrument.NewWithResult[*api.Block](metrics, "download"),
+		logger:                 log.WithPackage(params.Logger),
+		config:                 params.Config,
+		bucket:                 params.Config.AWS.Bucket,
+		client:                 params.Client,
+		downloader:             params.Downloader,
+		uploader:               params.Uploader,
+		blobStorageMetrics:     newBlobStorageMetrics(metrics),
+		instrumentUpload:       instrument.NewWithResult[string](metrics, "upload"),
+		instrumentUploadRaw:    instrument.NewWithResult[string](metrics, "upload_raw"),
+		instrumentDownload:     instrument.NewWithResult[*api.Block](metrics, "download"),
+		instrumentDownloadMany: instrument.NewWithResult[[]*api.Block](metrics, "download_many"),
 	}, nil
 }
 
@@ -404,51 +421,286 @@ func (s *blobStorageImpl) Download(ctx context.Context, metadata *api.BlockMetad
 		defer s.logDuration("download", time.Now())
 
 		if metadata.Skipped {
-			// No blob data is available when the block is skipped.
-			return &api.Block{
-				Blockchain: s.config.Chain.Blockchain,
-				Network:    s.config.Chain.Network,
-				SideChain:  s.config.Chain.Sidechain,
-				Metadata:   metadata,
-				Blobdata:   nil,
-			}, nil
+			return s.skippedBlock(metadata), nil
 		}
-
-		key := metadata.ObjectKeyMain
-		buf := manager.NewWriteAtBuffer([]byte{})
-
-		size, err := s.downloader.Download(ctx, buf, &awss3.GetObjectInput{
-			Bucket: aws.String(s.bucket),
-			Key:    aws.String(key),
-		})
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return nil, storageerrors.ErrRequestCanceled
-			}
-			return nil, xerrors.Errorf("failed to download from s3 (bucket=%s, key=%s): %w", s.bucket, key, err)
+		if isLegacyBlockObject(metadata) {
+			return s.downloadLegacy(ctx, metadata)
 		}
-
-		// a workaround to use timer
-		s.blobStorageMetrics.blobDownloadedSize.Record(time.Duration(size) * time.Millisecond)
-
-		compression := storage_utils.GetCompressionType(key)
-		blockData, err := storage_utils.Decompress(buf.Bytes(), compression)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to decompress block data with type %v: %w", compression.String(), err)
-		}
-
-		var block api.Block
-		err = proto.Unmarshal(blockData, &block)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal data downloaded from s3 bucket %s key %s: %w", s.bucket, key, err)
-		}
-
-		// When metadata is loaded from meta storage,
-		// the new fields, e.g. ParentHeight, may be populated with default values.
-		// Overwrite metadata using the one loaded from meta storage.
-		block.Metadata = metadata
-		return &block, nil
+		return s.downloadCSCBBlock(ctx, metadata)
 	})
+}
+
+func (s *blobStorageImpl) DownloadMany(ctx context.Context, metadatas []*api.BlockMetadata) ([]*api.Block, error) {
+	return s.instrumentDownloadMany.Instrument(ctx, func(ctx context.Context) ([]*api.Block, error) {
+		defer s.logDuration("download_many", time.Now())
+
+		result := make([]*api.Block, len(metadatas))
+		legacyRefs := make([]downloadRef, 0, len(metadatas))
+		cscbRefsByObject := make(map[string][]downloadRef)
+		for i, metadata := range metadatas {
+			if metadata.GetSkipped() {
+				result[i] = s.skippedBlock(metadata)
+				continue
+			}
+			ref := downloadRef{
+				index:    i,
+				metadata: metadata,
+			}
+			if isLegacyBlockObject(metadata) {
+				legacyRefs = append(legacyRefs, ref)
+				continue
+			}
+			key := metadata.GetObjectKeyMain()
+			if key == "" {
+				return nil, xerrors.Errorf("missing CSCB object key for height %d", metadata.GetHeight())
+			}
+			cscbRefsByObject[key] = append(cscbRefsByObject[key], ref)
+		}
+
+		group, ctx := syncgroup.New(ctx, syncgroup.WithThrottling(s.downloadWorkerLimit()))
+		for _, ref := range legacyRefs {
+			ref := ref
+			group.Go(func() error {
+				block, err := s.downloadLegacy(ctx, ref.metadata)
+				if err != nil {
+					return xerrors.Errorf("failed to download legacy block (input={%+v}): %w", ref.metadata, err)
+				}
+				result[ref.index] = block
+				return nil
+			})
+		}
+		for key, refs := range cscbRefsByObject {
+			key, refs := key, refs
+			group.Go(func() error {
+				if err := s.downloadCSCBObject(ctx, key, refs, result); err != nil {
+					return xerrors.Errorf("failed to download CSCB object %s: %w", key, err)
+				}
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			return nil, err
+		}
+		return result, nil
+	})
+}
+
+func (s *blobStorageImpl) skippedBlock(metadata *api.BlockMetadata) *api.Block {
+	return &api.Block{
+		Blockchain: s.config.Chain.Blockchain,
+		Network:    s.config.Chain.Network,
+		SideChain:  s.config.Chain.Sidechain,
+		Metadata:   metadata,
+		Blobdata:   nil,
+	}
+}
+
+func isLegacyBlockObject(metadata *api.BlockMetadata) bool {
+	return metadata.GetObjectFormat() != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH || metadata.GetByteLength() == 0
+}
+
+func (s *blobStorageImpl) downloadWorkerLimit() int {
+	limit := int(s.config.Api.NumWorkers)
+	if limit <= 0 {
+		return 1
+	}
+	return limit
+}
+
+func (s *blobStorageImpl) downloadLegacy(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
+	key := metadata.ObjectKeyMain
+	buf := manager.NewWriteAtBuffer([]byte{})
+
+	size, err := s.downloader.Download(ctx, buf, &awss3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, storageerrors.ErrRequestCanceled
+		}
+		return nil, xerrors.Errorf("failed to download from s3 (bucket=%s, key=%s): %w", s.bucket, key, err)
+	}
+
+	// a workaround to use timer
+	s.blobStorageMetrics.blobDownloadedSize.Record(time.Duration(size) * time.Millisecond)
+
+	compression := storage_utils.GetCompressionType(key)
+	blockData, err := storage_utils.Decompress(buf.Bytes(), compression)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to decompress block data with type %v: %w", compression.String(), err)
+	}
+
+	return unmarshalBlockData(s.bucket, key, metadata, blockData)
+}
+
+func (s *blobStorageImpl) downloadCSCBBlock(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error) {
+	result := make([]*api.Block, 1)
+	ref := downloadRef{
+		index:    0,
+		metadata: metadata,
+	}
+	if err := s.downloadCSCBObject(ctx, metadata.GetObjectKeyMain(), []downloadRef{ref}, result); err != nil {
+		return nil, err
+	}
+	return result[0], nil
+}
+
+func (s *blobStorageImpl) downloadCSCBObject(ctx context.Context, key string, refs []downloadRef, result []*api.Block) error {
+	index, err := s.readCSCBIndex(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	downloadsByChunk := make(map[uint32][]cscbBlockDownload)
+	for _, ref := range refs {
+		block, chunk, err := index.LookupBlock(ref.metadata)
+		if err != nil {
+			return err
+		}
+		downloadsByChunk[chunk.Index] = append(downloadsByChunk[chunk.Index], cscbBlockDownload{
+			ref:   ref,
+			block: block,
+			chunk: chunk,
+		})
+	}
+
+	chunkIndexes := make([]int, 0, len(downloadsByChunk))
+	for chunkIndex := range downloadsByChunk {
+		chunkIndexes = append(chunkIndexes, int(chunkIndex))
+	}
+	sort.Ints(chunkIndexes)
+
+	for _, chunkIndex := range chunkIndexes {
+		downloads := downloadsByChunk[uint32(chunkIndex)]
+		chunk := downloads[0].chunk
+		chunkPayload, err := s.downloadCSCBChunk(ctx, key, index.Header.Codec, chunk)
+		if err != nil {
+			return err
+		}
+		if err := cscb.ValidateChunkPayload(chunkPayload, chunk); err != nil {
+			return err
+		}
+		for _, download := range downloads {
+			blockPayload, err := cscb.ExtractBlockPayload(chunkPayload, download.block)
+			if err != nil {
+				return err
+			}
+			block, err := unmarshalBlockData(s.bucket, key, download.ref.metadata, blockPayload)
+			if err != nil {
+				return err
+			}
+			result[download.ref.index] = block
+		}
+	}
+	return nil
+}
+
+func (s *blobStorageImpl) readCSCBIndex(ctx context.Context, key string) (*cscb.Index, error) {
+	first, err := s.readObjectRange(ctx, key, 0, cscbInitialIndexReadSize-1)
+	if err != nil {
+		return nil, err
+	}
+	required, err := cscb.HeaderEnvelopeLength(first)
+	if err != nil {
+		return nil, err
+	}
+	if required <= uint64(len(first)) {
+		return cscb.ParseIndex(first)
+	}
+	remaining, err := s.readObjectRange(ctx, key, uint64(len(first)), required-1)
+	if err != nil {
+		return nil, err
+	}
+	indexData := make([]byte, 0, required)
+	indexData = append(indexData, first...)
+	indexData = append(indexData, remaining...)
+	return cscb.ParseIndex(indexData)
+}
+
+func (s *blobStorageImpl) downloadCSCBChunk(ctx context.Context, key string, codec api.Compression, chunk *cscb.ChunkDescriptor) ([]byte, error) {
+	compressed, err := s.readObjectRangeByLength(ctx, key, chunk.CompressedPayloadOffset, chunk.CompressedLength)
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(compressed)) != chunk.CompressedLength {
+		return nil, xerrors.Errorf("CSCB compressed chunk length mismatch: got %d want %d", len(compressed), chunk.CompressedLength)
+	}
+	reader, err := storage_utils.DecompressReader(bytes.NewReader(compressed), codec)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create CSCB chunk decompressor: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to decompress CSCB chunk: %w", err)
+	}
+	return decompressed, nil
+}
+
+func (s *blobStorageImpl) readObjectRangeByLength(ctx context.Context, key string, offset uint64, length uint64) ([]byte, error) {
+	if length == 0 {
+		return nil, xerrors.Errorf("empty range read for key %s at offset %d", key, offset)
+	}
+	end, err := inclusiveRangeEnd(offset, length)
+	if err != nil {
+		return nil, err
+	}
+	return s.readObjectRange(ctx, key, offset, end)
+}
+
+func (s *blobStorageImpl) readObjectRange(ctx context.Context, key string, start uint64, end uint64) ([]byte, error) {
+	if end < start {
+		return nil, xerrors.Errorf("invalid range for key %s: start=%d end=%d", key, start, end)
+	}
+	output, err := s.client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", start, end)),
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, storageerrors.ErrRequestCanceled
+		}
+		return nil, xerrors.Errorf("failed to range download from s3 (bucket=%s, key=%s, range=bytes=%d-%d): %w", s.bucket, key, start, end, err)
+	}
+	if output.Body == nil {
+		return nil, xerrors.Errorf("empty s3 body (bucket=%s, key=%s, range=bytes=%d-%d)", s.bucket, key, start, end)
+	}
+	defer func() { _ = output.Body.Close() }()
+	data, err := io.ReadAll(output.Body)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, storageerrors.ErrRequestCanceled
+		}
+		return nil, xerrors.Errorf("failed to read s3 range body (bucket=%s, key=%s, range=bytes=%d-%d): %w", s.bucket, key, start, end, err)
+	}
+	s.blobStorageMetrics.blobDownloadedSize.Record(time.Duration(len(data)) * time.Millisecond)
+	return data, nil
+}
+
+func inclusiveRangeEnd(offset uint64, length uint64) (uint64, error) {
+	if length == 0 {
+		return 0, xerrors.New("range length must be positive")
+	}
+	if offset > ^uint64(0)-(length-1) {
+		return 0, xerrors.Errorf("range overflow: offset=%d length=%d", offset, length)
+	}
+	return offset + length - 1, nil
+}
+
+func unmarshalBlockData(bucket string, key string, metadata *api.BlockMetadata, blockData []byte) (*api.Block, error) {
+	var block api.Block
+	err := proto.Unmarshal(blockData, &block)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal data downloaded from s3 bucket %s key %s: %w", bucket, key, err)
+	}
+
+	// When metadata is loaded from meta storage,
+	// the new fields, e.g. ParentHeight, may be populated with default values.
+	// Overwrite metadata using the one loaded from meta storage.
+	block.Metadata = metadata
+	return &block, nil
 }
 
 func (s *blobStorageImpl) PreSign(ctx context.Context, objectKey string) (string, error) {

--- a/internal/storage/blobstorage/s3/blob_storage.go
+++ b/internal/storage/blobstorage/s3/blob_storage.go
@@ -461,7 +461,7 @@ func (s *blobStorageImpl) DownloadMany(ctx context.Context, metadatas []*api.Blo
 		for _, ref := range legacyRefs {
 			ref := ref
 			group.Go(func() error {
-				block, err := s.downloadLegacy(ctx, ref.metadata)
+				block, err := s.Download(ctx, ref.metadata)
 				if err != nil {
 					return xerrors.Errorf("failed to download legacy block (input={%+v}): %w", ref.metadata, err)
 				}
@@ -626,14 +626,9 @@ func (s *blobStorageImpl) downloadCSCBChunk(ctx context.Context, key string, cod
 	if uint64(len(compressed)) != chunk.CompressedLength {
 		return nil, xerrors.Errorf("CSCB compressed chunk length mismatch: got %d want %d", len(compressed), chunk.CompressedLength)
 	}
-	reader, err := storage_utils.DecompressReader(bytes.NewReader(compressed), codec)
+	decompressed, err := cscb.DecodeChunkFrame(bytes.NewReader(compressed), codec)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create CSCB chunk decompressor: %w", err)
-	}
-	defer func() { _ = reader.Close() }()
-	decompressed, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to decompress CSCB chunk: %w", err)
+		return nil, err
 	}
 	return decompressed, nil
 }

--- a/internal/storage/blobstorage/s3/blob_storage_consolidated_test.go
+++ b/internal/storage/blobstorage/s3/blob_storage_consolidated_test.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5" // #nosec G501
 	"crypto/sha256"
@@ -11,11 +12,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	awss3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/s3"
 	s3mocks "github.com/coinbase/chainstorage/internal/s3/mocks"
@@ -242,6 +245,143 @@ func TestBlobStorage_UploadConsolidated_AcceptsConcurrentExactObject(t *testing.
 	require.Len(placements, 2)
 }
 
+func TestBlobStorage_DownloadConsolidatedBlock_RangeReadsChunk(t *testing.T) {
+	require := testutil.Require(t)
+	object, metadatas, expectedBlocks, objectData, index := testS3CSCBProtoObject(t)
+	defer object.Close()
+
+	targetMetadata := metadatas[1]
+	_, targetChunk, err := index.LookupBlock(targetMetadata)
+	require.NoError(err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	downloader := s3mocks.NewMockDownloader(ctrl)
+	uploader := s3mocks.NewMockUploader(ctrl)
+	client := s3mocks.NewMockClient(ctrl)
+	expectedRanges := map[string]int{
+		"bytes=0-65535":          1,
+		rangeHeader(targetChunk): 1,
+	}
+	expectRangeReads(t, client, objectData, expectedRanges)
+
+	var storage internal.BlobStorage
+	app := testapp.New(
+		t,
+		testapp.WithBlockchainNetwork(common.Blockchain_BLOCKCHAIN_SOLANA, common.Network_NETWORK_SOLANA_MAINNET),
+		fx.Provide(New),
+		fx.Provide(func() s3.Downloader { return downloader }),
+		fx.Provide(func() s3.Uploader { return uploader }),
+		fx.Provide(func() s3.Client { return client }),
+		fx.Populate(&storage),
+	)
+	defer app.Close()
+
+	actual, err := storage.Download(context.Background(), targetMetadata)
+	require.NoError(err)
+	require.True(proto.Equal(expectedBlocks[1], actual))
+	assertRangeReadsConsumed(t, expectedRanges)
+}
+
+func TestBlobStorage_DownloadManyConsolidatedBlocks_GroupsByObjectAndChunk(t *testing.T) {
+	require := testutil.Require(t)
+	object, metadatas, expectedBlocks, objectData, index := testS3CSCBProtoObject(t)
+	defer object.Close()
+
+	_, chunk0, err := index.LookupBlock(metadatas[0])
+	require.NoError(err)
+	_, chunk1, err := index.LookupBlock(metadatas[2])
+	require.NoError(err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	downloader := s3mocks.NewMockDownloader(ctrl)
+	uploader := s3mocks.NewMockUploader(ctrl)
+	client := s3mocks.NewMockClient(ctrl)
+	expectedRanges := map[string]int{
+		"bytes=0-65535":     1,
+		rangeHeader(chunk0): 1,
+		rangeHeader(chunk1): 1,
+	}
+	expectRangeReads(t, client, objectData, expectedRanges)
+
+	var storage internal.BlobStorage
+	app := testapp.New(
+		t,
+		testapp.WithBlockchainNetwork(common.Blockchain_BLOCKCHAIN_SOLANA, common.Network_NETWORK_SOLANA_MAINNET),
+		fx.Provide(New),
+		fx.Provide(func() s3.Downloader { return downloader }),
+		fx.Provide(func() s3.Uploader { return uploader }),
+		fx.Provide(func() s3.Client { return client }),
+		fx.Populate(&storage),
+	)
+	defer app.Close()
+
+	actual, err := storage.DownloadMany(context.Background(), []*api.BlockMetadata{
+		metadatas[2],
+		metadatas[0],
+		metadatas[1],
+	})
+	require.NoError(err)
+	require.Len(actual, 3)
+	require.True(proto.Equal(expectedBlocks[2], actual[0]))
+	require.True(proto.Equal(expectedBlocks[0], actual[1]))
+	require.True(proto.Equal(expectedBlocks[1], actual[2]))
+	assertRangeReadsConsumed(t, expectedRanges)
+}
+
+func TestBlobStorage_DownloadConsolidatedMetadataWithZeroLengthUsesLegacy(t *testing.T) {
+	require := testutil.Require(t)
+
+	metadata := &api.BlockMetadata{
+		Tag:           7,
+		Height:        100,
+		Hash:          "hash-100",
+		ObjectKeyMain: "legacy/object",
+		ObjectFormat:  api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteLength:    0,
+	}
+	expectedBlock := &api.Block{
+		Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+		Network:    common.Network_NETWORK_SOLANA_MAINNET,
+		Metadata:   metadata,
+	}
+	payload, err := proto.Marshal(expectedBlock)
+	require.NoError(err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	downloader := s3mocks.NewMockDownloader(ctrl)
+	downloader.EXPECT().Download(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, writer io.WriterAt, input *awss3.GetObjectInput, opts ...func(*manager.Downloader)) (int64, error) {
+			require.Equal(metadata.ObjectKeyMain, aws.ToString(input.Key))
+			written, err := writer.WriteAt(payload, 0)
+			return int64(written), err
+		})
+	uploader := s3mocks.NewMockUploader(ctrl)
+	client := s3mocks.NewMockClient(ctrl)
+	client.EXPECT().GetObject(gomock.Any(), gomock.Any()).Times(0)
+
+	var storage internal.BlobStorage
+	app := testapp.New(
+		t,
+		testapp.WithBlockchainNetwork(common.Blockchain_BLOCKCHAIN_SOLANA, common.Network_NETWORK_SOLANA_MAINNET),
+		fx.Provide(New),
+		fx.Provide(func() s3.Downloader { return downloader }),
+		fx.Provide(func() s3.Uploader { return uploader }),
+		fx.Provide(func() s3.Client { return client }),
+		fx.Populate(&storage),
+	)
+	defer app.Close()
+
+	actual, err := storage.Download(context.Background(), metadata)
+	require.NoError(err)
+	require.True(proto.Equal(expectedBlock, actual))
+}
+
 func testS3EncodeConfig() cscb.EncodeConfig {
 	return cscb.EncodeConfig{
 		Blockchain:             common.Blockchain_BLOCKCHAIN_SOLANA,
@@ -279,4 +419,117 @@ func testS3Payloads() []internal.ConsolidatedBlockPayload {
 			UncompressedLength: 6,
 		},
 	}
+}
+
+func testS3CSCBProtoObject(t *testing.T) (*cscb.Object, []*api.BlockMetadata, []*api.Block, []byte, *cscb.Index) {
+	t.Helper()
+	require := testutil.Require(t)
+
+	blocks := []*api.Block{
+		{
+			Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+			Network:    common.Network_NETWORK_SOLANA_MAINNET,
+			Metadata: &api.BlockMetadata{
+				Tag:    7,
+				Height: 100,
+				Hash:   "hash-100",
+			},
+		},
+		{
+			Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+			Network:    common.Network_NETWORK_SOLANA_MAINNET,
+			Metadata: &api.BlockMetadata{
+				Tag:    7,
+				Height: 101,
+				Hash:   "hash-101",
+			},
+		},
+		{
+			Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+			Network:    common.Network_NETWORK_SOLANA_MAINNET,
+			Metadata: &api.BlockMetadata{
+				Tag:    7,
+				Height: 102,
+				Hash:   "hash-102",
+			},
+		},
+	}
+	payloads := make([]internal.ConsolidatedBlockPayload, len(blocks))
+	for i, block := range blocks {
+		raw, err := proto.Marshal(block)
+		require.NoError(err)
+		payloads[i] = internal.ConsolidatedBlockPayload{
+			Metadata:           block.Metadata,
+			MetadataID:         int64(1000 + i),
+			RawBlockPayload:    internal.BytesPayloadSource(raw),
+			UncompressedLength: uint64(len(raw)),
+		}
+	}
+
+	cfg := testS3EncodeConfig()
+	cfg.CompressionChunkBlocks = 2
+	object, err := cscb.Encode(context.Background(), cfg, payloads)
+	require.NoError(err)
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := cscb.ParseIndex(data)
+	require.NoError(err)
+
+	metadatas := make([]*api.BlockMetadata, len(blocks))
+	expectedBlocks := make([]*api.Block, len(blocks))
+	for i, placement := range object.Placements {
+		metadata := proto.Clone(blocks[i].Metadata).(*api.BlockMetadata)
+		metadata.ObjectKeyMain = object.Key
+		metadata.ObjectFormat = placement.ObjectFormat
+		metadata.ByteOffset = placement.ByteOffset
+		metadata.ByteLength = placement.ByteLength
+		metadata.UncompressedLength = placement.UncompressedLength
+		metadatas[i] = metadata
+
+		expected := proto.Clone(blocks[i]).(*api.Block)
+		expected.Metadata = metadata
+		expectedBlocks[i] = expected
+	}
+	return object, metadatas, expectedBlocks, data, index
+}
+
+func expectRangeReads(t *testing.T, client *s3mocks.MockClient, objectData []byte, expectedRanges map[string]int) {
+	t.Helper()
+	require := testutil.Require(t)
+
+	totalReads := 0
+	for _, count := range expectedRanges {
+		totalReads += count
+	}
+	client.EXPECT().GetObject(gomock.Any(), gomock.Any()).Times(totalReads).
+		DoAndReturn(func(ctx context.Context, input *awss3.GetObjectInput, opts ...func(*awss3.Options)) (*awss3.GetObjectOutput, error) {
+			rangeValue := aws.ToString(input.Range)
+			require.Positive(expectedRanges[rangeValue], "unexpected range read %s", rangeValue)
+			expectedRanges[rangeValue]--
+
+			var start uint64
+			var end uint64
+			_, err := fmt.Sscanf(rangeValue, "bytes=%d-%d", &start, &end)
+			require.NoError(err)
+			require.Less(start, uint64(len(objectData)))
+			if end >= uint64(len(objectData)) {
+				end = uint64(len(objectData)) - 1
+			}
+			return &awss3.GetObjectOutput{
+				Body: io.NopCloser(bytes.NewReader(objectData[start : end+1])),
+			}, nil
+		})
+}
+
+func assertRangeReadsConsumed(t *testing.T, expectedRanges map[string]int) {
+	t.Helper()
+	require := testutil.Require(t)
+	for rangeValue, count := range expectedRanges {
+		require.Zero(count, "range %s was not read expected number of times", rangeValue)
+	}
+}
+
+func rangeHeader(chunk *cscb.ChunkDescriptor) string {
+	return fmt.Sprintf("bytes=%d-%d", chunk.CompressedPayloadOffset, chunk.CompressedPayloadOffset+chunk.CompressedLength-1)
 }


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-906/cscb-04-implement-server-cscb-range-reader-and-downloadmany-grouping

## Summary
- Add a CSCB header/envelope reader that validates format version, CRCs, block metadata placement, hash, and chunk bounds.
- Extend BlobStorage with DownloadMany and implement S3 CSCB range reads: header/envelope first, then only the target compressed chunk.
- Group server range reads by object/chunk through DownloadMany while preserving legacy single-object download behavior for legacy metadata and CSCB records with byte_length=0.
- Use a CSCB-specific zstd decoder limit that can read every zstd long-distance window allowed by the CSCB encoder.

## Scope boundary
- This PR does not enable primary metadata promotion or change GetBlockFile/GetBlockFilesByRange behavior for old SDK clients.
- SDK/GetBlockFile CSCB batch downloading remains the next client-compatibility step before any chain can expose consolidated rows through primary metadata.

## Validation
- go test ./internal/storage/blobstorage/cscb ./internal/storage/blobstorage/s3 ./internal/server
- go test ./internal/storage/blobstorage/... ./internal/workflow/...
- TEST_TYPE=unit go test ./...
- PATH=\"$(go env GOPATH)/bin:$PATH\" make lint