### PR TITLE
fix(INF-913): stream CSCB chunk block extraction

### DIFF
--- a/internal/storage/blobstorage/cscb/reader.go
+++ b/internal/storage/blobstorage/cscb/reader.go
@@ -363,7 +363,7 @@ func ExtractBlockPayloadsFromChunkFrame(frame io.Reader, codec api.Compression, 
 				if previousCRC != read.block.PayloadCRC32 {
 					return nil, xerrors.Errorf("CSCB duplicate block CRC mismatch at height %d: got %08x want %08x", read.block.Height, previousCRC, read.block.PayloadCRC32)
 				}
-				payloads[read.originalIndex] = previousPayload
+				payloads[read.originalIndex] = append([]byte(nil), previousPayload...)
 				continue
 			}
 			return nil, xerrors.Errorf("CSCB block payload overlaps previous read at height %d: start=%d offset=%d", read.block.Height, read.start, offset)

--- a/internal/storage/blobstorage/cscb/reader.go
+++ b/internal/storage/blobstorage/cscb/reader.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"hash/crc32"
 	"io"
+	"sort"
 
 	"github.com/klauspost/compress/zstd"
 	"golang.org/x/xerrors"
@@ -299,6 +300,101 @@ func DecodeChunkFrame(frame io.Reader, codec api.Compression) ([]byte, error) {
 	return decoded, nil
 }
 
