### PR TITLE
feat(INF-908): add server read shadow first flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -751,7 +751,7 @@ func (c *Config) validateConsolidationConfig() error {
 		return xerrors.Errorf("invalid consolidation codec %v", consolidation.Codec)
 	}
 
-	if !consolidation.Enabled {
+	if !consolidation.Enabled && !consolidation.ReadShadowFirst {
 		return nil
 	}
 
@@ -762,6 +762,10 @@ func (c *Config) validateConsolidationConfig() error {
 	}
 	if c.StorageType.MetaStorageType != MetaStorageType_POSTGRES {
 		return xerrors.Errorf("consolidation requires Postgres meta storage until DynamoDB shadow placement and guarded promotion are implemented, got %v", c.StorageType.MetaStorageType)
+	}
+
+	if !consolidation.Enabled {
+		return nil
 	}
 
 	if consolidation.CodecLevel <= 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -863,6 +863,17 @@ func TestConsolidationEnabledRejectsDynamoDB(t *testing.T) {
 	require.Contains(err.Error(), "requires Postgres meta storage")
 }
 
+func TestConsolidationReadShadowFirstRejectsDynamoDB(t *testing.T) {
+	require := testutil.Require(t)
+
+	require.NoError(os.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_READ_SHADOW_FIRST", "true"))
+	defer os.Unsetenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_READ_SHADOW_FIRST")
+
+	_, err := config.New()
+	require.Error(err)
+	require.Contains(err.Error(), "requires Postgres meta storage")
+}
+
 func TestParseConfigName(t *testing.T) {
 	tests := []struct {
 		configName string

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
@@ -168,6 +169,20 @@ const (
 	transactionsServedCounter = "transactions_served"
 
 	accountStateServedCounter = "account_state_served"
+
+	shadowReadCounter            = "shadow_read"
+	shadowReadBytesCounter       = "shadow_read_bytes"
+	shadowReadLatencyTimer       = "shadow_read_latency"
+	shadowPathTag                = "path"
+	shadowOutcomeTag             = "outcome"
+	shadowPathConsolidated       = "consolidated"
+	shadowPathLegacy             = "legacy"
+	shadowOutcomeMiss            = "miss"
+	shadowOutcomeError           = "error"
+	shadowOutcomeValidation      = "validation_mismatch"
+	shadowOutcomeSuccess         = "success"
+	shadowOutcomeFallbackSuccess = "fallback_success"
+	shadowOutcomeFallbackFailure = "fallback_failure"
 
 	errorCounter = "error"
 	serviceTag   = "service"
@@ -356,6 +371,24 @@ func (s *Server) emitTransactionsMetric(format string, clientID string, count in
 
 func (s *Server) emitAccountStateMetric(clientID string, count int64) {
 	s.metrics.scope.Tagged(map[string]string{clientIDTag: clientID}).Counter(accountStateServedCounter).Inc(count)
+}
+
+func (s *Server) emitShadowReadMetric(outcome string, count int64) {
+	if count <= 0 {
+		return
+	}
+	s.metrics.scope.Tagged(map[string]string{shadowOutcomeTag: outcome}).Counter(shadowReadCounter).Inc(count)
+}
+
+func (s *Server) emitShadowReadBytes(path string, count int64) {
+	if count <= 0 {
+		return
+	}
+	s.metrics.scope.Tagged(map[string]string{shadowPathTag: path}).Counter(shadowReadBytesCounter).Inc(count)
+}
+
+func (s *Server) emitShadowReadLatency(path string, duration time.Duration) {
+	s.metrics.scope.Tagged(map[string]string{shadowPathTag: path}).Timer(shadowReadLatencyTimer).Record(duration)
 }
 
 func (s *Server) GetLatestBlock(ctx context.Context, req *api.GetLatestBlockRequest) (*api.GetLatestBlockResponse, error) {
@@ -855,20 +888,211 @@ func (s *Server) getBlocksFromMetaStorage(ctx context.Context, req requestByRang
 }
 
 func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMetadata) (*api.Block, error) {
-	output, err := s.blobStorage.Download(ctx, block)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to download from blob storage (input={%+v}): %w", block, err)
+	if !s.config.AWS.Storage.Consolidation.ReadShadowFirst {
+		output, err := s.blobStorage.Download(ctx, block)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to download from blob storage (input={%+v}): %w", block, err)
+		}
+		return output, nil
 	}
 
-	return output, nil
+	shadow, ok := s.getShadowBlockMetadata(ctx, block)
+	if !ok {
+		output, err := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
+		if err != nil {
+			s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
+			return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", block, err)
+		}
+		s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
+		return output, nil
+	}
+
+	output, err := s.downloadBlockWithShadowMetrics(ctx, shadow, shadowPathConsolidated)
+	if err == nil {
+		s.emitShadowReadMetric(shadowOutcomeSuccess, 1)
+		return output, nil
+	}
+
+	s.emitShadowReadMetric(shadowReadErrorOutcome(err), 1)
+	s.logger.Warn(
+		"shadow consolidated block read failed; falling back to legacy",
+		zap.Uint32("tag", block.GetTag()),
+		zap.Uint64("height", block.GetHeight()),
+		zap.String("hash", block.GetHash()),
+		zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+		zap.Error(err),
+	)
+	fallback, fallbackErr := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
+	if fallbackErr != nil {
+		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
+		return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", block, fallbackErr)
+	}
+	s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
+	return fallback, nil
 }
 
 func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.Block, error) {
+	if !s.config.AWS.Storage.Consolidation.ReadShadowFirst {
+		output, err := s.blobStorage.DownloadMany(ctx, blocks)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
+		}
+		return output, nil
+	}
+
+	selectedBlocks, shadowCount, fallbackCount := s.selectShadowBlockMetadata(ctx, blocks)
+	output, err := s.downloadBlocksWithShadowMetrics(ctx, selectedBlocks)
+	if err == nil {
+		s.emitShadowReadMetric(shadowOutcomeSuccess, int64(shadowCount))
+		s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, int64(fallbackCount))
+		return output, nil
+	}
+
+	if shadowCount == 0 {
+		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
+	}
+
+	s.emitShadowReadMetric(shadowReadErrorOutcome(err), int64(shadowCount))
+	s.logger.Warn(
+		"shadow consolidated range read failed; falling back to legacy",
+		zap.Int("num_blocks", len(blocks)),
+		zap.Int("shadow_blocks", shadowCount),
+		zap.Error(err),
+	)
+	fallback, fallbackErr := s.downloadBlocksWithShadowMetrics(ctx, blocks)
+	if fallbackErr != nil {
+		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(len(blocks)))
+		return nil, xerrors.Errorf("failed to download fallback legacy blocks from blob storage: %w", fallbackErr)
+	}
+	s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, int64(len(blocks)))
+	return fallback, nil
+}
+
+func (s *Server) getShadowBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
+	if block.GetSkipped() {
+		s.emitShadowReadMetric(shadowOutcomeMiss, 1)
+		return nil, false
+	}
+
+	shadow, err := s.metaStorage.GetBlockConsolidationShadow(ctx, block)
+	if err != nil {
+		if xerrors.Is(err, storage.ErrItemNotFound) {
+			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
+			return nil, false
+		}
+		s.emitShadowReadMetric(shadowOutcomeError, 1)
+		s.logger.Warn(
+			"shadow consolidated metadata lookup failed; falling back to legacy",
+			zap.Uint32("tag", block.GetTag()),
+			zap.Uint64("height", block.GetHeight()),
+			zap.String("hash", block.GetHash()),
+			zap.Error(err),
+		)
+		return nil, false
+	}
+	if shadow.GetObjectFormat() != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH || shadow.GetByteLength() == 0 {
+		s.emitShadowReadMetric(shadowOutcomeValidation, 1)
+		s.logger.Warn(
+			"shadow consolidated metadata is invalid; falling back to legacy",
+			zap.Uint32("tag", block.GetTag()),
+			zap.Uint64("height", block.GetHeight()),
+			zap.String("hash", block.GetHash()),
+			zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+			zap.Int32("object_format", int32(shadow.GetObjectFormat())),
+			zap.Uint64("byte_length", shadow.GetByteLength()),
+		)
+		return nil, false
+	}
+	return shadow, true
+}
+
+func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, int, int) {
+	selected := make([]*api.BlockMetadata, len(blocks))
+	var shadowCount int
+	var fallbackCount int
+	for i, block := range blocks {
+		shadow, ok := s.getShadowBlockMetadata(ctx, block)
+		if ok {
+			selected[i] = shadow
+			shadowCount++
+			continue
+		}
+		selected[i] = block
+		fallbackCount++
+	}
+	return selected, shadowCount, fallbackCount
+}
+
+func (s *Server) downloadBlockWithShadowMetrics(ctx context.Context, block *api.BlockMetadata, path string) (*api.Block, error) {
+	start := time.Now()
+	output, err := s.blobStorage.Download(ctx, block)
+	s.emitShadowReadLatency(path, time.Since(start))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to download from blob storage (input={%+v}): %w", block, err)
+	}
+	s.emitShadowReadBytes(path, blockReadBytes(block, output))
+	return output, nil
+}
+
+func (s *Server) downloadBlocksWithShadowMetrics(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.Block, error) {
+	start := time.Now()
 	output, err := s.blobStorage.DownloadMany(ctx, blocks)
+	for _, block := range blocks {
+		path := shadowPathLegacy
+		if isConsolidatedBlockMetadata(block) {
+			path = shadowPathConsolidated
+		}
+		s.emitShadowReadLatency(path, time.Since(start))
+	}
 	if err != nil {
 		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
 	}
+	for i, block := range blocks {
+		path := shadowPathLegacy
+		if isConsolidatedBlockMetadata(block) {
+			path = shadowPathConsolidated
+		}
+		var downloaded *api.Block
+		if i < len(output) {
+			downloaded = output[i]
+		}
+		s.emitShadowReadBytes(path, blockReadBytes(block, downloaded))
+	}
 	return output, nil
+}
+
+func blockReadBytes(metadata *api.BlockMetadata, block *api.Block) int64 {
+	if isConsolidatedBlockMetadata(metadata) {
+		return int64(metadata.GetByteLength())
+	}
+	if block != nil {
+		return int64(proto.Size(block))
+	}
+	return 0
+}
+
+func isConsolidatedBlockMetadata(metadata *api.BlockMetadata) bool {
+	return metadata.GetObjectFormat() == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH && metadata.GetByteLength() > 0
+}
+
+func shadowReadErrorOutcome(err error) string {
+	if isShadowValidationError(err) {
+		return shadowOutcomeValidation
+	}
+	return shadowOutcomeError
+}
+
+func isShadowValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error()
+	return strings.Contains(errText, "CSCB block hash mismatch") ||
+		strings.Contains(errText, "CSCB block CRC mismatch") ||
+		strings.Contains(errText, "CSCB chunk CRC mismatch") ||
+		strings.Contains(errText, "CSCB envelope CRC mismatch") ||
+		strings.Contains(errText, "CSCB compressed chunk length mismatch") ||
+		strings.Contains(errText, "CSCB block payload length mismatch")
 }
 
 func (s *Server) newAuthContext(ctx context.Context) context.Context {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -914,7 +914,7 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		return blockWithPrimaryMetadata(output, block), nil
 	}
 
