### PR TITLE
fix(INF-907): avoid postgres hash lookup scan

### DIFF
--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -43,6 +43,14 @@ const (
 		bm.timestamp, bm.skipped, bm.object_format, bm.byte_offset, bm.byte_length, bm.uncompressed_length`
 )
 
+func blockMetadataByHashQuery() string {
+	return fmt.Sprintf(`
+				SELECT %s
+				FROM block_metadata
+				WHERE tag = $1 AND height = $2 AND hash = $3 AND skipped = false
+				LIMIT 1`, blockMetadataColumns)
+}
+
 func newBlockStorage(db *sql.DB, params Params) (internal.BlockStorage, error) {
 	metrics := params.Metrics.SubScope("block_storage").Tagged(map[string]string{
 		"storage_type": "postgres",
@@ -301,12 +309,7 @@ func (b *blockStorageImpl) GetBlockByHash(ctx context.Context, tag uint32, heigh
 			row = b.db.QueryRowContext(ctx, query, tag, height)
 		} else {
 			// Query block_metadata directly for the specific hash
-			query := fmt.Sprintf(`
-				SELECT %s
-				FROM block_metadata
-				WHERE tag = $1 AND height = $2 AND hash = $3
-				LIMIT 1`, blockMetadataColumns)
-			row = b.db.QueryRowContext(ctx, query, tag, height, blockHash)
+			row = b.db.QueryRowContext(ctx, blockMetadataByHashQuery(), tag, height, blockHash)
 		}
 
 		block, err := model.BlockMetadataFromRow(b.db, row)

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -274,6 +275,26 @@ func (s *blockStorageTestSuite) TestGetBlocksByHeightsBlockNotFound() {
 func (s *blockStorageTestSuite) TestGetBlockByHashInvalidHeight() {
 	_, err := s.accessor.GetBlockByHash(context.TODO(), tag, 0, "0x0")
 	assert.True(s.T(), xerrors.Is(err, errors.ErrInvalidHeight))
+}
+
+func (s *blockStorageTestSuite) TestGetBlockByHashQueryUsesPartialIndex() {
+	require := testutil.Require(s.T())
+
+	rows, err := s.db.QueryContext(context.Background(), "EXPLAIN "+blockMetadataByHashQuery(), tag, s.config.Chain.BlockStartHeight, "0x0")
+	require.NoError(err)
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(rows.Err())
+
+	plan := strings.Join(lines, "\n")
+	assert.Contains(s.T(), plan, "unique_tag_hash_regular")
+	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 
 func (s *blockStorageTestSuite) TestGetBlocksByHeightRangeInvalidRange() {


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-907

## Summary
- Adds the missing `skipped = false` predicate to Postgres block hash lookups so the query can use the existing `unique_tag_hash_regular` partial index.
- Extracts the hash lookup SQL into a helper and adds an EXPLAIN regression test that asserts the partial index is used instead of a seq scan.

## Evidence
- Dev Ethereum explicit `GetBlockFile(tag,height,hash)` timed out on `chainstorage:1a82265`.
- Read-only EXPLAIN in dev showed the current predicate planned a Parallel Seq Scan over `block_metadata`; the same query with `skipped = false` planned an index scan using `unique_tag_hash_regular`.

## Tests
- `go test ./internal/storage/metastorage/postgres`
- `go test ./internal/server ./internal/storage/metastorage/postgres`