+type blockPayloadRead struct {
+	originalIndex int
+	block         *BlockDescriptor
+	start         uint64
+	end           uint64
+}
+
+// ExtractBlockPayloadsFromChunkFrame streams a compressed chunk and returns
+// only the requested block payloads in the same order as blocks. It validates
+// each requested block CRC without materializing the full decompressed chunk.
+func ExtractBlockPayloadsFromChunkFrame(frame io.Reader, codec api.Compression, chunk *ChunkDescriptor, blocks []*BlockDescriptor) ([][]byte, error) {
+	if chunk == nil {
+		return nil, xerrors.New("CSCB chunk descriptor is required")
+	}
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+
+	reads := make([]blockPayloadRead, len(blocks))
+	for i, block := range blocks {
+		if block == nil {
+			return nil, xerrors.New("CSCB block descriptor is required")
+		}
+		if block.ChunkIndex != chunk.Index {
+			return nil, xerrors.Errorf("CSCB block chunk mismatch at height %d: block=%d chunk=%d", block.Height, block.ChunkIndex, chunk.Index)
+		}
+		end, err := checkedAdd(block.ChunkRelativeOffset, block.PayloadLength)
+		if err != nil {
+			return nil, err
+		}
+		if end > chunk.UncompressedLength {
+			return nil, xerrors.Errorf("CSCB block payload exceeds chunk bounds: end=%d chunk_length=%d", end, chunk.UncompressedLength)
+		}
+		reads[i] = blockPayloadRead{
+			originalIndex: i,
+			block:         block,
+			start:         block.ChunkRelativeOffset,
+			end:           end,
+		}
+	}
+	sort.SliceStable(reads, func(i, j int) bool {
+		return reads[i].start < reads[j].start
+	})
+
+	reader, err := NewChunkDecompressor(frame, codec)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = reader.Close() }()
+
+	payloads := make([][]byte, len(blocks))
+	var offset uint64
+	var hasPrevious bool
+	var previousStart uint64
+	var previousEnd uint64
+	var previousPayload []byte
+	var previousCRC uint32
+	for _, read := range reads {
+		if read.start < offset {
+			if hasPrevious && read.start == previousStart && read.end == previousEnd {
+				if previousCRC != read.block.PayloadCRC32 {
+					return nil, xerrors.Errorf("CSCB duplicate block CRC mismatch at height %d: got %08x want %08x", read.block.Height, previousCRC, read.block.PayloadCRC32)
+				}
+				payloads[read.originalIndex] = previousPayload
+				continue
+			}
+			return nil, xerrors.Errorf("CSCB block payload overlaps previous read at height %d: start=%d offset=%d", read.block.Height, read.start, offset)
+		}
+		if err := discardExactly(reader, read.start-offset); err != nil {
+			return nil, err
+		}
+
+		length, err := toInt(read.block.PayloadLength)
+		if err != nil {
+			return nil, err
+		}
+		payload := make([]byte, length)
+		if _, err := io.ReadFull(reader, payload); err != nil {
+			return nil, xerrors.Errorf("failed to read CSCB block payload at height %d: %w", read.block.Height, err)
+		}
+		offset = read.end
+		if crc := crc32.ChecksumIEEE(payload); crc != read.block.PayloadCRC32 {
+			return nil, xerrors.Errorf("CSCB block CRC mismatch at height %d: got %08x want %08x", read.block.Height, crc, read.block.PayloadCRC32)
+		} else {
+			previousCRC = crc
+		}
+		payloads[read.originalIndex] = payload
+		hasPrevious = true
+		previousStart = read.start
+		previousEnd = read.end
+		previousPayload = payload
+	}
+	return payloads, nil
+}
+
 func NewChunkDecompressor(frame io.Reader, codec api.Compression) (io.ReadCloser, error) {
 	switch codec {
 	case api.Compression_GZIP:
@@ -347,6 +443,20 @@ func ExtractBlockPayload(chunkPayload []byte, block *BlockDescriptor) ([]byte, e
 		return nil, xerrors.Errorf("CSCB block CRC mismatch: got %08x want %08x", crc, block.PayloadCRC32)
 	}
 	return payload, nil
+}
+
+func discardExactly(reader io.Reader, n uint64) error {
+	if n == 0 {
+		return nil
+	}
+	const maxInt64 = uint64(1<<63 - 1)
+	if n >= maxInt64 {
+		return xerrors.Errorf("discard length %d is too large", n)
+	}
+	if _, err := io.CopyN(io.Discard, reader, int64(n)); err != nil {
+		return xerrors.Errorf("failed to skip CSCB chunk bytes: %w", err)
+	}
+	return nil
 }
 
 type zstdReadCloser struct {

--- a/internal/storage/blobstorage/cscb/reader_test.go
+++ b/internal/storage/blobstorage/cscb/reader_test.go
@@ -106,6 +106,8 @@ func TestExtractBlockPayloadsFromChunkFramePreservesInputOrder(t *testing.T) {
 	require.Equal([]byte("bravo-bravo"), duplicatePayloads[0])
 	require.Equal([]byte("alpha"), duplicatePayloads[1])
 	require.Equal([]byte("bravo-bravo"), duplicatePayloads[2])
+	duplicatePayloads[0][0] = 'B'
+	require.Equal([]byte("bravo-bravo"), duplicatePayloads[2])
 }
 
 func TestLookupBlockRejectsMismatchedMetadata(t *testing.T) {

--- a/internal/storage/blobstorage/cscb/reader_test.go
+++ b/internal/storage/blobstorage/cscb/reader_test.go
@@ -47,6 +47,65 @@ func TestParseIndexAndExtractBlockPayload(t *testing.T) {
 	payload, err := ExtractBlockPayload(chunkPayload, block)
 	require.NoError(err)
 	require.Equal([]byte("bravo-bravo"), payload)
+
+	streamedPayloads, err := ExtractBlockPayloadsFromChunkFrame(bytes.NewReader(frame), index.Header.Codec, chunk, []*BlockDescriptor{block})
+	require.NoError(err)
+	require.Len(streamedPayloads, 1)
+	require.Equal([]byte("bravo-bravo"), streamedPayloads[0])
+}
+
+func TestExtractBlockPayloadsFromChunkFramePreservesInputOrder(t *testing.T) {
+	require := testutil.Require(t)
+
+	object, err := Encode(context.Background(), testEncodeConfig(api.Compression_ZSTD), testPayloads())
+	require.NoError(err)
+	defer object.Close()
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := ParseIndex(data)
+	require.NoError(err)
+	require.Len(index.Chunks, 2)
+
+	metadata0 := &api.BlockMetadata{
+		Tag:                7,
+		Height:             100,
+		Hash:               "hash-100",
+		ObjectKeyMain:      object.Key,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteOffset:         object.Placements[0].ByteOffset,
+		ByteLength:         object.Placements[0].ByteLength,
+		UncompressedLength: object.Placements[0].UncompressedLength,
+	}
+	metadata1 := &api.BlockMetadata{
+		Tag:                7,
+		Height:             101,
+		Hash:               "hash-101",
+		ObjectKeyMain:      object.Key,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteOffset:         object.Placements[1].ByteOffset,
+		ByteLength:         object.Placements[1].ByteLength,
+		UncompressedLength: object.Placements[1].UncompressedLength,
+	}
+	block0, chunk0, err := index.LookupBlock(metadata0)
+	require.NoError(err)
+	block1, chunk1, err := index.LookupBlock(metadata1)
+	require.NoError(err)
+	require.Equal(chunk0.Index, chunk1.Index)
+
+	frame := data[chunk0.CompressedPayloadOffset : chunk0.CompressedPayloadOffset+chunk0.CompressedLength]
+	payloads, err := ExtractBlockPayloadsFromChunkFrame(bytes.NewReader(frame), index.Header.Codec, chunk0, []*BlockDescriptor{block1, block0})
+	require.NoError(err)
+	require.Len(payloads, 2)
+	require.Equal([]byte("bravo-bravo"), payloads[0])
+	require.Equal([]byte("alpha"), payloads[1])
+
+	duplicatePayloads, err := ExtractBlockPayloadsFromChunkFrame(bytes.NewReader(frame), index.Header.Codec, chunk0, []*BlockDescriptor{block1, block0, block1})
+	require.NoError(err)
+	require.Len(duplicatePayloads, 3)
+	require.Equal([]byte("bravo-bravo"), duplicatePayloads[0])
+	require.Equal([]byte("alpha"), duplicatePayloads[1])
+	require.Equal([]byte("bravo-bravo"), duplicatePayloads[2])
 }
 
 func TestLookupBlockRejectsMismatchedMetadata(t *testing.T) {

--- a/internal/storage/blobstorage/downloader/block.go
+++ b/internal/storage/blobstorage/downloader/block.go
@@ -1,7 +1,6 @@
 package downloader
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -91,11 +90,12 @@ type (
 	}
 
 	blockDownloaderImpl struct {
-		config     *config.Config
-		logger     *zap.Logger
-		httpClient HTTPClient
-		retry      retry.RetryWithResult[*api.Block]
-		retryBytes retry.RetryWithResult[[]byte]
+		config        *config.Config
+		logger        *zap.Logger
+		httpClient    HTTPClient
+		retry         retry.RetryWithResult[*api.Block]
+		retryBytes    retry.RetryWithResult[[]byte]
+		retryPayloads retry.RetryWithResult[[][]byte]
 	}
 
 	downloadRef struct {
@@ -135,11 +135,12 @@ const (
 func NewBlockDownloader(params BlockDownloaderParams) BlockDownloader {
 	logger := log.WithPackage(params.Logger)
 	return &blockDownloaderImpl{
-		config:     params.Config,
-		logger:     logger,
-		httpClient: params.HttpClient,
-		retry:      retry.NewWithResult[*api.Block](retry.WithLogger(logger)),
-		retryBytes: retry.NewWithResult[[]byte](retry.WithLogger(logger)),
+		config:        params.Config,
+		logger:        logger,
+		httpClient:    params.HttpClient,
+		retry:         retry.NewWithResult[*api.Block](retry.WithLogger(logger)),
+		retryBytes:    retry.NewWithResult[[]byte](retry.WithLogger(logger)),
+		retryPayloads: retry.NewWithResult[[][]byte](retry.WithLogger(logger)),
 	}
 }
 
@@ -433,14 +434,11 @@ func (d *blockDownloaderImpl) downloadCSCBBlockPayload(ctx context.Context, bloc
 	if err != nil {
 		return nil, err
 	}
-	chunkPayload, err := d.downloadCSCBChunk(ctx, blockFile.GetFileUrl(), index.Header.Codec, chunk)
+	blockPayloads, err := d.downloadCSCBChunkPayloads(ctx, blockFile.GetFileUrl(), index.Header.Codec, chunk, []*cscb.BlockDescriptor{block})
 	if err != nil {
 		return nil, err
 	}
-	if err := cscb.ValidateChunkPayload(chunkPayload, chunk); err != nil {
-		return nil, err
-	}
-	return cscb.ExtractBlockPayload(chunkPayload, block)
+	return blockPayloads[0], nil
 }
 
 func (d *blockDownloaderImpl) downloadCSCBFile(ctx context.Context, limiter downloadLimiter, fileURL string, refs []downloadRef, result []*api.Block) error {
@@ -475,18 +473,16 @@ func (d *blockDownloaderImpl) downloadCSCBFile(ctx context.Context, limiter down
 		group.Go(func() error {
 			return limiter.Do(ctx, func() error {
 				chunk := downloads[0].chunk
-				chunkPayload, err := d.downloadCSCBChunk(ctx, fileURL, index.Header.Codec, chunk)
+				blocks := make([]*cscb.BlockDescriptor, len(downloads))
+				for i, download := range downloads {
+					blocks[i] = download.block
+				}
+				blockPayloads, err := d.downloadCSCBChunkPayloads(ctx, fileURL, index.Header.Codec, chunk, blocks)
 				if err != nil {
 					return err
 				}
-				if err := cscb.ValidateChunkPayload(chunkPayload, chunk); err != nil {
-					return err
-				}
-				for _, download := range downloads {
-					blockPayload, err := cscb.ExtractBlockPayload(chunkPayload, download.block)
-					if err != nil {
-						return err
-					}
+				for i, download := range downloads {
+					blockPayload := blockPayloads[i]
 					block, err := unmarshalCSCBBlock(download.ref.blockFile, blockPayload)
 					if err != nil {
 						return err
@@ -525,30 +521,31 @@ func (d *blockDownloaderImpl) readCSCBIndex(ctx context.Context, limiter downloa
 	return cscb.ParseIndex(indexData)
 }
 
-func (d *blockDownloaderImpl) downloadCSCBChunk(ctx context.Context, fileURL string, codec api.Compression, chunk *cscb.ChunkDescriptor) ([]byte, error) {
-	compressed, err := d.readHTTPRangeByLength(ctx, nil, fileURL, chunk.CompressedPayloadOffset, chunk.CompressedLength)
-	if err != nil {
-		return nil, err
+func (d *blockDownloaderImpl) downloadCSCBChunkPayloads(ctx context.Context, fileURL string, codec api.Compression, chunk *cscb.ChunkDescriptor, blocks []*cscb.BlockDescriptor) ([][]byte, error) {
+	if len(blocks) == 0 {
+		return nil, xerrors.New("CSCB block descriptors are required")
 	}
-	if uint64(len(compressed)) != chunk.CompressedLength {
-		return nil, xerrors.Errorf("CSCB compressed chunk length mismatch: got %d want %d", len(compressed), chunk.CompressedLength)
-	}
-	decompressed, err := cscb.DecodeChunkFrame(bytes.NewReader(compressed), codec)
-	if err != nil {
-		return nil, err
-	}
-	return decompressed, nil
+	return d.retryPayloads.Retry(ctx, func(ctx context.Context) ([][]byte, error) {
+		payloads, err := d.downloadCSCBChunkPayloadsUnthrottled(ctx, fileURL, codec, chunk, blocks)
+		if err != nil && (xerrors.Is(err, io.EOF) || xerrors.Is(err, io.ErrUnexpectedEOF)) {
+			return nil, retry.Retryable(err)
+		}
+		return payloads, err
+	})
 }
 
-func (d *blockDownloaderImpl) readHTTPRangeByLength(ctx context.Context, limiter downloadLimiter, fileURL string, offset uint64, length uint64) ([]byte, error) {
-	if length == 0 {
-		return nil, xerrors.Errorf("empty range read for %s at offset %d", fileURL, offset)
-	}
-	end, err := inclusiveRangeEnd(offset, length)
+func (d *blockDownloaderImpl) downloadCSCBChunkPayloadsUnthrottled(ctx context.Context, fileURL string, codec api.Compression, chunk *cscb.ChunkDescriptor, blocks []*cscb.BlockDescriptor) ([][]byte, error) {
+	body, err := d.openHTTPRangeByLengthUnthrottled(ctx, fileURL, chunk.CompressedPayloadOffset, chunk.CompressedLength)
 	if err != nil {
 		return nil, err
 	}
-	return d.readHTTPRange(ctx, limiter, fileURL, offset, end)
+	defer func() { _ = body.Close() }()
+
+	limitedBody, err := limitReaderByLength(body, chunk.CompressedLength)
+	if err != nil {
+		return nil, err
+	}
+	return cscb.ExtractBlockPayloadsFromChunkFrame(limitedBody, codec, chunk, blocks)
 }
 
 func (d *blockDownloaderImpl) readHTTPRange(ctx context.Context, limiter downloadLimiter, fileURL string, start uint64, end uint64) ([]byte, error) {
@@ -580,12 +577,14 @@ func (d *blockDownloaderImpl) readHTTPRangeUnthrottled(ctx context.Context, file
 		finalizer := finalizer.WithCloser(httpResp.Body)
 		defer finalizer.Finalize()
 
+		ignoredInitialRange := false
 		if statusCode := httpResp.StatusCode; statusCode != http.StatusPartialContent {
 			if statusCode == http.StatusOK && start == 0 {
 				// Some test transports or non-S3-compatible stores may
 				// ignore Range for the initial index read. Treat that as
 				// usable because the object starts at byte 0 and contains
 				// at least the header/envelope we need.
+				ignoredInitialRange = true
 			} else if statusCode == http.StatusRequestTimeout ||
 				statusCode == http.StatusTooManyRequests ||
 				statusCode >= http.StatusInternalServerError {
@@ -595,12 +594,92 @@ func (d *blockDownloaderImpl) readHTTPRangeUnthrottled(ctx context.Context, file
 			}
 		}
 
-		bodyBytes, err := ioutil.ReadAll(httpResp.Body)
-		if err != nil {
-			return nil, retry.Retryable(xerrors.Errorf("failed to read range body: %w", err))
+		expectedLength := end - start + 1
+		var bodyBytes []byte
+		var readErr error
+		if ignoredInitialRange {
+			bodyBytes, readErr = readRangePrefixBody(httpResp.Body, expectedLength)
+		} else {
+			bodyBytes, readErr = readExpectedRangeBody(httpResp.Body, expectedLength, start == 0)
+		}
+		if readErr != nil {
+			return nil, retry.Retryable(xerrors.Errorf("failed to read range body: %w", readErr))
 		}
 		return bodyBytes, finalizer.Close()
 	})
+}
+
+func (d *blockDownloaderImpl) openHTTPRangeByLengthUnthrottled(ctx context.Context, fileURL string, offset uint64, length uint64) (io.ReadCloser, error) {
+	if length == 0 {
+		return nil, xerrors.Errorf("empty range read for %s at offset %d", fileURL, offset)
+	}
+	end, err := inclusiveRangeEnd(offset, length)
+	if err != nil {
+		return nil, err
+	}
+	return d.openHTTPRangeUnthrottled(ctx, fileURL, offset, end)
+}
+
+func (d *blockDownloaderImpl) openHTTPRangeUnthrottled(ctx context.Context, fileURL string, start uint64, end uint64) (io.ReadCloser, error) {
+	if end < start {
+		return nil, xerrors.Errorf("invalid range for %s: start=%d end=%d", fileURL, start, end)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create range download request: %w", err)
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, retry.Retryable(xerrors.Errorf("failed to range download block file: %w", err))
+	}
+	if statusCode := httpResp.StatusCode; statusCode != http.StatusPartialContent {
+		if httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
+		if statusCode == http.StatusRequestTimeout ||
+			statusCode == http.StatusTooManyRequests ||
+			statusCode >= http.StatusInternalServerError {
+			return nil, retry.Retryable(xerrors.Errorf("received %d status code: %w", statusCode, errors.ErrDownloadFailure))
+		}
+		return nil, xerrors.Errorf("received non-retryable %d status code: %w", statusCode, errors.ErrDownloadFailure)
+	}
+	if httpResp.Body == nil {
+		return nil, xerrors.Errorf("empty range body for %s", fileURL)
+	}
+	return httpResp.Body, nil
+}
+
+func limitReaderByLength(reader io.Reader, length uint64) (io.Reader, error) {
+	const maxInt64 = uint64(1<<63 - 1)
+	if length >= maxInt64 {
+		return nil, xerrors.Errorf("range body length %d is too large", length)
+	}
+	return io.LimitReader(reader, int64(length)), nil
+}
+
+func readRangePrefixBody(body io.Reader, maxLength uint64) ([]byte, error) {
+	const maxInt64 = uint64(1<<63 - 1)
+	if maxLength >= maxInt64 {
+		return nil, xerrors.Errorf("range body length %d is too large", maxLength)
+	}
+	return io.ReadAll(io.LimitReader(body, int64(maxLength)))
+}
+
+func readExpectedRangeBody(body io.Reader, expectedLength uint64, allowShort bool) ([]byte, error) {
+	const maxInt64 = uint64(1<<63 - 1)
+	if expectedLength >= maxInt64 {
+		return nil, xerrors.Errorf("range body length %d is too large", expectedLength)
+	}
+	bodyBytes, err := io.ReadAll(io.LimitReader(body, int64(expectedLength)+1))
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(bodyBytes)) > expectedLength || (!allowShort && uint64(len(bodyBytes)) != expectedLength) {
+		return nil, xerrors.Errorf("range body length mismatch: got %d want %d", len(bodyBytes), expectedLength)
+	}
+	return bodyBytes, nil
 }
 
 func newDownloadLimiter(limit int) downloadLimiter {

--- a/internal/storage/blobstorage/downloader/block_test.go
+++ b/internal/storage/blobstorage/downloader/block_test.go
@@ -1,6 +1,7 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -64,6 +65,38 @@ type (
 
 func TestBlockDownloaderSuite(t *testing.T) {
 	suite.Run(t, new(blockDownloaderTestSuite))
+}
+
+func TestReadExpectedRangeBodyAllowsShortInitialRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	actual, err := readExpectedRangeBody(bytes.NewReader([]byte("short")), 64*1024, true)
+	require.NoError(err)
+	require.Equal([]byte("short"), actual)
+}
+
+func TestReadExpectedRangeBodyRejectsShortNonInitialRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	_, err := readExpectedRangeBody(bytes.NewReader([]byte("short")), 10, false)
+	require.Error(err)
+	require.Contains(err.Error(), "range body length mismatch")
+}
+
+func TestReadExpectedRangeBodyRejectsOversizedRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	_, err := readExpectedRangeBody(bytes.NewReader([]byte("too-long")), 3, true)
+	require.Error(err)
+	require.Contains(err.Error(), "range body length mismatch")
+}
+
+func TestReadRangePrefixBodyTruncatesOversizedRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	actual, err := readRangePrefixBody(bytes.NewReader([]byte("too-long")), 3)
+	require.NoError(err)
+	require.Equal([]byte("too"), actual)
 }
 
 func (s *blockDownloaderTestSuite) SetupTest() {
@@ -313,6 +346,43 @@ func (s *blockDownloaderTestSuite) TestDownload_CSCB() {
 	}, ranges)
 }
 
+func (s *blockDownloaderTestSuite) TestDownload_CSCBInitialIndexIgnoresRangeWithBoundedPrefix() {
+	require := testutil.Require(s.T())
+	fixture := newCSCBDownloaderFixture(s.T(), 3, 2)
+	defer fixture.close()
+
+	data := append([]byte{}, fixture.data...)
+	if len(data) <= 64*1024 {
+		data = append(data, bytes.Repeat([]byte{0}, 64*1024-len(data)+1)...)
+	}
+	server, recorder := newInitialRangeIgnoringHTTPServer(data)
+	defer server.Close()
+	for _, file := range fixture.blockFiles {
+		file.FileUrl = server.URL
+	}
+
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(func() HTTPClient { return server.Client() }),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+
+	rawBlock, err := s.downloader.Download(context.Background(), fixture.blockFiles[1])
+	require.NoError(err)
+	expected := proto.Clone(fixture.blocks[1]).(*api.Block)
+	expected.Metadata = blockFileToMetadata(fixture.blockFiles[1])
+	if diff := cmp.Diff(expected, rawBlock, protocmp.Transform()); diff != "" {
+		require.FailNow(diff)
+	}
+
+	ranges := recorder.rangesSnapshot()
+	require.Equal([]string{
+		"bytes=0-65535",
+		rangeHeader(fixture.index.Chunks[0].CompressedPayloadOffset, fixture.index.Chunks[0].CompressedLength),
+	}, ranges)
+}
+
 func (s *blockDownloaderTestSuite) TestDownloadMany_CSCBGroupsByChunk() {
 	require := testutil.Require(s.T())
 	fixture := newCSCBDownloaderFixture(s.T(), 4, 2)
@@ -354,6 +424,47 @@ func (s *blockDownloaderTestSuite) TestDownloadMany_CSCBGroupsByChunk() {
 		"bytes=0-65535",
 		rangeHeader(fixture.index.Chunks[0].CompressedPayloadOffset, fixture.index.Chunks[0].CompressedLength),
 		rangeHeader(fixture.index.Chunks[1].CompressedPayloadOffset, fixture.index.Chunks[1].CompressedLength),
+	}, ranges)
+}
+
+func (s *blockDownloaderTestSuite) TestDownloadMany_CSCBAllowsDuplicateInputs() {
+	require := testutil.Require(s.T())
+	fixture := newCSCBDownloaderFixture(s.T(), 4, 2)
+	defer fixture.close()
+
+	server, recorder := newRangeHTTPServer(fixture.data)
+	defer server.Close()
+	for _, file := range fixture.blockFiles {
+		file.FileUrl = server.URL
+	}
+
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(func() HTTPClient { return server.Client() }),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+
+	blockFiles := []*api.BlockFile{
+		fixture.blockFiles[1],
+		fixture.blockFiles[1],
+	}
+	rawBlocks, err := s.downloader.DownloadMany(context.Background(), blockFiles)
+	require.NoError(err)
+	require.Len(rawBlocks, len(blockFiles))
+
+	for i, blockFile := range blockFiles {
+		expected := proto.Clone(fixture.blocks[1]).(*api.Block)
+		expected.Metadata = blockFileToMetadata(blockFile)
+		if diff := cmp.Diff(expected, rawBlocks[i], protocmp.Transform()); diff != "" {
+			require.FailNow(diff)
+		}
+	}
+
+	ranges := recorder.rangesSnapshot()
+	require.Equal([]string{
+		"bytes=0-65535",
+		rangeHeader(fixture.index.Chunks[0].CompressedPayloadOffset, fixture.index.Chunks[0].CompressedLength),
 	}, ranges)
 }
 
@@ -618,6 +729,27 @@ func newRangeHTTPServer(data []byte) (*httptest.Server, *rangeRequestRecorder) {
 	return newRangeHTTPServerWithTracker(data, nil, 0)
 }
 
+func newInitialRangeIgnoringHTTPServer(data []byte) (*httptest.Server, *rangeRequestRecorder) {
+	recorder := &rangeRequestRecorder{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet {
+			writer.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		rangeValue := request.Header.Get("Range")
+		done := recorder.record(rangeValue)
+		defer done()
+		if rangeValue == "bytes=0-65535" {
+			_, _ = writer.Write(data)
+			return
+		}
+
+		writeRangeResponse(writer, rangeValue, data)
+	}))
+	return server, recorder
+}
+
 func newRangeHTTPServerWithTracker(data []byte, tracker *rangeConcurrencyTracker, delay time.Duration) (*httptest.Server, *rangeRequestRecorder) {
 	recorder := &rangeRequestRecorder{
 		tracker: tracker,
@@ -640,23 +772,27 @@ func newRangeHTTPServerWithTracker(data []byte, tracker *rangeConcurrencyTracker
 			return
 		}
 
-		var start, end uint64
-		if _, err := fmt.Sscanf(rangeValue, "bytes=%d-%d", &start, &end); err != nil {
-			writer.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		if start >= uint64(len(data)) || end < start {
-			writer.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-			return
-		}
-		if end >= uint64(len(data)) {
-			end = uint64(len(data)) - 1
-		}
-		writer.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
-		writer.WriteHeader(http.StatusPartialContent)
-		_, _ = writer.Write(data[start : end+1])
+		writeRangeResponse(writer, rangeValue, data)
 	}))
 	return server, recorder
+}
+
+func writeRangeResponse(writer http.ResponseWriter, rangeValue string, data []byte) {
+	var start, end uint64
+	if _, err := fmt.Sscanf(rangeValue, "bytes=%d-%d", &start, &end); err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if start >= uint64(len(data)) || end < start {
+		writer.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+	if end >= uint64(len(data)) {
+		end = uint64(len(data)) - 1
+	}
+	writer.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+	writer.WriteHeader(http.StatusPartialContent)
+	_, _ = writer.Write(data[start : end+1])
 }
 
 func (r *rangeRequestRecorder) record(rangeValue string) func() {

--- a/internal/storage/blobstorage/s3/blob_storage.go
+++ b/internal/storage/blobstorage/s3/blob_storage.go
@@ -574,18 +574,16 @@ func (s *blobStorageImpl) downloadCSCBObject(ctx context.Context, key string, re
 	for _, chunkIndex := range chunkIndexes {
 		downloads := downloadsByChunk[uint32(chunkIndex)]
 		chunk := downloads[0].chunk
-		chunkPayload, err := s.downloadCSCBChunk(ctx, key, index.Header.Codec, chunk)
+		blocks := make([]*cscb.BlockDescriptor, len(downloads))
+		for i, download := range downloads {
+			blocks[i] = download.block
+		}
+		blockPayloads, err := s.downloadCSCBChunkPayloads(ctx, key, index.Header.Codec, chunk, blocks)
 		if err != nil {
 			return err
 		}
-		if err := cscb.ValidateChunkPayload(chunkPayload, chunk); err != nil {
-			return err
-		}
-		for _, download := range downloads {
-			blockPayload, err := cscb.ExtractBlockPayload(chunkPayload, download.block)
-			if err != nil {
-				return err
-			}
+		for i, download := range downloads {
+			blockPayload := blockPayloads[i]
 			block, err := unmarshalBlockData(s.bucket, key, download.ref.metadata, blockPayload)
 			if err != nil {
 				return err
@@ -618,22 +616,33 @@ func (s *blobStorageImpl) readCSCBIndex(ctx context.Context, key string) (*cscb.
 	return cscb.ParseIndex(indexData)
 }
 
-func (s *blobStorageImpl) downloadCSCBChunk(ctx context.Context, key string, codec api.Compression, chunk *cscb.ChunkDescriptor) ([]byte, error) {
-	compressed, err := s.readObjectRangeByLength(ctx, key, chunk.CompressedPayloadOffset, chunk.CompressedLength)
+func (s *blobStorageImpl) downloadCSCBChunkPayloads(ctx context.Context, key string, codec api.Compression, chunk *cscb.ChunkDescriptor, blocks []*cscb.BlockDescriptor) ([][]byte, error) {
+	if len(blocks) == 0 {
+		return nil, xerrors.New("CSCB block descriptors are required")
+	}
+	body, err := s.openObjectRangeByLength(ctx, key, chunk.CompressedPayloadOffset, chunk.CompressedLength)
 	if err != nil {
 		return nil, err
 	}
-	if uint64(len(compressed)) != chunk.CompressedLength {
-		return nil, xerrors.Errorf("CSCB compressed chunk length mismatch: got %d want %d", len(compressed), chunk.CompressedLength)
-	}
-	decompressed, err := cscb.DecodeChunkFrame(bytes.NewReader(compressed), codec)
+	defer func() { _ = body.Close() }()
+
+	countingBody := &countingReadCloser{ReadCloser: body}
+	limitedBody, err := limitReaderByLength(countingBody, chunk.CompressedLength)
 	if err != nil {
 		return nil, err
 	}
-	return decompressed, nil
+	payloads, err := cscb.ExtractBlockPayloadsFromChunkFrame(limitedBody, codec, chunk, blocks)
+	s.blobStorageMetrics.blobDownloadedSize.Record(time.Duration(countingBody.bytesRead) * time.Millisecond)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, storageerrors.ErrRequestCanceled
+		}
+		return nil, err
+	}
+	return payloads, nil
 }
 
-func (s *blobStorageImpl) readObjectRangeByLength(ctx context.Context, key string, offset uint64, length uint64) ([]byte, error) {
+func (s *blobStorageImpl) openObjectRangeByLength(ctx context.Context, key string, offset uint64, length uint64) (io.ReadCloser, error) {
 	if length == 0 {
 		return nil, xerrors.Errorf("empty range read for key %s at offset %d", key, offset)
 	}
@@ -641,10 +650,31 @@ func (s *blobStorageImpl) readObjectRangeByLength(ctx context.Context, key strin
 	if err != nil {
 		return nil, err
 	}
-	return s.readObjectRange(ctx, key, offset, end)
+	return s.openObjectRange(ctx, key, offset, end)
 }
 
 func (s *blobStorageImpl) readObjectRange(ctx context.Context, key string, start uint64, end uint64) ([]byte, error) {
+	if end < start {
+		return nil, xerrors.Errorf("invalid range for key %s: start=%d end=%d", key, start, end)
+	}
+	body, err := s.openObjectRange(ctx, key, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = body.Close() }()
+	expectedLength := end - start + 1
+	data, err := readExpectedRangeBody(body, expectedLength, start == 0)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, storageerrors.ErrRequestCanceled
+		}
+		return nil, xerrors.Errorf("failed to read s3 range body (bucket=%s, key=%s, range=bytes=%d-%d): %w", s.bucket, key, start, end, err)
+	}
+	s.blobStorageMetrics.blobDownloadedSize.Record(time.Duration(len(data)) * time.Millisecond)
+	return data, nil
+}
+
+func (s *blobStorageImpl) openObjectRange(ctx context.Context, key string, start uint64, end uint64) (io.ReadCloser, error) {
 	if end < start {
 		return nil, xerrors.Errorf("invalid range for key %s: start=%d end=%d", key, start, end)
 	}
@@ -662,15 +692,40 @@ func (s *blobStorageImpl) readObjectRange(ctx context.Context, key string, start
 	if output.Body == nil {
 		return nil, xerrors.Errorf("empty s3 body (bucket=%s, key=%s, range=bytes=%d-%d)", s.bucket, key, start, end)
 	}
-	defer func() { _ = output.Body.Close() }()
-	data, err := io.ReadAll(output.Body)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return nil, storageerrors.ErrRequestCanceled
-		}
-		return nil, xerrors.Errorf("failed to read s3 range body (bucket=%s, key=%s, range=bytes=%d-%d): %w", s.bucket, key, start, end, err)
+	return output.Body, nil
+}
+
+func limitReaderByLength(reader io.Reader, length uint64) (io.Reader, error) {
+	const maxInt64 = uint64(1<<63 - 1)
+	if length >= maxInt64 {
+		return nil, xerrors.Errorf("range body length %d is too large", length)
 	}
-	s.blobStorageMetrics.blobDownloadedSize.Record(time.Duration(len(data)) * time.Millisecond)
+	return io.LimitReader(reader, int64(length)), nil
+}
+
+type countingReadCloser struct {
+	io.ReadCloser
+	bytesRead uint64
+}
+
+func (r *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.bytesRead += uint64(n)
+	return n, err
+}
+
+func readExpectedRangeBody(body io.Reader, expectedLength uint64, allowShort bool) ([]byte, error) {
+	const maxInt64 = uint64(1<<63 - 1)
+	if expectedLength >= maxInt64 {
+		return nil, xerrors.Errorf("range body length %d is too large", expectedLength)
+	}
+	data, err := io.ReadAll(io.LimitReader(body, int64(expectedLength)+1))
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(data)) > expectedLength || (!allowShort && uint64(len(data)) != expectedLength) {
+		return nil, xerrors.Errorf("range body length mismatch: got %d want %d", len(data), expectedLength)
+	}
 	return data, nil
 }
 

--- a/internal/storage/blobstorage/s3/blob_storage_consolidated_test.go
+++ b/internal/storage/blobstorage/s3/blob_storage_consolidated_test.go
@@ -332,6 +332,73 @@ func TestBlobStorage_DownloadManyConsolidatedBlocks_GroupsByObjectAndChunk(t *te
 	assertRangeReadsConsumed(t, expectedRanges)
 }
 
+func TestBlobStorage_DownloadManyConsolidatedBlocks_AllowsDuplicateInputs(t *testing.T) {
+	require := testutil.Require(t)
+	object, metadatas, expectedBlocks, objectData, index := testS3CSCBProtoObject(t)
+	defer object.Close()
+
+	_, chunk, err := index.LookupBlock(metadatas[1])
+	require.NoError(err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	downloader := s3mocks.NewMockDownloader(ctrl)
+	uploader := s3mocks.NewMockUploader(ctrl)
+	client := s3mocks.NewMockClient(ctrl)
+	expectedRanges := map[string]int{
+		"bytes=0-65535":    1,
+		rangeHeader(chunk): 1,
+	}
+	expectRangeReads(t, client, objectData, expectedRanges)
+
+	var storage internal.BlobStorage
+	app := testapp.New(
+		t,
+		testapp.WithBlockchainNetwork(common.Blockchain_BLOCKCHAIN_SOLANA, common.Network_NETWORK_SOLANA_MAINNET),
+		fx.Provide(New),
+		fx.Provide(func() s3.Downloader { return downloader }),
+		fx.Provide(func() s3.Uploader { return uploader }),
+		fx.Provide(func() s3.Client { return client }),
+		fx.Populate(&storage),
+	)
+	defer app.Close()
+
+	actual, err := storage.DownloadMany(context.Background(), []*api.BlockMetadata{
+		metadatas[1],
+		metadatas[1],
+	})
+	require.NoError(err)
+	require.Len(actual, 2)
+	require.True(proto.Equal(expectedBlocks[1], actual[0]))
+	require.True(proto.Equal(expectedBlocks[1], actual[1]))
+	assertRangeReadsConsumed(t, expectedRanges)
+}
+
+func TestReadExpectedRangeBodyAllowsShortInitialRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	actual, err := readExpectedRangeBody(bytes.NewReader([]byte("short")), 64*1024, true)
+	require.NoError(err)
+	require.Equal([]byte("short"), actual)
+}
+
+func TestReadExpectedRangeBodyRejectsShortNonInitialRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	_, err := readExpectedRangeBody(bytes.NewReader([]byte("short")), 10, false)
+	require.Error(err)
+	require.Contains(err.Error(), "range body length mismatch")
+}
+
+func TestReadExpectedRangeBodyRejectsOversizedRead(t *testing.T) {
+	require := testutil.Require(t)
+
+	_, err := readExpectedRangeBody(bytes.NewReader([]byte("too-long")), 3, true)
+	require.Error(err)
+	require.Contains(err.Error(), "range body length mismatch")
+}
+
 func TestBlobStorage_DownloadConsolidatedMetadataWithZeroLengthUsesLegacy(t *testing.T) {
 	require := testutil.Require(t)
 


### PR DESCRIPTION
## Summary
- Linear: https://linear.app/cipherowl/issue/INF-913
- stream CSCB compressed chunk reads to extract only requested block payloads instead of materializing the full decompressed chunk
- apply the same streaming extraction to server-side S3 reads and SDK/downloader reads
- stream the compressed CSCB chunk range body directly into the extractor instead of heap-buffering the compressed chunk
- preserve duplicate CSCB batch inputs by reading each identical payload once and returning it in every requested position
- bound HTTP/S3 range-body reads so chunk range responses cannot silently over-read into memory
- bound the HTTP downloader's initial-index fallback when a non-S3-compatible store ignores `Range` and returns `200 OK`

## Prod evidence
- Solana prod `GetNativeBlock` with `read_source=CONSOLIDATED` for height `427630500` OOM-killed a server pod with exit 137 under the 512 MiB limit.
- The CSCB object chunk for that block is compressed to `11,274,343` bytes but decompresses to `194,008,802` bytes. The requested block payload is `9,168,745` bytes.
- Root cause: the read path decompressed and retained the full chunk before extracting one block, then continued into protobuf/native response allocations.

## Fix details
- `cscb.ExtractBlockPayloadsFromChunkFrame` streams the chunk decompressor, skips to requested block offsets, reads only requested payload bytes, and validates each returned payload with the block CRC.
- Multi-block reads still group by CSCB object/chunk and preserve caller order.
- Duplicate block requests within a batch reuse the validated payload for each original result slot while still rejecting true overlapping ranges.
- HTTP/S3 range readers cap body reads at expected length + 1 and reject oversized or short non-initial ranges. Initial index reads still allow short responses because the first read intentionally probes a fixed maximum prefix.
- HTTP initial-index reads that receive `200 OK` because the store ignored `Range` now read only the bounded prefix instead of failing or buffering the full object.
- CSCB chunk reads use bounded range streams, so memory scales with requested payloads plus decompressor state instead of compressed chunk size plus decompressed chunk size.

## Validation
- Focused test: `PATH="$PATH:$(go env GOPATH)/bin" make test TARGET='internal/storage/blobstorage/cscb/... ./internal/storage/blobstorage/s3/... ./internal/storage/blobstorage/downloader/...'`
- Broader blobstorage test: `go test ./internal/storage/blobstorage/...`
- Prod chunk probe against the exact Solana chunk extracted the `9,168,745` byte target payload with max RSS about `54.6 MB`.

## Rollout note
Do not enable consolidated-first reads in prod until this PR is deployed and the Solana consolidated read retest passes.