-	s.emitShadowReadMetric(shadowReadErrorOutcome(errors.Unwrap(err)), 1)
+	s.emitShadowReadMetric(shadowReadErrorOutcome(err), 1)
 	s.logger.Warn(
 		"shadow consolidated block read failed; falling back to legacy",
 		zap.Uint32("tag", block.GetTag()),
@@ -954,7 +954,7 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
 	}
 
-	s.emitShadowReadMetric(shadowReadErrorOutcome(errors.Unwrap(err)), int64(shadowCount))
+	s.emitShadowReadMetric(shadowReadErrorOutcome(err), int64(shadowCount))
 	s.logger.Warn(
 		"shadow consolidated range read failed; falling back to legacy",
 		zap.Int("num_blocks", len(blocks)),
@@ -1143,7 +1143,25 @@ func isShadowValidationError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "CSCB")
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if isCSCBValidationMessage(current.Error()) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCSCBValidationMessage(errText string) bool {
+	return strings.Contains(errText, "invalid CSCB") ||
+		strings.Contains(errText, "unsupported CSCB") ||
+		strings.Contains(errText, "unexpected CSCB") ||
+		strings.Contains(errText, "duplicate CSCB") ||
+		strings.Contains(errText, "failed to decompress CSCB chunk") ||
+		strings.Contains(errText, "CSCB header") ||
+		strings.Contains(errText, "CSCB index") ||
+		strings.Contains(errText, "CSCB envelope") ||
+		strings.Contains(errText, "CSCB block") ||
+		strings.Contains(errText, "CSCB chunk")
 }
 
 func (s *Server) newAuthContext(ctx context.Context) context.Context {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -1142,29 +1142,7 @@ func isShadowValidationError(err error) bool {
 	if err == nil {
 		return false
 	}
-	errText := err.Error()
-	return strings.Contains(errText, "invalid CSCB magic") ||
-		strings.Contains(errText, "invalid CSCB envelope magic") ||
-		strings.Contains(errText, "unsupported CSCB format version") ||
-		strings.Contains(errText, "unsupported CSCB compression scope") ||
-		strings.Contains(errText, "unexpected CSCB") ||
-		strings.Contains(errText, "CSCB block offset mismatch") ||
-		strings.Contains(errText, "CSCB block length mismatch") ||
-		strings.Contains(errText, "CSCB block uncompressed length mismatch") ||
-		strings.Contains(errText, "CSCB block hash mismatch") ||
-		strings.Contains(errText, "CSCB block CRC mismatch") ||
-		strings.Contains(errText, "CSCB block count mismatch") ||
-		strings.Contains(errText, "CSCB block height") ||
-		strings.Contains(errText, "CSCB chunk count mismatch") ||
-		strings.Contains(errText, "CSCB chunk index") ||
-		strings.Contains(errText, "CSCB chunk length mismatch") ||
-		strings.Contains(errText, "CSCB chunk CRC mismatch") ||
-		strings.Contains(errText, "CSCB envelope CRC mismatch") ||
-		strings.Contains(errText, "CSCB compressed chunk length mismatch") ||
-		strings.Contains(errText, "CSCB block payload length mismatch") ||
-		strings.Contains(errText, "CSCB block payload exceeds chunk bounds") ||
-		strings.Contains(errText, "unsupported CSCB codec") ||
-		strings.Contains(errText, "failed to decompress CSCB chunk")
+	return strings.Contains(err.Error(), "CSCB")
 }
 
 func (s *Server) newAuthContext(ctx context.Context) context.Context {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -913,7 +914,7 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		return blockWithPrimaryMetadata(output, block), nil
 	}
 
-	s.emitShadowReadMetric(shadowReadErrorOutcome(err), 1)
+	s.emitShadowReadMetric(shadowReadErrorOutcome(errors.Unwrap(err)), 1)
 	s.logger.Warn(
 		"shadow consolidated block read failed; falling back to legacy",
 		zap.Uint32("tag", block.GetTag()),
@@ -953,7 +954,7 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
 	}
 
-	s.emitShadowReadMetric(shadowReadErrorOutcome(err), int64(shadowCount))
+	s.emitShadowReadMetric(shadowReadErrorOutcome(errors.Unwrap(err)), int64(shadowCount))
 	s.logger.Warn(
 		"shadow consolidated range read failed; falling back to legacy",
 		zap.Int("num_blocks", len(blocks)),

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -910,7 +910,7 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 	output, err := s.downloadBlockWithShadowMetrics(ctx, shadow, shadowPathConsolidated)
 	if err == nil {
 		s.emitShadowReadMetric(shadowOutcomeSuccess, 1)
-		return output, nil
+		return blockWithPrimaryMetadata(output, block), nil
 	}
 
 	s.emitShadowReadMetric(shadowReadErrorOutcome(err), 1)
@@ -945,10 +945,11 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 	if err == nil {
 		s.emitShadowReadMetric(shadowOutcomeSuccess, int64(shadowCount))
 		s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, int64(fallbackCount))
-		return output, nil
+		return blocksWithPrimaryMetadata(output, blocks), nil
 	}
 
 	if shadowCount == 0 {
+		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(fallbackCount))
 		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
 	}
 
@@ -965,7 +966,7 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 		return nil, xerrors.Errorf("failed to download fallback legacy blocks from blob storage: %w", fallbackErr)
 	}
 	s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, int64(len(blocks)))
-	return fallback, nil
+	return blocksWithPrimaryMetadata(fallback, blocks), nil
 }
 
 func (s *Server) getShadowBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
@@ -1109,6 +1110,23 @@ func blockReadLogicalBytes(metadata *api.BlockMetadata, block *api.Block) int64 
 	return 0
 }
 
+func blockWithPrimaryMetadata(block *api.Block, metadata *api.BlockMetadata) *api.Block {
+	if block != nil {
+		block.Metadata = metadata
+	}
+	return block
+}
+
+func blocksWithPrimaryMetadata(blocks []*api.Block, metadatas []*api.BlockMetadata) []*api.Block {
+	for i, block := range blocks {
+		if i >= len(metadatas) {
+			break
+		}
+		blockWithPrimaryMetadata(block, metadatas[i])
+	}
+	return blocks
+}
+
 func isConsolidatedBlockMetadata(metadata *api.BlockMetadata) bool {
 	return metadata.GetObjectFormat() == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH && metadata.GetByteLength() > 0
 }
@@ -1139,10 +1157,14 @@ func isShadowValidationError(err error) bool {
 		strings.Contains(errText, "CSCB block height") ||
 		strings.Contains(errText, "CSCB chunk count mismatch") ||
 		strings.Contains(errText, "CSCB chunk index") ||
+		strings.Contains(errText, "CSCB chunk length mismatch") ||
 		strings.Contains(errText, "CSCB chunk CRC mismatch") ||
 		strings.Contains(errText, "CSCB envelope CRC mismatch") ||
 		strings.Contains(errText, "CSCB compressed chunk length mismatch") ||
-		strings.Contains(errText, "CSCB block payload length mismatch")
+		strings.Contains(errText, "CSCB block payload length mismatch") ||
+		strings.Contains(errText, "CSCB block payload exceeds chunk bounds") ||
+		strings.Contains(errText, "unsupported CSCB codec") ||
+		strings.Contains(errText, "failed to decompress CSCB chunk")
 }
 
 func (s *Server) newAuthContext(ctx context.Context) context.Context {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -170,19 +170,19 @@ const (
 
 	accountStateServedCounter = "account_state_served"
 
-	shadowReadCounter            = "shadow_read"
-	shadowReadBytesCounter       = "shadow_read_bytes"
-	shadowReadLatencyTimer       = "shadow_read_latency"
-	shadowPathTag                = "path"
-	shadowOutcomeTag             = "outcome"
-	shadowPathConsolidated       = "consolidated"
-	shadowPathLegacy             = "legacy"
-	shadowOutcomeMiss            = "miss"
-	shadowOutcomeError           = "error"
-	shadowOutcomeValidation      = "validation_mismatch"
-	shadowOutcomeSuccess         = "success"
-	shadowOutcomeFallbackSuccess = "fallback_success"
-	shadowOutcomeFallbackFailure = "fallback_failure"
+	shadowReadCounter             = "shadow_read"
+	shadowReadLogicalBytesCounter = "shadow_read_logical_bytes"
+	shadowReadLatencyTimer        = "shadow_read_latency"
+	shadowPathTag                 = "path"
+	shadowOutcomeTag              = "outcome"
+	shadowPathConsolidated        = "consolidated"
+	shadowPathLegacy              = "legacy"
+	shadowOutcomeMiss             = "miss"
+	shadowOutcomeError            = "error"
+	shadowOutcomeValidation       = "validation_mismatch"
+	shadowOutcomeSuccess          = "success"
+	shadowOutcomeFallbackSuccess  = "fallback_success"
+	shadowOutcomeFallbackFailure  = "fallback_failure"
 
 	errorCounter = "error"
 	serviceTag   = "service"
@@ -380,11 +380,11 @@ func (s *Server) emitShadowReadMetric(outcome string, count int64) {
 	s.metrics.scope.Tagged(map[string]string{shadowOutcomeTag: outcome}).Counter(shadowReadCounter).Inc(count)
 }
 
-func (s *Server) emitShadowReadBytes(path string, count int64) {
+func (s *Server) emitShadowReadLogicalBytes(path string, count int64) {
 	if count <= 0 {
 		return
 	}
-	s.metrics.scope.Tagged(map[string]string{shadowPathTag: path}).Counter(shadowReadBytesCounter).Inc(count)
+	s.metrics.scope.Tagged(map[string]string{shadowPathTag: path}).Counter(shadowReadLogicalBytesCounter).Inc(count)
 }
 
 func (s *Server) emitShadowReadLatency(path string, duration time.Duration) {
@@ -990,7 +990,7 @@ func (s *Server) getShadowBlockMetadata(ctx context.Context, block *api.BlockMet
 		)
 		return nil, false
 	}
-	if shadow.GetObjectFormat() != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH || shadow.GetByteLength() == 0 {
+	if !isConsolidatedBlockMetadata(shadow) {
 		s.emitShadowReadMetric(shadowOutcomeValidation, 1)
 		s.logger.Warn(
 			"shadow consolidated metadata is invalid; falling back to legacy",
@@ -1010,13 +1010,51 @@ func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.Bl
 	selected := make([]*api.BlockMetadata, len(blocks))
 	var shadowCount int
 	var fallbackCount int
+	shadows, err := s.metaStorage.GetBlocksConsolidationShadow(ctx, blocks)
+	if err != nil {
+		s.emitShadowReadMetric(shadowOutcomeError, int64(len(blocks)))
+		s.logger.Warn(
+			"shadow consolidated metadata batch lookup failed; falling back to legacy",
+			zap.Int("num_blocks", len(blocks)),
+			zap.Error(err),
+		)
+		copy(selected, blocks)
+		return selected, 0, len(blocks)
+	}
+	if len(shadows) != len(blocks) {
+		s.emitShadowReadMetric(shadowOutcomeError, int64(len(blocks)))
+		s.logger.Warn(
+			"shadow consolidated metadata batch lookup returned invalid result count; falling back to legacy",
+			zap.Int("num_blocks", len(blocks)),
+			zap.Int("num_shadows", len(shadows)),
+		)
+		copy(selected, blocks)
+		return selected, 0, len(blocks)
+	}
+
 	for i, block := range blocks {
-		shadow, ok := s.getShadowBlockMetadata(ctx, block)
-		if ok {
+		shadow := shadows[i]
+		if shadow == nil {
+			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
+			selected[i] = block
+			fallbackCount++
+			continue
+		}
+		if isConsolidatedBlockMetadata(shadow) {
 			selected[i] = shadow
 			shadowCount++
 			continue
 		}
+		s.emitShadowReadMetric(shadowOutcomeValidation, 1)
+		s.logger.Warn(
+			"shadow consolidated metadata is invalid; falling back to legacy",
+			zap.Uint32("tag", block.GetTag()),
+			zap.Uint64("height", block.GetHeight()),
+			zap.String("hash", block.GetHash()),
+			zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+			zap.Int32("object_format", int32(shadow.GetObjectFormat())),
+			zap.Uint64("byte_length", shadow.GetByteLength()),
+		)
 		selected[i] = block
 		fallbackCount++
 	}
@@ -1030,7 +1068,7 @@ func (s *Server) downloadBlockWithShadowMetrics(ctx context.Context, block *api.
 	if err != nil {
 		return nil, xerrors.Errorf("failed to download from blob storage (input={%+v}): %w", block, err)
 	}
-	s.emitShadowReadBytes(path, blockReadBytes(block, output))
+	s.emitShadowReadLogicalBytes(path, blockReadLogicalBytes(block, output))
 	return output, nil
 }
 
@@ -1056,12 +1094,12 @@ func (s *Server) downloadBlocksWithShadowMetrics(ctx context.Context, blocks []*
 		if i < len(output) {
 			downloaded = output[i]
 		}
-		s.emitShadowReadBytes(path, blockReadBytes(block, downloaded))
+		s.emitShadowReadLogicalBytes(path, blockReadLogicalBytes(block, downloaded))
 	}
 	return output, nil
 }
 
-func blockReadBytes(metadata *api.BlockMetadata, block *api.Block) int64 {
+func blockReadLogicalBytes(metadata *api.BlockMetadata, block *api.Block) int64 {
 	if isConsolidatedBlockMetadata(metadata) {
 		return int64(metadata.GetByteLength())
 	}
@@ -1087,8 +1125,20 @@ func isShadowValidationError(err error) bool {
 		return false
 	}
 	errText := err.Error()
-	return strings.Contains(errText, "CSCB block hash mismatch") ||
+	return strings.Contains(errText, "invalid CSCB magic") ||
+		strings.Contains(errText, "invalid CSCB envelope magic") ||
+		strings.Contains(errText, "unsupported CSCB format version") ||
+		strings.Contains(errText, "unsupported CSCB compression scope") ||
+		strings.Contains(errText, "unexpected CSCB") ||
+		strings.Contains(errText, "CSCB block offset mismatch") ||
+		strings.Contains(errText, "CSCB block length mismatch") ||
+		strings.Contains(errText, "CSCB block uncompressed length mismatch") ||
+		strings.Contains(errText, "CSCB block hash mismatch") ||
 		strings.Contains(errText, "CSCB block CRC mismatch") ||
+		strings.Contains(errText, "CSCB block count mismatch") ||
+		strings.Contains(errText, "CSCB block height") ||
+		strings.Contains(errText, "CSCB chunk count mismatch") ||
+		strings.Contains(errText, "CSCB chunk index") ||
 		strings.Contains(errText, "CSCB chunk CRC mismatch") ||
 		strings.Contains(errText, "CSCB envelope CRC mismatch") ||
 		strings.Contains(errText, "CSCB compressed chunk length mismatch") ||

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -153,6 +153,16 @@ func TestIsShadowValidationError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "chunk length mismatch",
+			err:  xerrors.New("CSCB chunk length mismatch: got 1 want 2"),
+			want: true,
+		},
+		{
+			name: "block payload bounds",
+			err:  xerrors.New("CSCB block payload exceeds chunk bounds: end=10 chunk_length=5"),
+			want: true,
+		},
+		{
 			name: "hash mismatch",
 			err:  xerrors.New("CSCB block hash mismatch at height 100"),
 			want: true,
@@ -798,7 +808,7 @@ func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstUsesShadow() {
 	})
 	require.NoError(err)
 	require.NotNil(resp)
-	require.Equal(shadowBlock, resp.Block)
+	require.Equal(blockMetadata, resp.Block.GetMetadata())
 
 	snapshot := scope.Snapshot()
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=success"].Value())
@@ -1146,12 +1156,15 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstUsesBatchLooku
 	shadowMetadatas[2] = makeShadowBlockMetadata(blockMetadatas[2])
 	selectedMetadatas := []*api.BlockMetadata{shadowMetadatas[0], blockMetadatas[1], shadowMetadatas[2]}
 	blocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+	downloadedBlocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+	downloadedBlocks[0].Metadata = shadowMetadatas[0]
+	downloadedBlocks[2].Metadata = shadowMetadatas[2]
 
 	gomock.InOrder(
 		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
 		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
 		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), blockMetadatas).Times(1).Return(shadowMetadatas, nil),
-		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), selectedMetadatas).Times(1).Return(blocks, nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), selectedMetadatas).Times(1).Return(downloadedBlocks, nil),
 	)
 
 	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
@@ -1167,6 +1180,42 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstUsesBatchLooku
 	require.Equal(int64(2), snapshot.Counters()["server.shadow_read+outcome=success"].Value())
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=miss"].Value())
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
+func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstAllMissFallbackFailure() {
+	const (
+		startHeight uint64 = 9000
+		endHeight   uint64 = 9003
+		numBlocks          = int(endHeight - startHeight)
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().GetLatestBlockTag()
+	blockMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, numBlocks, tag)
+	shadowMetadatas := make([]*api.BlockMetadata, len(blockMetadatas))
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
+		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
+		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), blockMetadatas).Times(1).Return(shadowMetadatas, nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), blockMetadatas).Times(1).Return(nil, xerrors.New("mock legacy download error")),
+	)
+
+	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	})
+	require.Error(err)
+	require.Nil(resp)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=miss"].Value())
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=fallback_failure"].Value())
 }
 
 func (s *handlerTestSuite) TestGetRawBlocksByRange_MaxRangeExceeded() {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -136,6 +136,41 @@ func makeShadowBlockMetadata(block *api.BlockMetadata) *api.BlockMetadata {
 	return shadow
 }
 
+func TestIsShadowValidationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "block offset mismatch",
+			err:  xerrors.New("CSCB block offset mismatch at height 100: index=1 metadata=2"),
+			want: true,
+		},
+		{
+			name: "unsupported header",
+			err:  xerrors.New("unsupported CSCB format version: 99"),
+			want: true,
+		},
+		{
+			name: "hash mismatch",
+			err:  xerrors.New("CSCB block hash mismatch at height 100"),
+			want: true,
+		},
+		{
+			name: "generic storage error",
+			err:  xerrors.New("s3 timeout"),
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := testutil.Require(t)
+			require.Equal(test.want, isShadowValidationError(test.err))
+		})
+	}
+}
+
 func (s *handlerTestSuite) TearDownTest() {
 	s.app.Close()
 	s.ctrl.Finish()
@@ -767,7 +802,7 @@ func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstUsesShadow() {
 
 	snapshot := scope.Snapshot()
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=success"].Value())
-	require.Equal(int64(shadowMetadata.ByteLength), snapshot.Counters()["server.shadow_read_bytes+path=consolidated"].Value())
+	require.Equal(int64(shadowMetadata.ByteLength), snapshot.Counters()["server.shadow_read_logical_bytes+path=consolidated"].Value())
 }
 
 func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstFallsBackOnMiss() {
@@ -1073,9 +1108,7 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstFallsBackOnSha
 	gomock.InOrder(
 		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
 		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
-		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadatas[0]).Times(1).Return(shadowMetadatas[0], nil),
-		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadatas[1]).Times(1).Return(shadowMetadatas[1], nil),
-		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadatas[2]).Times(1).Return(shadowMetadatas[2], nil),
+		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), blockMetadatas).Times(1).Return(shadowMetadatas, nil),
 		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), shadowMetadatas).Times(1).Return(nil, xerrors.New("mock consolidated download error")),
 		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), blockMetadatas).Times(1).Return(blocks, nil),
 	)
@@ -1092,6 +1125,48 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstFallsBackOnSha
 	snapshot := scope.Snapshot()
 	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
 	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
+func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstUsesBatchLookupWithMiss() {
+	const (
+		startHeight uint64 = 9000
+		endHeight   uint64 = 9003
+		numBlocks          = int(endHeight - startHeight)
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().GetLatestBlockTag()
+	blockMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, numBlocks, tag)
+	shadowMetadatas := make([]*api.BlockMetadata, len(blockMetadatas))
+	shadowMetadatas[0] = makeShadowBlockMetadata(blockMetadatas[0])
+	shadowMetadatas[2] = makeShadowBlockMetadata(blockMetadatas[2])
+	selectedMetadatas := []*api.BlockMetadata{shadowMetadatas[0], blockMetadatas[1], shadowMetadatas[2]}
+	blocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
+		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
+		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), blockMetadatas).Times(1).Return(shadowMetadatas, nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), selectedMetadatas).Times(1).Return(blocks, nil),
+	)
+
+	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(blocks, resp.Blocks)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(2), snapshot.Counters()["server.shadow_read+outcome=success"].Value())
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=miss"].Value())
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
 }
 
 func (s *handlerTestSuite) TestGetRawBlocksByRange_MaxRangeExceeded() {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -888,6 +888,41 @@ func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstFallsBackOnValidationE
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
 }
 
+func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstFallsBackOnDownloadError() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().Chain.BlockTag.Stable
+	blockMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	shadowMetadata := makeShadowBlockMetadata(blockMetadata)
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(blockMetadata, nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(shadowMetadata, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), shadowMetadata).Times(1).Return(nil, xerrors.New("s3 timeout")),
+		s.blobStorage.EXPECT().Download(gomock.Any(), blockMetadata).Times(1).Return(block, nil),
+	)
+
+	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
+		Height: blockMetadata.Height,
+		Hash:   blockMetadata.Hash,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(block, resp.Block)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
 func (s *handlerTestSuite) TestGetRawBlocksByRange_StableTag() {
 	const (
 		startHeight uint64 = 9000

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -163,6 +163,11 @@ func TestIsShadowValidationError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "block index envelope bounds",
+			err:  xerrors.New("CSCB block index record 3 exceeds envelope length"),
+			want: true,
+		},
+		{
 			name: "hash mismatch",
 			err:  xerrors.New("CSCB block hash mismatch at height 100"),
 			want: true,

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
@@ -126,13 +127,13 @@ func (s *handlerTestSuite) SetupTest() {
 }
 
 func makeShadowBlockMetadata(block *api.BlockMetadata) *api.BlockMetadata {
-	shadow := *block
+	shadow := proto.Clone(block).(*api.BlockMetadata)
 	shadow.ObjectKeyMain = fmt.Sprintf("consolidated/v=1/shard=000000000000-000000010000/%012d-%012d-deadbeef.cscb.zstd", block.Height, block.Height)
 	shadow.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH
 	shadow.ByteOffset = 4096
 	shadow.ByteLength = 8192
 	shadow.UncompressedLength = 16384
-	return &shadow
+	return shadow
 }
 
 func (s *handlerTestSuite) TearDownTest() {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -168,6 +168,16 @@ func TestIsShadowValidationError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "wrapped cscb object timeout",
+			err:  xerrors.Errorf("failed to download CSCB object (key=consolidated): %w", xerrors.New("s3 timeout")),
+			want: false,
+		},
+		{
+			name: "wrapped metadata context timeout",
+			err:  xerrors.Errorf("failed to download from blob storage (input={ObjectFormat:BLOCK_OBJECT_FORMAT_CSCB_BATCH}): %w", xerrors.New("s3 timeout")),
+			want: false,
+		},
+		{
 			name: "hash mismatch",
 			err:  xerrors.New("CSCB block hash mismatch at height 100"),
 			want: true,
@@ -1159,7 +1169,7 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstFallsBackOnSha
 		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
 		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
 		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), blockMetadatas).Times(1).Return(shadowMetadatas, nil),
-		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), shadowMetadatas).Times(1).Return(nil, xerrors.New("mock consolidated download error")),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), shadowMetadatas).Times(1).Return(nil, xerrors.Errorf("failed to download CSCB object (key=consolidated): %w", xerrors.New("s3 timeout"))),
 		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), blockMetadatas).Times(1).Return(blocks, nil),
 	)
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -13,6 +13,7 @@ import (
 	geth "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally/v4"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
@@ -122,6 +123,16 @@ func (s *handlerTestSuite) SetupTest() {
 	s.eventTagForTestEvents = s.config.Chain.EventTag.Stable
 	s.config.Chain.Feature.TransactionIndexing = true
 	s.config.Chain.Feature.VerifiedAccountStateEnabled = true
+}
+
+func makeShadowBlockMetadata(block *api.BlockMetadata) *api.BlockMetadata {
+	shadow := *block
+	shadow.ObjectKeyMain = fmt.Sprintf("consolidated/v=1/shard=000000000000-000000010000/%012d-%012d-deadbeef.cscb.zstd", block.Height, block.Height)
+	shadow.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH
+	shadow.ByteOffset = 4096
+	shadow.ByteLength = 8192
+	shadow.UncompressedLength = 16384
+	return &shadow
 }
 
 func (s *handlerTestSuite) TearDownTest() {
@@ -247,6 +258,45 @@ func (s *handlerTestSuite) TestGetBlockFile() {
 				return "http://endpoint/foo/bar", nil
 			},
 		),
+	)
+
+	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
+		Height: height,
+		Hash:   hash,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(expected, resp.File)
+}
+
+func (s *handlerTestSuite) TestGetBlockFile_ReadShadowFirstStillUsesPrimaryMetadata() {
+	const (
+		height        uint64 = 13193825
+		hash                 = "0xda5a0439434adf072394e0b94f78e56032c5409a2c58668995f306b171ff4ace"
+		parentHash           = "0xba6a6c85739b50384625e10718524fb2c1fcf88858eabf6db9bd851902b53546"
+		objectKeyMain        = "foo/bar"
+	)
+
+	require := testutil.Require(s.T())
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+	tag := s.app.Config().Chain.BlockTag.Stable
+	expected := &api.BlockFile{
+		Tag:        tag,
+		Hash:       hash,
+		ParentHash: parentHash,
+		Height:     height,
+		FileUrl:    "http://endpoint/foo/bar",
+	}
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, height, hash).Times(1).Return(&api.BlockMetadata{
+			Tag:           tag,
+			Hash:          hash,
+			ParentHash:    parentHash,
+			Height:        height,
+			ObjectKeyMain: objectKeyMain,
+		}, nil),
+		s.blobStorage.EXPECT().PreSign(gomock.Any(), objectKeyMain).Times(1).Return("http://endpoint/foo/bar", nil),
 	)
 
 	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
@@ -677,6 +727,116 @@ func (s *handlerTestSuite) TestGetRawBlock_Gzip() {
 	require.Equal(block, resp.Block)
 }
 
+func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstUsesShadow() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().Chain.BlockTag.Stable
+	blockMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	shadowMetadata := makeShadowBlockMetadata(blockMetadata)
+	shadowBlock := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+	shadowBlock.Metadata = shadowMetadata
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, tag uint32, height uint64, hash string) (*api.BlockMetadata, error) {
+				require.Equal(blockMetadata.Tag, tag)
+				require.Equal(blockMetadata.Height, height)
+				require.Equal(blockMetadata.Hash, hash)
+				return blockMetadata, nil
+			},
+		),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(shadowMetadata, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), shadowMetadata).Times(1).Return(shadowBlock, nil),
+	)
+
+	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
+		Height: blockMetadata.Height,
+		Hash:   blockMetadata.Hash,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(shadowBlock, resp.Block)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=success"].Value())
+	require.Equal(int64(shadowMetadata.ByteLength), snapshot.Counters()["server.shadow_read_bytes+path=consolidated"].Value())
+}
+
+func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstFallsBackOnMiss() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().Chain.BlockTag.Stable
+	blockMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(blockMetadata, nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(nil, storage.ErrItemNotFound),
+		s.blobStorage.EXPECT().Download(gomock.Any(), blockMetadata).Times(1).Return(block, nil),
+	)
+
+	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
+		Height: blockMetadata.Height,
+		Hash:   blockMetadata.Hash,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(block, resp.Block)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=miss"].Value())
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
+func (s *handlerTestSuite) TestGetRawBlock_ReadShadowFirstFallsBackOnValidationError() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().Chain.BlockTag.Stable
+	blockMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	shadowMetadata := makeShadowBlockMetadata(blockMetadata)
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(blockMetadata, nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(shadowMetadata, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), shadowMetadata).Times(1).Return(nil, xerrors.New("CSCB block hash mismatch at height 13193825")),
+		s.blobStorage.EXPECT().Download(gomock.Any(), blockMetadata).Times(1).Return(block, nil),
+	)
+
+	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
+		Height: blockMetadata.Height,
+		Hash:   blockMetadata.Hash,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(block, resp.Block)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=validation_mismatch"].Value())
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
 func (s *handlerTestSuite) TestGetRawBlocksByRange_StableTag() {
 	const (
 		startHeight uint64 = 9000
@@ -887,6 +1047,50 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_DownloadCancelError() {
 	})
 	require.Error(err)
 	s.verifyStatusCode(codes.Canceled, err)
+}
+
+func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadShadowFirstFallsBackOnShadowDownloadError() {
+	const (
+		startHeight uint64 = 9000
+		endHeight   uint64 = 9003
+		numBlocks          = int(endHeight - startHeight)
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+
+	tag := s.app.Config().GetLatestBlockTag()
+	blockMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, numBlocks, tag)
+	shadowMetadatas := make([]*api.BlockMetadata, len(blockMetadatas))
+	for i, blockMetadata := range blockMetadatas {
+		shadowMetadatas[i] = makeShadowBlockMetadata(blockMetadata)
+	}
+	blocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
+		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadatas[0]).Times(1).Return(shadowMetadatas[0], nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadatas[1]).Times(1).Return(shadowMetadatas[1], nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadatas[2]).Times(1).Return(shadowMetadatas[2], nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), shadowMetadatas).Times(1).Return(nil, xerrors.New("mock consolidated download error")),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), blockMetadatas).Times(1).Return(blocks, nil),
+	)
+
+	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(blocks, resp.Blocks)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
 }
 
 func (s *handlerTestSuite) TestGetRawBlocksByRange_MaxRangeExceeded() {

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -277,6 +277,10 @@ func (a *blockStorageImpl) GetBlockByTimestamp(ctx context.Context, tag uint32, 
 	return nil, xerrors.New("GetBlockByTimestamp not implemented for DynamoDB")
 }
 
+func (a *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlockConsolidationShadow not implemented for DynamoDB")
+}
+
 func makeBlockMetaDataDDBEntry(block *api.BlockMetadata) *model.BlockMetaDataDDBEntry {
 	blockMetaDataDDBEntry := model.BlockMetaDataDDBEntry{
 		BlockPid:           getBlockPidForHeight(block.Tag, block.Height),

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -281,6 +281,10 @@ func (a *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, bloc
 	return nil, xerrors.New("GetBlockConsolidationShadow not implemented for DynamoDB")
 }
 
+func (a *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlocksConsolidationShadow not implemented for DynamoDB")
+}
+
 func makeBlockMetaDataDDBEntry(block *api.BlockMetadata) *model.BlockMetaDataDDBEntry {
 	blockMetaDataDDBEntry := model.BlockMetaDataDDBEntry{
 		BlockPid:           getBlockPidForHeight(block.Tag, block.Height),

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -254,6 +254,10 @@ func (b *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, bloc
 	return nil, xerrors.New("GetBlockConsolidationShadow not implemented for Firestore")
 }
 
+func (b *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blocks []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlocksConsolidationShadow not implemented for Firestore")
+}
+
 func (b *blockStorageImpl) getLatestBlockDocRef(tag uint32) *firestore.DocumentRef {
 	return b.client.Doc(fmt.Sprintf("env/%s/blocks/%d-latest", b.env, tag))
 }

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -250,6 +250,10 @@ func (b *blockStorageImpl) GetBlockByTimestamp(ctx context.Context, tag uint32, 
 	return nil, xerrors.New("GetBlockByTimestamp not implemented for Firestore")
 }
 
+func (b *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, block *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlockConsolidationShadow not implemented for Firestore")
+}
+
 func (b *blockStorageImpl) getLatestBlockDocRef(tag uint32) *firestore.DocumentRef {
 	return b.client.Doc(fmt.Sprintf("env/%s/blocks/%d-latest", b.env, tag))
 }

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -25,6 +25,7 @@ type (
 		// GetBlockByTimestamp gets the latest block before or at the given timestamp
 		GetBlockByTimestamp(ctx context.Context, tag uint32, timestamp uint64) (*api.BlockMetadata, error)
 		GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error)
+		GetBlocksConsolidationShadow(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error)
 	}
 
 	EventStorage interface {

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -24,6 +24,7 @@ type (
 		GetBlocksByHeights(ctx context.Context, tag uint32, heights []uint64) ([]*api.BlockMetadata, error)
 		// GetBlockByTimestamp gets the latest block before or at the given timestamp
 		GetBlockByTimestamp(ctx context.Context, tag uint32, timestamp uint64) (*api.BlockMetadata, error)
+		GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error)
 	}
 
 	EventStorage interface {

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -113,6 +113,21 @@ func (mr *MockMetaStorageMockRecorder) GetBlockByHeight(arg0, arg1, arg2 any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockByHeight), arg0, arg1, arg2)
 }
 
+// GetBlockConsolidationShadow mocks base method.
+func (m *MockMetaStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockConsolidationShadow", arg0, arg1)
+	ret0, _ := ret[0].(*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockConsolidationShadow indicates an expected call of GetBlockConsolidationShadow.
+func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationShadow(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationShadow", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationShadow), arg0, arg1)
+}
+
 // GetBlockByTimestamp mocks base method.
 func (m *MockMetaStorage) GetBlockByTimestamp(arg0 context.Context, arg1 uint32, arg2 uint64) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -512,6 +527,21 @@ func (m *MockBlockStorage) GetBlockByHeight(arg0 context.Context, arg1 uint32, a
 func (mr *MockBlockStorageMockRecorder) GetBlockByHeight(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockByHeight), arg0, arg1, arg2)
+}
+
+// GetBlockConsolidationShadow mocks base method.
+func (m *MockBlockStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockConsolidationShadow", arg0, arg1)
+	ret0, _ := ret[0].(*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockConsolidationShadow indicates an expected call of GetBlockConsolidationShadow.
+func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationShadow(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationShadow", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationShadow), arg0, arg1)
 }
 
 // GetBlockByTimestamp mocks base method.

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -128,6 +128,21 @@ func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationShadow(arg0, arg1 an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationShadow", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationShadow), arg0, arg1)
 }
 
+// GetBlocksConsolidationShadow mocks base method.
+func (m *MockMetaStorage) GetBlocksConsolidationShadow(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlocksConsolidationShadow", arg0, arg1)
+	ret0, _ := ret[0].([]*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlocksConsolidationShadow indicates an expected call of GetBlocksConsolidationShadow.
+func (mr *MockMetaStorageMockRecorder) GetBlocksConsolidationShadow(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksConsolidationShadow", reflect.TypeOf((*MockMetaStorage)(nil).GetBlocksConsolidationShadow), arg0, arg1)
+}
+
 // GetBlockByTimestamp mocks base method.
 func (m *MockMetaStorage) GetBlockByTimestamp(arg0 context.Context, arg1 uint32, arg2 uint64) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -542,6 +557,21 @@ func (m *MockBlockStorage) GetBlockConsolidationShadow(arg0 context.Context, arg
 func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationShadow(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationShadow", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationShadow), arg0, arg1)
+}
+
+// GetBlocksConsolidationShadow mocks base method.
+func (m *MockBlockStorage) GetBlocksConsolidationShadow(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlocksConsolidationShadow", arg0, arg1)
+	ret0, _ := ret[0].([]*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlocksConsolidationShadow indicates an expected call of GetBlocksConsolidationShadow.
+func (mr *MockBlockStorageMockRecorder) GetBlocksConsolidationShadow(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksConsolidationShadow", reflect.TypeOf((*MockBlockStorage)(nil).GetBlocksConsolidationShadow), arg0, arg1)
 }
 
 // GetBlockByTimestamp mocks base method.

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -543,45 +543,124 @@ func (b *blockStorageImpl) GetBlockByTimestamp(ctx context.Context, tag uint32, 
 }
 
 func (b *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
-	if block.GetSkipped() {
-		return nil, xerrors.Errorf("skipped block has no consolidation shadow: %w", errors.ErrItemNotFound)
-	}
-
-	var objectKey string
-	var objectFormat int32
-	var byteOffset, byteLength int64
-	var uncompressedLength sql.NullInt64
-	query := `
-		SELECT consolidated_object_key_main, object_format, byte_offset, byte_length, uncompressed_length
-		FROM block_consolidation_shadow
-		WHERE tag = $1
-			AND height = $2
-			AND hash = $3
-			AND legacy_object_key_main = $4
-			AND validated_at IS NOT NULL
-		ORDER BY created_at DESC
-		LIMIT 1`
-	err := b.db.QueryRowContext(ctx, query, block.GetTag(), block.GetHeight(), block.GetHash(), block.GetObjectKeyMain()).Scan(
-		&objectKey,
-		&objectFormat,
-		&byteOffset,
-		&byteLength,
-		&uncompressedLength,
-	)
+	shadows, err := b.GetBlocksConsolidationShadow(ctx, []*api.BlockMetadata{block})
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, xerrors.Errorf("consolidation shadow not found: %w", errors.ErrItemNotFound)
+		return nil, err
+	}
+	if len(shadows) == 0 || shadows[0] == nil {
+		return nil, xerrors.Errorf("consolidation shadow not found: %w", errors.ErrItemNotFound)
+	}
+	return shadows[0], nil
+}
+
+func (b *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error) {
+	shadows := make([]*api.BlockMetadata, len(blocks))
+	placeholders := make([]string, 0, len(blocks))
+	args := make([]interface{}, 0, len(blocks)*5)
+	nextArg := 1
+	for i, block := range blocks {
+		if block.GetSkipped() {
+			continue
 		}
-		return nil, xerrors.Errorf("failed to get consolidation shadow: %w", err)
+		placeholders = append(placeholders, fmt.Sprintf(
+			"($%d::int, $%d::int, $%d::bigint, $%d::varchar, $%d::text)",
+			nextArg,
+			nextArg+1,
+			nextArg+2,
+			nextArg+3,
+			nextArg+4,
+		))
+		args = append(args, i, block.GetTag(), block.GetHeight(), block.GetHash(), block.GetObjectKeyMain())
+		nextArg += 5
+	}
+	if len(placeholders) == 0 {
+		return shadows, nil
 	}
 
+	query := fmt.Sprintf(`
+		WITH input(ord, tag, height, hash, legacy_object_key_main) AS (
+			VALUES %s
+		)
+		SELECT
+			input.ord,
+			shadow.consolidated_object_key_main,
+			shadow.object_format,
+			shadow.byte_offset,
+			shadow.byte_length,
+			shadow.uncompressed_length
+		FROM input
+		LEFT JOIN LATERAL (
+			SELECT consolidated_object_key_main, object_format, byte_offset, byte_length, uncompressed_length
+			FROM block_consolidation_shadow
+			WHERE tag = input.tag
+				AND height = input.height
+				AND hash = input.hash
+				AND legacy_object_key_main = input.legacy_object_key_main
+				AND validated_at IS NOT NULL
+			ORDER BY created_at DESC
+			LIMIT 1
+		) shadow ON true
+		ORDER BY input.ord ASC`, strings.Join(placeholders, ", "))
+	rows, err := b.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get consolidation shadows: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	for rows.Next() {
+		var ord int
+		var objectKey sql.NullString
+		var objectFormat sql.NullInt64
+		var byteOffset, byteLength sql.NullInt64
+		var uncompressedLength sql.NullInt64
+		if err := rows.Scan(
+			&ord,
+			&objectKey,
+			&objectFormat,
+			&byteOffset,
+			&byteLength,
+			&uncompressedLength,
+		); err != nil {
+			return nil, xerrors.Errorf("failed to scan consolidation shadow: %w", err)
+		}
+		if !objectKey.Valid {
+			continue
+		}
+		if ord < 0 || ord >= len(blocks) {
+			return nil, xerrors.Errorf("consolidation shadow input order out of range: %d", ord)
+		}
+		shadows[ord] = makeConsolidationShadowBlockMetadata(
+			blocks[ord],
+			objectKey.String,
+			api.BlockObjectFormat(objectFormat.Int64),
+			uint64Value(byteOffset),
+			uint64Value(byteLength),
+			uint64Value(uncompressedLength),
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate consolidation shadows: %w", err)
+	}
+	return shadows, nil
+}
+
+func makeConsolidationShadowBlockMetadata(
+	block *api.BlockMetadata,
+	objectKey string,
+	objectFormat api.BlockObjectFormat,
+	byteOffset uint64,
+	byteLength uint64,
+	uncompressedLength uint64,
+) *api.BlockMetadata {
 	shadow := proto.Clone(block).(*api.BlockMetadata)
 	shadow.ObjectKeyMain = objectKey
-	shadow.ObjectFormat = api.BlockObjectFormat(objectFormat)
-	shadow.ByteOffset = uint64(byteOffset)
-	shadow.ByteLength = uint64(byteLength)
-	shadow.UncompressedLength = uint64Value(uncompressedLength)
-	return shadow, nil
+	shadow.ObjectFormat = objectFormat
+	shadow.ByteOffset = byteOffset
+	shadow.ByteLength = byteLength
+	shadow.UncompressedLength = uncompressedLength
+	return shadow
 }
 
 func uint64Value(value sql.NullInt64) uint64 {

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
@@ -574,13 +575,13 @@ func (b *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, bloc
 		return nil, xerrors.Errorf("failed to get consolidation shadow: %w", err)
 	}
 
-	shadow := *block
+	shadow := proto.Clone(block).(*api.BlockMetadata)
 	shadow.ObjectKeyMain = objectKey
 	shadow.ObjectFormat = api.BlockObjectFormat(objectFormat)
 	shadow.ByteOffset = uint64(byteOffset)
 	shadow.ByteLength = uint64(byteLength)
 	shadow.UncompressedLength = uint64Value(uncompressedLength)
-	return &shadow, nil
+	return shadow, nil
 }
 
 func uint64Value(value sql.NullInt64) uint64 {

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -541,6 +541,48 @@ func (b *blockStorageImpl) GetBlockByTimestamp(ctx context.Context, tag uint32, 
 	})
 }
 
+func (b *blockStorageImpl) GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
+	if block.GetSkipped() {
+		return nil, xerrors.Errorf("skipped block has no consolidation shadow: %w", errors.ErrItemNotFound)
+	}
+
+	var objectKey string
+	var objectFormat int32
+	var byteOffset, byteLength int64
+	var uncompressedLength sql.NullInt64
+	query := `
+		SELECT consolidated_object_key_main, object_format, byte_offset, byte_length, uncompressed_length
+		FROM block_consolidation_shadow
+		WHERE tag = $1
+			AND height = $2
+			AND hash = $3
+			AND legacy_object_key_main = $4
+			AND validated_at IS NOT NULL
+		ORDER BY created_at DESC
+		LIMIT 1`
+	err := b.db.QueryRowContext(ctx, query, block.GetTag(), block.GetHeight(), block.GetHash(), block.GetObjectKeyMain()).Scan(
+		&objectKey,
+		&objectFormat,
+		&byteOffset,
+		&byteLength,
+		&uncompressedLength,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, xerrors.Errorf("consolidation shadow not found: %w", errors.ErrItemNotFound)
+		}
+		return nil, xerrors.Errorf("failed to get consolidation shadow: %w", err)
+	}
+
+	shadow := *block
+	shadow.ObjectKeyMain = objectKey
+	shadow.ObjectFormat = api.BlockObjectFormat(objectFormat)
+	shadow.ByteOffset = uint64(byteOffset)
+	shadow.ByteLength = uint64(byteLength)
+	shadow.UncompressedLength = uint64Value(uncompressedLength)
+	return &shadow, nil
+}
+
 func uint64Value(value sql.NullInt64) uint64 {
 	if !value.Valid {
 		return 0

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -311,6 +311,134 @@ func (s *blockStorageTestSuite) equalProto(x, y any) {
 	}
 }
 
+func (s *blockStorageTestSuite) getBlockMetadataID(ctx context.Context, block *api.BlockMetadata) int64 {
+	require := testutil.Require(s.T())
+	var blockMetadataID int64
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT id FROM block_metadata WHERE tag = $1 AND height = $2 AND hash = $3 AND object_key_main = $4`,
+		block.GetTag(),
+		block.GetHeight(),
+		block.GetHash(),
+		block.GetObjectKeyMain(),
+	).Scan(&blockMetadataID)
+	require.NoError(err)
+	return blockMetadataID
+}
+
+func (s *blockStorageTestSuite) insertConsolidationShadow(
+	ctx context.Context,
+	block *api.BlockMetadata,
+	consolidatedObjectKey string,
+	byteOffset uint64,
+	byteLength uint64,
+	uncompressedLength uint64,
+	validated bool,
+	legacyObjectKeyMain string,
+) {
+	require := testutil.Require(s.T())
+	if legacyObjectKeyMain == "" {
+		legacyObjectKeyMain = block.GetObjectKeyMain()
+	}
+	var validatedAt any
+	if validated {
+		validatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO block_consolidation_shadow (
+			block_metadata_id, tag, height, hash, legacy_object_key_main, consolidated_object_key_main,
+			object_format, byte_offset, byte_length, uncompressed_length, validated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		s.getBlockMetadataID(ctx, block),
+		block.GetTag(),
+		block.GetHeight(),
+		block.GetHash(),
+		legacyObjectKeyMain,
+		consolidatedObjectKey,
+		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
+		byteOffset,
+		byteLength,
+		uncompressedLength,
+		validatedAt,
+	)
+	require.NoError(err)
+}
+
+func expectedConsolidationShadow(
+	block *api.BlockMetadata,
+	consolidatedObjectKey string,
+	byteOffset uint64,
+	byteLength uint64,
+	uncompressedLength uint64,
+) *api.BlockMetadata {
+	shadow := proto.Clone(block).(*api.BlockMetadata)
+	shadow.ObjectKeyMain = consolidatedObjectKey
+	shadow.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH
+	shadow.ByteOffset = byteOffset
+	shadow.ByteLength = byteLength
+	shadow.UncompressedLength = uncompressedLength
+	return shadow
+}
+
+func (s *blockStorageTestSuite) TestGetConsolidationShadowPredicates() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 4, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/validated.cscb.zstd", 10, 20, 20, true, "")
+	s.insertConsolidationShadow(ctx, blocks[1], "consolidated/unvalidated.cscb.zstd", 30, 40, 40, false, "")
+	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/wrong-legacy-key.cscb.zstd", 50, 60, 60, true, "legacy/key/does/not/match")
+
+	expected := expectedConsolidationShadow(blocks[0], "consolidated/validated.cscb.zstd", 10, 20, 20)
+	actual, err := s.accessor.GetBlockConsolidationShadow(ctx, blocks[0])
+	require.NoError(err)
+	s.equalProto(expected, actual)
+
+	_, err = s.accessor.GetBlockConsolidationShadow(ctx, blocks[1])
+	require.Error(err)
+	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+
+	_, err = s.accessor.GetBlockConsolidationShadow(ctx, blocks[2])
+	require.Error(err)
+	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+
+	_, err = s.accessor.GetBlockConsolidationShadow(ctx, blocks[3])
+	require.Error(err)
+	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+
+	skipped := &api.BlockMetadata{Tag: tag, Height: startHeight + 10, Skipped: true}
+	_, err = s.accessor.GetBlockConsolidationShadow(ctx, skipped)
+	require.Error(err)
+	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+}
+
+func (s *blockStorageTestSuite) TestGetBlocksConsolidationShadowPreservesOrderAndMisses() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 3, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/first.cscb.zstd", 100, 200, 200, true, "")
+	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/third.cscb.zstd", 300, 400, 400, true, "")
+	skipped := &api.BlockMetadata{Tag: tag, Height: startHeight + 99, Skipped: true}
+
+	actual, err := s.accessor.GetBlocksConsolidationShadow(ctx, []*api.BlockMetadata{blocks[2], blocks[1], skipped, blocks[0]})
+	require.NoError(err)
+	require.Len(actual, 4)
+	s.equalProto(expectedConsolidationShadow(blocks[2], "consolidated/third.cscb.zstd", 300, 400, 400), actual[0])
+	require.Nil(actual[1])
+	require.Nil(actual[2])
+	s.equalProto(expectedConsolidationShadow(blocks[0], "consolidated/first.cscb.zstd", 100, 200, 200), actual[3])
+}
+
 func (s *blockStorageTestSuite) TestWatermarkVisibilityControl() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Add server-side `read_shadow_first` behavior for materialized content reads: when disabled, use the current legacy path with no shadow lookup; when enabled, try validated CSCB shadow placement first and fall back to primary legacy metadata on miss, lookup error, validation/read error, or range download failure.
- Add Postgres `block_consolidation_shadow` lookup guarded by `(tag, height, hash, legacy_object_key_main)` and `validated_at IS NOT NULL`.
- Keep `GetBlockFile`/`GetBlockFilesByRange` on primary metadata only, so old SDK/file clients are not switched by this flag.
- Add shadow read metrics for miss/error/validation/fallback/success plus path-tagged latency and bytes counters.

## Tests

- `TEST_TYPE=unit go test ./internal/server -run 'TestHandlerSuite/(TestGetBlockFile_ReadShadowFirstStillUsesPrimaryMetadata|TestGetRawBlock_ReadShadowFirstUsesShadow|TestGetRawBlock_ReadShadowFirstFallsBackOnMiss|TestGetRawBlock_ReadShadowFirstFallsBackOnValidationError|TestGetRawBlocksByRange_ReadShadowFirstFallsBackOnShadowDownloadError)'`
- `TEST_TYPE=unit go test ./internal/server ./internal/config ./internal/storage/metastorage/... ./internal/storage/blobstorage/...`
- `TEST_TYPE=unit go test ./...`

Linear: INF-908