### PR TITLE
test(INF-914): add CSCB dual-read validation harness

### DIFF
--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -592,7 +592,7 @@ func (v *cscbValidator) runCase(ctx context.Context, validationCase cscbValidati
 			result.Passed = false
 			result.MismatchHeights = appendUnique(result.MismatchHeights, comparison.mismatchHeights...)
 		}
-		if i == 0 {
+		if result.CanonicalHashesCompared == 0 && comparison.hashesCompared > 0 {
 			result.CanonicalHashesCompared = comparison.hashesCompared
 			result.FirstCanonicalHashLegacy = comparison.firstLegacyHash
 			result.FirstCanonicalHashCSCB = comparison.firstConsolidatedHash
@@ -704,10 +704,7 @@ func compareCSCBBlocks(legacy []*api.Block, consolidated []*api.Block) cscbBlock
 	for i := range legacy {
 		legacyHash, legacyErr := canonicalBlockHash(legacy[i])
 		consolidatedHash, consolidatedErr := canonicalBlockHash(consolidated[i])
-		height := legacy[i].GetMetadata().GetHeight()
-		if height == 0 {
-			height = consolidated[i].GetMetadata().GetHeight()
-		}
+		height := firstNonZeroHeight(legacy[i], consolidated[i])
 		if comparison.hashesCompared == 0 {
 			comparison.firstLegacyHash = legacyHash
 			comparison.firstConsolidatedHash = consolidatedHash
@@ -725,24 +722,51 @@ func compareCSCBBlocks(legacy []*api.Block, consolidated []*api.Block) cscbBlock
 func collectBlockHeights(blocks []*api.Block) []uint64 {
 	heights := make([]uint64, 0, len(blocks))
 	for _, block := range blocks {
-		heights = append(heights, block.GetMetadata().GetHeight())
+		if height := firstNonZeroHeight(block); height > 0 {
+			heights = append(heights, height)
+		}
 	}
 	return heights
+}
+
+func firstNonZeroHeight(blocks ...*api.Block) uint64 {
+	for _, block := range blocks {
+		if block == nil || block.GetMetadata() == nil {
+			continue
+		}
+		if height := block.GetMetadata().GetHeight(); height > 0 {
+			return height
+		}
+	}
+	return 0
 }
 
 func canonicalBlockHash(block *api.Block) (string, error) {
 	if block == nil {
 		return "", xerrors.New("nil block")
 	}
-	clone := proto.Clone(block).(*api.Block)
-	if clone.Metadata != nil {
-		clone.Metadata.ObjectKeyMain = ""
-		clone.Metadata.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
-		clone.Metadata.ByteOffset = 0
-		clone.Metadata.ByteLength = 0
-		clone.Metadata.UncompressedLength = 0
+	if block.Metadata != nil {
+		originalObjectKeyMain := block.Metadata.ObjectKeyMain
+		originalObjectFormat := block.Metadata.ObjectFormat
+		originalByteOffset := block.Metadata.ByteOffset
+		originalByteLength := block.Metadata.ByteLength
+		originalUncompressedLength := block.Metadata.UncompressedLength
+
+		block.Metadata.ObjectKeyMain = ""
+		block.Metadata.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
+		block.Metadata.ByteOffset = 0
+		block.Metadata.ByteLength = 0
+		block.Metadata.UncompressedLength = 0
+
+		defer func() {
+			block.Metadata.ObjectKeyMain = originalObjectKeyMain
+			block.Metadata.ObjectFormat = originalObjectFormat
+			block.Metadata.ByteOffset = originalByteOffset
+			block.Metadata.ByteLength = originalByteLength
+			block.Metadata.UncompressedLength = originalUncompressedLength
+		}()
 	}
-	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(clone)
+	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(block)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -1,0 +1,999 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/coinbase/chainstorage/internal/gateway"
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+const (
+	defaultCSCBValidationTimeout = 2 * time.Minute
+	defaultCSCBRandomSeed        = int64(914)
+)
+
+var (
+	cscbURLRegexp = regexp.MustCompile(`https?://[^\s,})]+`)
+
+	cscbFlags struct {
+		startHeight          uint64
+		endHeight            uint64
+		tag                  uint32
+		chunkBlocks          uint64
+		randomSamples        int
+		randomSeed           int64
+		iterations           int
+		fullObjectIterations int
+		timeout              time.Duration
+		fallbackHeight       uint64
+		disableFallbackCase  bool
+		serverAddress        string
+		grpc                 bool
+		clientID             string
+		reportJSON           string
+		reportMarkdown       string
+	}
+
+	cscbCmd = &cobra.Command{
+		Use:   "cscb",
+		Short: "CSCB validation utilities",
+	}
+
+	cscbValidateCmd = &cobra.Command{
+		Use:   "validate",
+		Short: "Compare legacy and consolidated CSCB reads and write a validation report.",
+		RunE:  runCSCBValidate,
+	}
+)
+
+type (
+	cscbValidationCase struct {
+		Name           string   `json:"name"`
+		Kind           string   `json:"kind"`
+		StartHeight    uint64   `json:"start_height"`
+		EndHeight      uint64   `json:"end_height"`
+		Heights        []uint64 `json:"heights,omitempty"`
+		ExpectFallback bool     `json:"expect_fallback"`
+		Iterations     int      `json:"iterations"`
+	}
+
+	cscbValidationReport struct {
+		GeneratedAt            string                     `json:"generated_at"`
+		Command                string                     `json:"command"`
+		Environment            string                     `json:"environment"`
+		Blockchain             string                     `json:"blockchain"`
+		Network                string                     `json:"network"`
+		Tag                    uint32                     `json:"tag"`
+		StartHeight            uint64                     `json:"start_height"`
+		EndHeight              uint64                     `json:"end_height"`
+		ChunkBlocks            uint64                     `json:"chunk_blocks"`
+		RandomSeed             int64                      `json:"random_seed"`
+		RandomSamples          int                        `json:"random_samples"`
+		Iterations             int                        `json:"iterations"`
+		FullObjectIterations   int                        `json:"full_object_iterations"`
+		FallbackHeight         uint64                     `json:"fallback_height,omitempty"`
+		ServerAddressOverride  string                     `json:"server_address_override,omitempty"`
+		GRPCTransportOverride  bool                       `json:"grpc_transport_override"`
+		ClientID               string                     `json:"client_id,omitempty"`
+		Passed                 bool                       `json:"passed"`
+		TotalCases             int                        `json:"total_cases"`
+		PassedCases            int                        `json:"passed_cases"`
+		FailedCases            int                        `json:"failed_cases"`
+		CorrectnessMismatches  int                        `json:"correctness_mismatches"`
+		ObservedFallbackBlocks int                        `json:"observed_fallback_blocks"`
+		Cases                  []cscbValidationCaseResult `json:"cases"`
+	}
+
+	cscbValidationCaseResult struct {
+		Name                     string            `json:"name"`
+		Kind                     string            `json:"kind"`
+		StartHeight              uint64            `json:"start_height"`
+		EndHeight                uint64            `json:"end_height"`
+		Heights                  []uint64          `json:"heights,omitempty"`
+		Iterations               int               `json:"iterations"`
+		ExpectFallback           bool              `json:"expect_fallback"`
+		ObservedFallback         bool              `json:"observed_fallback"`
+		ObservedFallbackBlocks   int               `json:"observed_fallback_blocks"`
+		Correct                  bool              `json:"correct"`
+		Passed                   bool              `json:"passed"`
+		Error                    string            `json:"error,omitempty"`
+		MismatchHeights          []uint64          `json:"mismatch_heights,omitempty"`
+		Legacy                   cscbSourceSummary `json:"legacy"`
+		Consolidated             cscbSourceSummary `json:"consolidated"`
+		LatencyRatioConsolidated float64           `json:"latency_ratio_consolidated_vs_legacy,omitempty"`
+		BytesRatioConsolidated   float64           `json:"bytes_ratio_consolidated_vs_legacy,omitempty"`
+		CanonicalHashesCompared  int               `json:"canonical_hashes_compared"`
+		FirstCanonicalHashLegacy string            `json:"first_canonical_hash_legacy,omitempty"`
+		FirstCanonicalHashCSCB   string            `json:"first_canonical_hash_consolidated,omitempty"`
+	}
+
+	cscbSourceSummary struct {
+		Latency    cscbLatencySummary `json:"latency"`
+		HTTP       cscbHTTPSummary    `json:"http"`
+		Files      cscbFileSummary    `json:"files"`
+		ErrorCount int                `json:"error_count"`
+	}
+
+	cscbLatencySummary struct {
+		Samples int     `json:"samples"`
+		P50Ms   float64 `json:"p50_ms"`
+		P95Ms   float64 `json:"p95_ms"`
+		MinMs   float64 `json:"min_ms"`
+		MaxMs   float64 `json:"max_ms"`
+	}
+
+	cscbHTTPSummary struct {
+		Requests int64 `json:"requests"`
+		Bytes    int64 `json:"bytes"`
+	}
+
+	cscbFileSummary struct {
+		Count                     int      `json:"count"`
+		LegacyObjectCount         int      `json:"legacy_object_count"`
+		ConsolidatedObjectCount   int      `json:"consolidated_object_count"`
+		SkippedCount              int      `json:"skipped_count"`
+		MetadataByteLength        uint64   `json:"metadata_byte_length"`
+		MetadataUncompressedBytes uint64   `json:"metadata_uncompressed_bytes"`
+		Formats                   []string `json:"formats"`
+		FirstHeight               uint64   `json:"first_height,omitempty"`
+		LastHeight                uint64   `json:"last_height,omitempty"`
+	}
+
+	cscbFetchResult struct {
+		files    []*api.BlockFile
+		blocks   []*api.Block
+		duration time.Duration
+		http     cscbHTTPSnapshot
+		err      error
+	}
+
+	cscbHTTPSnapshot struct {
+		requests int64
+		bytes    int64
+	}
+
+	cscbCountingHTTPClient struct {
+		base     downloader.HTTPClient
+		requests atomic.Int64
+		bytes    atomic.Int64
+	}
+
+	cscbCountingReadCloser struct {
+		body   io.ReadCloser
+		client *cscbCountingHTTPClient
+	}
+
+	cscbValidator struct {
+		client     gateway.Client
+		downloader downloader.BlockDownloader
+		counter    *cscbCountingHTTPClient
+		tag        uint32
+		timeout    time.Duration
+	}
+)
+
+func init() {
+	cscbValidateCmd.Flags().Uint64Var(&cscbFlags.startHeight, "start-height", 0, "inclusive start height for the CSCB canary object")
+	cscbValidateCmd.Flags().Uint64Var(&cscbFlags.endHeight, "end-height", 0, "exclusive end height for the CSCB canary object")
+	cscbValidateCmd.Flags().Uint32Var(&cscbFlags.tag, "tag", 0, "block tag; 0 uses chainstorage effective stable tag")
+	cscbValidateCmd.Flags().Uint64Var(&cscbFlags.chunkBlocks, "chunk-blocks", 25, "expected CSCB compression chunk size in blocks")
+	cscbValidateCmd.Flags().IntVar(&cscbFlags.randomSamples, "random-samples", 5, "number of deterministic random single-block samples")
+	cscbValidateCmd.Flags().Int64Var(&cscbFlags.randomSeed, "random-seed", defaultCSCBRandomSeed, "random seed for single-block sample selection")
+	cscbValidateCmd.Flags().IntVar(&cscbFlags.iterations, "iterations", 3, "iterations for non-full-object cases")
+	cscbValidateCmd.Flags().IntVar(&cscbFlags.fullObjectIterations, "full-object-iterations", 1, "iterations for the full-object range case")
+	cscbValidateCmd.Flags().DurationVar(&cscbFlags.timeout, "timeout", defaultCSCBValidationTimeout, "timeout for each source read")
+	cscbValidateCmd.Flags().Uint64Var(&cscbFlags.fallbackHeight, "fallback-height", 0, "height expected to miss consolidated metadata; defaults to start-height - 1 when possible")
+	cscbValidateCmd.Flags().BoolVar(&cscbFlags.disableFallbackCase, "disable-fallback-case", false, "skip the consolidated miss/fallback case")
+	cscbValidateCmd.Flags().StringVar(&cscbFlags.serverAddress, "server-address", "", "override Chainstorage SDK server address for this run")
+	cscbValidateCmd.Flags().BoolVar(&cscbFlags.grpc, "grpc", false, "force gRPC SDK transport; useful with a verified localhost port-forward")
+	cscbValidateCmd.Flags().StringVar(&cscbFlags.clientID, "client-id", "INF-914-cscb-dual-read-validation", "client ID header for server-side metrics/logs")
+	cscbValidateCmd.Flags().StringVar(&cscbFlags.reportJSON, "report-json", "", "write JSON report to this path")
+	cscbValidateCmd.Flags().StringVar(&cscbFlags.reportMarkdown, "report-md", "", "write Markdown report to this path")
+
+	if err := cscbValidateCmd.MarkFlagRequired("start-height"); err != nil {
+		panic(err)
+	}
+	if err := cscbValidateCmd.MarkFlagRequired("end-height"); err != nil {
+		panic(err)
+	}
+
+	cscbCmd.AddCommand(cscbValidateCmd)
+	rootCmd.AddCommand(cscbCmd)
+}
+
+func runCSCBValidate(cmd *cobra.Command, args []string) error {
+	if cscbFlags.startHeight >= cscbFlags.endHeight {
+		return xerrors.New("start-height must be less than end-height")
+	}
+	if cscbFlags.chunkBlocks == 0 {
+		return xerrors.New("chunk-blocks must be positive")
+	}
+	if cscbFlags.randomSamples < 0 {
+		return xerrors.New("random-samples cannot be negative")
+	}
+	if cscbFlags.iterations <= 0 {
+		return xerrors.New("iterations must be positive")
+	}
+	if cscbFlags.fullObjectIterations <= 0 {
+		return xerrors.New("full-object-iterations must be positive")
+	}
+	if cscbFlags.timeout <= 0 {
+		return xerrors.New("timeout must be positive")
+	}
+	if cscbFlags.serverAddress != "" {
+		if err := os.Setenv("CHAINSTORAGE_SDK_CHAINSTORAGE_ADDRESS", cscbFlags.serverAddress); err != nil {
+			return xerrors.Errorf("failed to set server address override: %w", err)
+		}
+	}
+	if cscbFlags.grpc {
+		if err := os.Setenv("CHAINSTORAGE_SDK_RESTFUL", "false"); err != nil {
+			return xerrors.Errorf("failed to set gRPC transport override: %w", err)
+		}
+	}
+
+	counter := newCSCBCountingHTTPClient(downloader.NewHTTPClient())
+	var deps struct {
+		fx.In
+		Client     gateway.Client
+		Downloader downloader.BlockDownloader
+	}
+	app := startApp(
+		fx.Provide(func() downloader.HTTPClient { return counter }),
+		fx.Provide(downloader.NewBlockDownloader),
+		gateway.WithClientID(cscbFlags.clientID),
+		fx.Populate(&deps),
+	)
+	defer app.Close()
+
+	tag := app.Config().GetEffectiveBlockTag(cscbFlags.tag)
+	validator := &cscbValidator{
+		client:     deps.Client,
+		downloader: deps.Downloader,
+		counter:    counter,
+		tag:        tag,
+		timeout:    cscbFlags.timeout,
+	}
+	report, validationErr := validator.run(cmd.Context(), cscbValidationRunConfig{
+		startHeight:          cscbFlags.startHeight,
+		endHeight:            cscbFlags.endHeight,
+		chunkBlocks:          cscbFlags.chunkBlocks,
+		randomSamples:        cscbFlags.randomSamples,
+		randomSeed:           cscbFlags.randomSeed,
+		iterations:           cscbFlags.iterations,
+		fullObjectIterations: cscbFlags.fullObjectIterations,
+		fallbackHeight:       cscbFlags.fallbackHeight,
+		disableFallbackCase:  cscbFlags.disableFallbackCase,
+		serverAddress:        cscbFlags.serverAddress,
+		grpc:                 cscbFlags.grpc,
+		clientID:             cscbFlags.clientID,
+	})
+	report.Command = strings.Join(os.Args, " ")
+	report.Environment = string(env)
+	report.Blockchain = blockchain.String()
+	report.Network = network.String()
+
+	if cscbFlags.reportJSON != "" {
+		if err := writeCSCBJSONReport(cscbFlags.reportJSON, report); err != nil {
+			return err
+		}
+	}
+	if cscbFlags.reportMarkdown != "" {
+		if err := writeCSCBMarkdownReport(cscbFlags.reportMarkdown, report); err != nil {
+			return err
+		}
+	}
+	if validationErr != nil {
+		return validationErr
+	}
+	if !report.Passed {
+		return xerrors.Errorf("CSCB validation failed: %d failed cases, %d mismatch heights", report.FailedCases, report.CorrectnessMismatches)
+	}
+	return nil
+}
+
+type cscbValidationRunConfig struct {
+	startHeight          uint64
+	endHeight            uint64
+	chunkBlocks          uint64
+	randomSamples        int
+	randomSeed           int64
+	iterations           int
+	fullObjectIterations int
+	fallbackHeight       uint64
+	disableFallbackCase  bool
+	serverAddress        string
+	grpc                 bool
+	clientID             string
+}
+
+func (v *cscbValidator) run(ctx context.Context, cfg cscbValidationRunConfig) (*cscbValidationReport, error) {
+	fallbackHeight := cfg.fallbackHeight
+	if fallbackHeight == 0 && cfg.startHeight > 0 {
+		fallbackHeight = cfg.startHeight - 1
+	}
+	cases := buildCSCBValidationCases(cfg, fallbackHeight)
+
+	report := &cscbValidationReport{
+		GeneratedAt:           time.Now().UTC().Format(time.RFC3339),
+		Tag:                   v.tag,
+		StartHeight:           cfg.startHeight,
+		EndHeight:             cfg.endHeight,
+		ChunkBlocks:           cfg.chunkBlocks,
+		RandomSeed:            cfg.randomSeed,
+		RandomSamples:         cfg.randomSamples,
+		Iterations:            cfg.iterations,
+		FullObjectIterations:  cfg.fullObjectIterations,
+		FallbackHeight:        fallbackHeight,
+		ServerAddressOverride: cfg.serverAddress,
+		GRPCTransportOverride: cfg.grpc,
+		ClientID:              cfg.clientID,
+		TotalCases:            len(cases),
+	}
+
+	for _, validationCase := range cases {
+		result := v.runCase(ctx, validationCase)
+		report.Cases = append(report.Cases, result)
+		if result.Passed {
+			report.PassedCases++
+		} else {
+			report.FailedCases++
+		}
+		report.CorrectnessMismatches += len(result.MismatchHeights)
+		report.ObservedFallbackBlocks += result.ObservedFallbackBlocks
+	}
+	report.Passed = report.FailedCases == 0
+	return report, nil
+}
+
+func buildCSCBValidationCases(cfg cscbValidationRunConfig, fallbackHeight uint64) []cscbValidationCase {
+	cases := []cscbValidationCase{
+		{
+			Name:        "single_first_block",
+			Kind:        "single",
+			StartHeight: cfg.startHeight,
+			EndHeight:   cfg.startHeight + 1,
+			Heights:     []uint64{cfg.startHeight},
+			Iterations:  cfg.iterations,
+		},
+		{
+			Name:        "single_last_block",
+			Kind:        "single",
+			StartHeight: cfg.endHeight - 1,
+			EndHeight:   cfg.endHeight,
+			Heights:     []uint64{cfg.endHeight - 1},
+			Iterations:  cfg.iterations,
+		},
+	}
+
+	for _, height := range chunkBoundaryHeights(cfg.startHeight, cfg.endHeight, cfg.chunkBlocks) {
+		cases = append(cases, cscbValidationCase{
+			Name:        fmt.Sprintf("single_chunk_boundary_%d", height),
+			Kind:        "single",
+			StartHeight: height,
+			EndHeight:   height + 1,
+			Heights:     []uint64{height},
+			Iterations:  cfg.iterations,
+		})
+	}
+
+	for _, height := range randomSampleHeights(cfg.startHeight, cfg.endHeight, cfg.randomSamples, cfg.randomSeed) {
+		cases = append(cases, cscbValidationCase{
+			Name:        fmt.Sprintf("single_random_%d", height),
+			Kind:        "single",
+			StartHeight: height,
+			EndHeight:   height + 1,
+			Heights:     []uint64{height},
+			Iterations:  cfg.iterations,
+		})
+	}
+
+	withinStart := boundedHeight(cfg.startHeight+5, cfg.startHeight, cfg.endHeight-1)
+	withinEnd := boundedHeight(withinStart+10, withinStart+1, cfg.endHeight)
+	cases = append(cases, cscbValidationCase{
+		Name:        "range_within_one_chunk",
+		Kind:        "range",
+		StartHeight: withinStart,
+		EndHeight:   withinEnd,
+		Iterations:  cfg.iterations,
+	})
+
+	boundary := cfg.startHeight + cfg.chunkBlocks
+	if boundary <= cfg.startHeight || boundary >= cfg.endHeight {
+		boundary = cfg.startHeight + (cfg.endHeight-cfg.startHeight)/2
+	}
+	acrossStart := boundedHeight(boundary-5, cfg.startHeight, cfg.endHeight-1)
+	acrossEnd := boundedHeight(boundary+5, acrossStart+1, cfg.endHeight)
+	cases = append(cases, cscbValidationCase{
+		Name:        "range_across_chunk_boundary",
+		Kind:        "range",
+		StartHeight: acrossStart,
+		EndHeight:   acrossEnd,
+		Iterations:  cfg.iterations,
+	})
+
+	twoChunkEnd := boundedHeight(cfg.startHeight+2*cfg.chunkBlocks, cfg.startHeight+1, cfg.endHeight)
+	cases = append(cases, cscbValidationCase{
+		Name:        "range_two_chunks",
+		Kind:        "range",
+		StartHeight: cfg.startHeight,
+		EndHeight:   twoChunkEnd,
+		Iterations:  cfg.iterations,
+	})
+
+	cases = append(cases, cscbValidationCase{
+		Name:        "range_full_object",
+		Kind:        "range",
+		StartHeight: cfg.startHeight,
+		EndHeight:   cfg.endHeight,
+		Iterations:  cfg.fullObjectIterations,
+	})
+
+	if !cfg.disableFallbackCase && fallbackHeight > 0 {
+		cases = append(cases, cscbValidationCase{
+			Name:           "single_consolidated_miss_fallback",
+			Kind:           "single",
+			StartHeight:    fallbackHeight,
+			EndHeight:      fallbackHeight + 1,
+			Heights:        []uint64{fallbackHeight},
+			ExpectFallback: true,
+			Iterations:     cfg.iterations,
+		})
+	}
+
+	return cases
+}
+
+func chunkBoundaryHeights(startHeight uint64, endHeight uint64, chunkBlocks uint64) []uint64 {
+	if chunkBlocks == 0 || endHeight <= startHeight+1 {
+		return nil
+	}
+	candidates := make([]uint64, 0, 6)
+	for boundary := startHeight + chunkBlocks; boundary < endHeight && len(candidates) < 6; boundary += chunkBlocks {
+		if boundary > startHeight {
+			candidates = append(candidates, boundary-1)
+		}
+		candidates = append(candidates, boundary)
+	}
+	return uniqueSortedHeights(candidates, startHeight, endHeight)
+}
+
+func randomSampleHeights(startHeight uint64, endHeight uint64, samples int, seed int64) []uint64 {
+	if samples <= 0 || endHeight <= startHeight {
+		return nil
+	}
+	span := endHeight - startHeight
+	if uint64(samples) >= span {
+		heights := make([]uint64, 0, span)
+		for height := startHeight; height < endHeight; height++ {
+			heights = append(heights, height)
+		}
+		return heights
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+	seen := make(map[uint64]struct{}, samples)
+	for len(seen) < samples {
+		height := startHeight + uint64(rng.Int63n(int64(span)))
+		seen[height] = struct{}{}
+	}
+
+	heights := make([]uint64, 0, len(seen))
+	for height := range seen {
+		heights = append(heights, height)
+	}
+	sort.Slice(heights, func(i int, j int) bool { return heights[i] < heights[j] })
+	return heights
+}
+
+func uniqueSortedHeights(heights []uint64, startHeight uint64, endHeight uint64) []uint64 {
+	seen := make(map[uint64]struct{}, len(heights))
+	for _, height := range heights {
+		if height < startHeight || height >= endHeight {
+			continue
+		}
+		seen[height] = struct{}{}
+	}
+	out := make([]uint64, 0, len(seen))
+	for height := range seen {
+		out = append(out, height)
+	}
+	sort.Slice(out, func(i int, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func boundedHeight(value uint64, min uint64, max uint64) uint64 {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func (v *cscbValidator) runCase(ctx context.Context, validationCase cscbValidationCase) cscbValidationCaseResult {
+	result := cscbValidationCaseResult{
+		Name:           validationCase.Name,
+		Kind:           validationCase.Kind,
+		StartHeight:    validationCase.StartHeight,
+		EndHeight:      validationCase.EndHeight,
+		Heights:        validationCase.Heights,
+		Iterations:     validationCase.Iterations,
+		ExpectFallback: validationCase.ExpectFallback,
+		Correct:        true,
+		Passed:         true,
+	}
+
+	var legacyDurations []time.Duration
+	var consolidatedDurations []time.Duration
+	var legacyRequests int64
+	var legacyBytes int64
+	var consolidatedRequests int64
+	var consolidatedBytes int64
+
+	for i := 0; i < validationCase.Iterations; i++ {
+		legacy := v.fetch(ctx, validationCase, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
+		consolidated := v.fetch(ctx, validationCase, api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED)
+
+		if legacy.err != nil {
+			result.Legacy.ErrorCount++
+			result.Error = appendResultError(result.Error, "legacy", legacy.err)
+		} else {
+			legacyDurations = append(legacyDurations, legacy.duration)
+			legacyRequests += legacy.http.requests
+			legacyBytes += legacy.http.bytes
+			if result.Legacy.Files.Count == 0 {
+				result.Legacy.Files = summarizeCSCBFiles(legacy.files)
+			}
+		}
+
+		if consolidated.err != nil {
+			result.Consolidated.ErrorCount++
+			result.Error = appendResultError(result.Error, "consolidated", consolidated.err)
+		} else {
+			consolidatedDurations = append(consolidatedDurations, consolidated.duration)
+			consolidatedRequests += consolidated.http.requests
+			consolidatedBytes += consolidated.http.bytes
+			if result.Consolidated.Files.Count == 0 {
+				result.Consolidated.Files = summarizeCSCBFiles(consolidated.files)
+			}
+		}
+
+		if legacy.err != nil || consolidated.err != nil {
+			result.Correct = false
+			result.Passed = false
+			continue
+		}
+
+		comparison := compareCSCBBlocks(legacy.blocks, consolidated.blocks)
+		if !comparison.correct {
+			result.Correct = false
+			result.Passed = false
+			result.MismatchHeights = appendUnique(result.MismatchHeights, comparison.mismatchHeights...)
+		}
+		if i == 0 {
+			result.CanonicalHashesCompared = comparison.hashesCompared
+			result.FirstCanonicalHashLegacy = comparison.firstLegacyHash
+			result.FirstCanonicalHashCSCB = comparison.firstConsolidatedHash
+		}
+	}
+
+	result.Legacy.Latency = summarizeDurations(legacyDurations)
+	result.Consolidated.Latency = summarizeDurations(consolidatedDurations)
+	result.Legacy.HTTP = cscbHTTPSummary{Requests: legacyRequests, Bytes: legacyBytes}
+	result.Consolidated.HTTP = cscbHTTPSummary{Requests: consolidatedRequests, Bytes: consolidatedBytes}
+	result.ObservedFallbackBlocks = result.Consolidated.Files.LegacyObjectCount
+	result.ObservedFallback = result.ObservedFallbackBlocks > 0
+	if validationCase.ExpectFallback && !result.ObservedFallback {
+		result.Passed = false
+		result.Error = appendResultErrorString(result.Error, "expected consolidated read to fall back to legacy metadata")
+	}
+	if !validationCase.ExpectFallback && result.ObservedFallback {
+		result.Passed = false
+		result.Error = appendResultErrorString(result.Error, "unexpected consolidated fallback to legacy metadata")
+	}
+	result.LatencyRatioConsolidated = ratio(result.Consolidated.Latency.P50Ms, result.Legacy.Latency.P50Ms)
+	result.BytesRatioConsolidated = ratio(float64(result.Consolidated.HTTP.Bytes), float64(result.Legacy.HTTP.Bytes))
+	return result
+}
+
+func (v *cscbValidator) fetch(ctx context.Context, validationCase cscbValidationCase, readSource api.BlockReadSource) cscbFetchResult {
+	ctx, cancel := context.WithTimeout(ctx, v.timeout)
+	defer cancel()
+
+	v.counter.Reset()
+	start := time.Now()
+	files, err := v.getFiles(ctx, validationCase, readSource)
+	if err != nil {
+		return cscbFetchResult{duration: time.Since(start), http: v.counter.Snapshot(), err: err}
+	}
+	blocks, err := v.downloadFiles(ctx, files)
+	return cscbFetchResult{
+		files:    files,
+		blocks:   blocks,
+		duration: time.Since(start),
+		http:     v.counter.Snapshot(),
+		err:      err,
+	}
+}
+
+func (v *cscbValidator) getFiles(ctx context.Context, validationCase cscbValidationCase, readSource api.BlockReadSource) ([]*api.BlockFile, error) {
+	if validationCase.Kind == "single" {
+		resp, err := v.client.GetBlockFile(ctx, &api.GetBlockFileRequest{
+			Tag:        v.tag,
+			Height:     validationCase.StartHeight,
+			ReadSource: readSource,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("GetBlockFile failed: %w", err)
+		}
+		if resp.GetFile() == nil {
+			return nil, xerrors.New("GetBlockFile returned nil file")
+		}
+		return []*api.BlockFile{resp.GetFile()}, nil
+	}
+
+	resp, err := v.client.GetBlockFilesByRange(ctx, &api.GetBlockFilesByRangeRequest{
+		Tag:         v.tag,
+		StartHeight: validationCase.StartHeight,
+		EndHeight:   validationCase.EndHeight,
+		ReadSource:  readSource,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("GetBlockFilesByRange failed: %w", err)
+	}
+	if len(resp.GetFiles()) == 0 {
+		return nil, xerrors.New("GetBlockFilesByRange returned no files")
+	}
+	return resp.GetFiles(), nil
+}
+
+func (v *cscbValidator) downloadFiles(ctx context.Context, files []*api.BlockFile) ([]*api.Block, error) {
+	if len(files) == 1 {
+		block, err := v.downloader.Download(ctx, files[0])
+		if err != nil {
+			return nil, xerrors.Errorf("Download failed: %w", err)
+		}
+		return []*api.Block{block}, nil
+	}
+	blocks, err := v.downloader.DownloadMany(ctx, files)
+	if err != nil {
+		return nil, xerrors.Errorf("DownloadMany failed: %w", err)
+	}
+	return blocks, nil
+}
+
+type cscbBlockComparison struct {
+	correct               bool
+	mismatchHeights       []uint64
+	hashesCompared        int
+	firstLegacyHash       string
+	firstConsolidatedHash string
+}
+
+func compareCSCBBlocks(legacy []*api.Block, consolidated []*api.Block) cscbBlockComparison {
+	comparison := cscbBlockComparison{correct: true}
+	if len(legacy) != len(consolidated) {
+		comparison.correct = false
+		comparison.mismatchHeights = append(comparison.mismatchHeights, collectBlockHeights(legacy)...)
+		comparison.mismatchHeights = append(comparison.mismatchHeights, collectBlockHeights(consolidated)...)
+		comparison.mismatchHeights = uniqueSortedHeights(comparison.mismatchHeights, 0, ^uint64(0))
+		return comparison
+	}
+	for i := range legacy {
+		legacyHash, legacyErr := canonicalBlockHash(legacy[i])
+		consolidatedHash, consolidatedErr := canonicalBlockHash(consolidated[i])
+		height := legacy[i].GetMetadata().GetHeight()
+		if height == 0 {
+			height = consolidated[i].GetMetadata().GetHeight()
+		}
+		if comparison.hashesCompared == 0 {
+			comparison.firstLegacyHash = legacyHash
+			comparison.firstConsolidatedHash = consolidatedHash
+		}
+		comparison.hashesCompared++
+		if legacyErr != nil || consolidatedErr != nil || legacyHash != consolidatedHash {
+			comparison.correct = false
+			comparison.mismatchHeights = append(comparison.mismatchHeights, height)
+		}
+	}
+	comparison.mismatchHeights = uniqueSortedHeights(comparison.mismatchHeights, 0, ^uint64(0))
+	return comparison
+}
+
+func collectBlockHeights(blocks []*api.Block) []uint64 {
+	heights := make([]uint64, 0, len(blocks))
+	for _, block := range blocks {
+		heights = append(heights, block.GetMetadata().GetHeight())
+	}
+	return heights
+}
+
+func canonicalBlockHash(block *api.Block) (string, error) {
+	if block == nil {
+		return "", xerrors.New("nil block")
+	}
+	clone := proto.Clone(block).(*api.Block)
+	if clone.Metadata != nil {
+		clone.Metadata.ObjectKeyMain = ""
+		clone.Metadata.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
+		clone.Metadata.ByteOffset = 0
+		clone.Metadata.ByteLength = 0
+		clone.Metadata.UncompressedLength = 0
+	}
+	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(clone)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func summarizeDurations(durations []time.Duration) cscbLatencySummary {
+	if len(durations) == 0 {
+		return cscbLatencySummary{}
+	}
+	sorted := append([]time.Duration(nil), durations...)
+	sort.Slice(sorted, func(i int, j int) bool { return sorted[i] < sorted[j] })
+	return cscbLatencySummary{
+		Samples: len(sorted),
+		P50Ms:   durationMillis(percentileDuration(sorted, 0.50)),
+		P95Ms:   durationMillis(percentileDuration(sorted, 0.95)),
+		MinMs:   durationMillis(sorted[0]),
+		MaxMs:   durationMillis(sorted[len(sorted)-1]),
+	}
+}
+
+func percentileDuration(sorted []time.Duration, percentile float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if percentile <= 0 {
+		return sorted[0]
+	}
+	if percentile >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}
+
+func durationMillis(duration time.Duration) float64 {
+	return float64(duration.Microseconds()) / 1000
+}
+
+func summarizeCSCBFiles(files []*api.BlockFile) cscbFileSummary {
+	summary := cscbFileSummary{Count: len(files)}
+	formats := make(map[string]struct{})
+	for i, file := range files {
+		if i == 0 {
+			summary.FirstHeight = file.GetHeight()
+		}
+		summary.LastHeight = file.GetHeight()
+		if file.GetSkipped() {
+			summary.SkippedCount++
+		}
+		if isCSCBFile(file) {
+			summary.ConsolidatedObjectCount++
+		} else {
+			summary.LegacyObjectCount++
+		}
+		summary.MetadataByteLength += file.GetByteLength()
+		summary.MetadataUncompressedBytes += file.GetUncompressedLength()
+		formats[file.GetObjectFormat().String()] = struct{}{}
+	}
+	for format := range formats {
+		summary.Formats = append(summary.Formats, format)
+	}
+	sort.Strings(summary.Formats)
+	return summary
+}
+
+func isCSCBFile(file *api.BlockFile) bool {
+	return file.GetObjectFormat() == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH && file.GetByteLength() > 0
+}
+
+func appendUnique(existing []uint64, additions ...uint64) []uint64 {
+	seen := make(map[uint64]struct{}, len(existing)+len(additions))
+	for _, value := range existing {
+		seen[value] = struct{}{}
+	}
+	for _, value := range additions {
+		seen[value] = struct{}{}
+	}
+	out := make([]uint64, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i int, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func appendResultError(existing string, source string, err error) string {
+	return appendResultErrorString(existing, fmt.Sprintf("%s: %s", source, sanitizeCSCBError(err)))
+}
+
+func appendResultErrorString(existing string, message string) string {
+	if existing == "" {
+		return message
+	}
+	return existing + "; " + message
+}
+
+func sanitizeCSCBError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return sanitizeCSCBString(err.Error())
+}
+
+func sanitizeCSCBString(value string) string {
+	return cscbURLRegexp.ReplaceAllString(value, "<redacted-url>")
+}
+
+func ratio(numerator float64, denominator float64) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return numerator / denominator
+}
+
+func newCSCBCountingHTTPClient(base downloader.HTTPClient) *cscbCountingHTTPClient {
+	return &cscbCountingHTTPClient{base: base}
+}
+
+func (c *cscbCountingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requests.Add(1)
+	resp, err := c.base.Do(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		return resp, err
+	}
+	resp.Body = &cscbCountingReadCloser{body: resp.Body, client: c}
+	return resp, nil
+}
+
+func (c *cscbCountingHTTPClient) Reset() {
+	c.requests.Store(0)
+	c.bytes.Store(0)
+}
+
+func (c *cscbCountingHTTPClient) Snapshot() cscbHTTPSnapshot {
+	return cscbHTTPSnapshot{
+		requests: c.requests.Load(),
+		bytes:    c.bytes.Load(),
+	}
+}
+
+func (r *cscbCountingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.body.Read(p)
+	if n > 0 {
+		r.client.bytes.Add(int64(n))
+	}
+	return n, err
+}
+
+func (r *cscbCountingReadCloser) Close() error {
+	return r.body.Close()
+}
+
+func writeCSCBJSONReport(path string, report *cscbValidationReport) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return xerrors.Errorf("failed to create report directory: %w", err)
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to marshal JSON report: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return xerrors.Errorf("failed to write JSON report: %w", err)
+	}
+	return nil
+}
+
+func writeCSCBMarkdownReport(path string, report *cscbValidationReport) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return xerrors.Errorf("failed to create report directory: %w", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# CSCB Dual-Read Validation Report\n\n")
+	fmt.Fprintf(&b, "- generated_at: `%s`\n", report.GeneratedAt)
+	fmt.Fprintf(&b, "- target: `%s/%s/%s`\n", report.Environment, report.Blockchain, report.Network)
+	fmt.Fprintf(&b, "- tag: `%d`\n", report.Tag)
+	fmt.Fprintf(&b, "- canary_range: `[%d, %d)`\n", report.StartHeight, report.EndHeight)
+	fmt.Fprintf(&b, "- chunk_blocks: `%d`\n", report.ChunkBlocks)
+	if report.ServerAddressOverride != "" {
+		fmt.Fprintf(&b, "- server_address_override: `%s`\n", report.ServerAddressOverride)
+	}
+	fmt.Fprintf(&b, "- grpc_transport_override: `%t`\n", report.GRPCTransportOverride)
+	if report.ClientID != "" {
+		fmt.Fprintf(&b, "- client_id: `%s`\n", report.ClientID)
+	}
+	fmt.Fprintf(&b, "- passed: `%t`\n", report.Passed)
+	fmt.Fprintf(&b, "- cases: `%d passed / %d total`\n", report.PassedCases, report.TotalCases)
+	fmt.Fprintf(&b, "- mismatch_heights: `%d`\n", report.CorrectnessMismatches)
+	fmt.Fprintf(&b, "- observed_fallback_blocks: `%d`\n\n", report.ObservedFallbackBlocks)
+
+	fmt.Fprintf(&b, "## Case Results\n\n")
+	fmt.Fprintf(&b, "| case | range | pass | fallback | legacy p50/p95 ms | consolidated p50/p95 ms | legacy bytes | consolidated bytes | mismatches |\n")
+	fmt.Fprintf(&b, "|---|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	for _, c := range report.Cases {
+		fmt.Fprintf(
+			&b,
+			"| %s | `[%d,%d)` | %t | %t | %.2f / %.2f | %.2f / %.2f | %d | %d | %s |\n",
+			c.Name,
+			c.StartHeight,
+			c.EndHeight,
+			c.Passed,
+			c.ObservedFallback,
+			c.Legacy.Latency.P50Ms,
+			c.Legacy.Latency.P95Ms,
+			c.Consolidated.Latency.P50Ms,
+			c.Consolidated.Latency.P95Ms,
+			c.Legacy.HTTP.Bytes,
+			c.Consolidated.HTTP.Bytes,
+			formatHeights(c.MismatchHeights),
+		)
+	}
+
+	fmt.Fprintf(&b, "\n## Source Summary\n\n")
+	for _, c := range report.Cases {
+		if c.Error != "" {
+			fmt.Fprintf(&b, "### %s\n\nerror: `%s`\n\n", c.Name, c.Error)
+			continue
+		}
+		fmt.Fprintf(&b, "### %s\n\n", c.Name)
+		fmt.Fprintf(&b, "- legacy files: `%d`, formats: `%s`, HTTP requests: `%d`, bytes: `%d`\n",
+			c.Legacy.Files.Count,
+			strings.Join(c.Legacy.Files.Formats, ","),
+			c.Legacy.HTTP.Requests,
+			c.Legacy.HTTP.Bytes,
+		)
+		fmt.Fprintf(&b, "- consolidated files: `%d`, formats: `%s`, HTTP requests: `%d`, bytes: `%d`\n",
+			c.Consolidated.Files.Count,
+			strings.Join(c.Consolidated.Files.Formats, ","),
+			c.Consolidated.HTTP.Requests,
+			c.Consolidated.HTTP.Bytes,
+		)
+		fmt.Fprintf(&b, "- canonical hashes compared: `%d`\n\n", c.CanonicalHashesCompared)
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func formatHeights(heights []uint64) string {
+	if len(heights) == 0 {
+		return ""
+	}
+	values := make([]string, len(heights))
+	for i, height := range heights {
+		values[i] = fmt.Sprintf("%d", height)
+	}
+	return strings.Join(values, ",")
+}

--- a/cmd/admin/cscb_validate_test.go
+++ b/cmd/admin/cscb_validate_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+func TestBuildCSCBValidationCasesIncludesRequiredCoverage(t *testing.T) {
+	require := require.New(t)
+	cfg := cscbValidationRunConfig{
+		startHeight:          1000,
+		endHeight:            1100,
+		chunkBlocks:          25,
+		randomSamples:        2,
+		randomSeed:           914,
+		iterations:           3,
+		fullObjectIterations: 1,
+	}
+
+	cases := buildCSCBValidationCases(cfg, 999)
+	names := make(map[string]cscbValidationCase, len(cases))
+	for _, validationCase := range cases {
+		names[validationCase.Name] = validationCase
+	}
+
+	require.Contains(names, "single_first_block")
+	require.Contains(names, "single_last_block")
+	require.Contains(names, "range_within_one_chunk")
+	require.Contains(names, "range_across_chunk_boundary")
+	require.Contains(names, "range_full_object")
+	require.Contains(names, "single_consolidated_miss_fallback")
+	require.True(names["single_consolidated_miss_fallback"].ExpectFallback)
+	require.Equal(1, names["range_full_object"].Iterations)
+	require.Equal(3, names["range_across_chunk_boundary"].Iterations)
+	require.NotEmpty(chunkBoundaryHeights(1000, 1100, 25))
+	require.Len(randomSampleHeights(1000, 1100, 2, 914), 2)
+}
+
+func TestCompareCSCBBlocksIgnoresSourceSpecificMetadata(t *testing.T) {
+	require := require.New(t)
+	legacy := &api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:           1,
+			Height:        42,
+			Hash:          "hash",
+			ParentHash:    "parent",
+			ObjectKeyMain: "legacy/object",
+		},
+	}
+	consolidated := &api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:                1,
+			Height:             42,
+			Hash:               "hash",
+			ParentHash:         "parent",
+			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:         1024,
+			ByteLength:         2048,
+			UncompressedLength: 4096,
+		},
+	}
+
+	comparison := compareCSCBBlocks([]*api.Block{legacy}, []*api.Block{consolidated})
+	require.True(comparison.correct)
+	require.Empty(comparison.mismatchHeights)
+	require.Equal(1, comparison.hashesCompared)
+	require.Equal(comparison.firstLegacyHash, comparison.firstConsolidatedHash)
+}
+
+func TestCompareCSCBBlocksDetectsMismatch(t *testing.T) {
+	require := require.New(t)
+	legacy := &api.Block{
+		Metadata: &api.BlockMetadata{Height: 42, Hash: "hash"},
+	}
+	consolidated := &api.Block{
+		Metadata: &api.BlockMetadata{Height: 42, Hash: "different"},
+	}
+
+	comparison := compareCSCBBlocks([]*api.Block{legacy}, []*api.Block{consolidated})
+	require.False(comparison.correct)
+	require.Equal([]uint64{42}, comparison.mismatchHeights)
+}
+
+func TestSummarizeDurationsUsesNearestRankPercentile(t *testing.T) {
+	require := require.New(t)
+	summary := summarizeDurations([]time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		30 * time.Millisecond,
+		40 * time.Millisecond,
+		50 * time.Millisecond,
+	})
+
+	require.Equal(5, summary.Samples)
+	require.Equal(float64(30), summary.P50Ms)
+	require.Equal(float64(50), summary.P95Ms)
+	require.Equal(float64(10), summary.MinMs)
+	require.Equal(float64(50), summary.MaxMs)
+}
+
+func TestSanitizeCSCBStringRedactsEmbeddedURLs(t *testing.T) {
+	require := require.New(t)
+	errText := `Download failed: blockFile={FileUrl:"https://bucket.s3.amazonaws.com/key?X-Amz-Signature=secret", Height:42}`
+
+	sanitized := sanitizeCSCBString(errText)
+	require.NotContains(sanitized, "X-Amz-Signature")
+	require.NotContains(sanitized, "secret")
+	require.Contains(sanitized, "<redacted-url>")
+}

--- a/cmd/admin/cscb_validate_test.go
+++ b/cmd/admin/cscb_validate_test.go
@@ -85,6 +85,40 @@ func TestCompareCSCBBlocksDetectsMismatch(t *testing.T) {
 	require.Equal([]uint64{42}, comparison.mismatchHeights)
 }
 
+func TestCompareCSCBBlocksHandlesNilBlocks(t *testing.T) {
+	require := require.New(t)
+	consolidated := &api.Block{
+		Metadata: &api.BlockMetadata{Height: 42, Hash: "hash"},
+	}
+
+	comparison := compareCSCBBlocks([]*api.Block{nil}, []*api.Block{consolidated})
+	require.False(comparison.correct)
+	require.Equal([]uint64{42}, comparison.mismatchHeights)
+}
+
+func TestCanonicalBlockHashRestoresMetadata(t *testing.T) {
+	require := require.New(t)
+	block := &api.Block{
+		Metadata: &api.BlockMetadata{
+			Height:             42,
+			Hash:               "hash",
+			ObjectKeyMain:      "consolidated/object",
+			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:         10,
+			ByteLength:         20,
+			UncompressedLength: 30,
+		},
+	}
+
+	_, err := canonicalBlockHash(block)
+	require.NoError(err)
+	require.Equal("consolidated/object", block.Metadata.ObjectKeyMain)
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, block.Metadata.ObjectFormat)
+	require.Equal(uint64(10), block.Metadata.ByteOffset)
+	require.Equal(uint64(20), block.Metadata.ByteLength)
+	require.Equal(uint64(30), block.Metadata.UncompressedLength)
+}
+
 func TestSummarizeDurationsUsesNearestRankPercentile(t *testing.T) {
 	require := require.New(t)
 	summary := summarizeDurations([]time.Duration{

--- a/docs/reports/INF-914-cscb-dual-read-validation.json
+++ b/docs/reports/INF-914-cscb-dual-read-validation.json
@@ -1,0 +1,1347 @@
+{
+  "generated_at": "2026-06-22T05:28:49Z",
+  "command": "/Users/boyangxu/.cache/go/build/9d/9d56949bbf7c987975c8069d8d0715461b3dfd2181f50913602759aaaff0ad2f-d/admin --blockchain solana --network mainnet --env production cscb validate --start-height 428058000 --end-height 428059000 --chunk-blocks 25 --random-samples 5 --random-seed 914 --iterations 3 --full-object-iterations 1 --fallback-height 428057999 --timeout 5m --server-address localhost:19090 --grpc --report-json docs/reports/INF-914-cscb-dual-read-validation.json --report-md docs/reports/INF-914-cscb-dual-read-validation.md",
+  "environment": "production",
+  "blockchain": "BLOCKCHAIN_SOLANA",
+  "network": "NETWORK_SOLANA_MAINNET",
+  "tag": 2,
+  "start_height": 428058000,
+  "end_height": 428059000,
+  "chunk_blocks": 25,
+  "random_seed": 914,
+  "random_samples": 5,
+  "iterations": 3,
+  "full_object_iterations": 1,
+  "fallback_height": 428057999,
+  "server_address_override": "localhost:19090",
+  "grpc_transport_override": true,
+  "client_id": "INF-914-cscb-dual-read-validation",
+  "passed": true,
+  "total_cases": 18,
+  "passed_cases": 18,
+  "failed_cases": 0,
+  "correctness_mismatches": 0,
+  "observed_fallback_blocks": 1,
+  "cases": [
+    {
+      "name": "single_first_block",
+      "kind": "single",
+      "start_height": 428058000,
+      "end_height": 428058001,
+      "heights": [
+        428058000
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 1389.387,
+          "p95_ms": 1728.344,
+          "min_ms": 1251.48,
+          "max_ms": 1728.344
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2847939
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058000,
+          "last_height": 428058000
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 553.336,
+          "p95_ms": 571.616,
+          "min_ms": 460.878,
+          "max_ms": 571.616
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 2882226
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 8915187,
+          "metadata_uncompressed_bytes": 8915187,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058000,
+          "last_height": 428058000
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.3982590883605504,
+      "bytes_ratio_consolidated_vs_legacy": 1.0120392325818777,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "0e0e470e962f11735a8de95a692a8d5c0542cddace6f2c5f4e7481a889a11df7",
+      "first_canonical_hash_consolidated": "0e0e470e962f11735a8de95a692a8d5c0542cddace6f2c5f4e7481a889a11df7"
+    },
+    {
+      "name": "single_last_block",
+      "kind": "single",
+      "start_height": 428058999,
+      "end_height": 428059000,
+      "heights": [
+        428058999
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 218.822,
+          "p95_ms": 1013.836,
+          "min_ms": 198.491,
+          "max_ms": 1013.836
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2247348
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058999,
+          "last_height": 428058999
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 399.035,
+          "p95_ms": 521.437,
+          "min_ms": 362.858,
+          "max_ms": 521.437
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 3777807
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 6842578,
+          "metadata_uncompressed_bytes": 6842578,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058999,
+          "last_height": 428058999
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 1.8235597883211012,
+      "bytes_ratio_consolidated_vs_legacy": 1.681006679873344,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "c3b881848de06cadbedb95271bfdc6992ff752c5a010f4b708abf22a8d7dbe07",
+      "first_canonical_hash_consolidated": "c3b881848de06cadbedb95271bfdc6992ff752c5a010f4b708abf22a8d7dbe07"
+    },
+    {
+      "name": "single_chunk_boundary_428058024",
+      "kind": "single",
+      "start_height": 428058024,
+      "end_height": 428058025,
+      "heights": [
+        428058024
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 207.551,
+          "p95_ms": 288.986,
+          "min_ms": 175.27,
+          "max_ms": 288.986
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 3084087
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058024,
+          "last_height": 428058024
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 1039.391,
+          "p95_ms": 1052.372,
+          "min_ms": 936.045,
+          "max_ms": 1052.372
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 39109401
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 10758103,
+          "metadata_uncompressed_bytes": 10758103,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058024,
+          "last_height": 428058024
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 5.007882399988437,
+      "bytes_ratio_consolidated_vs_legacy": 12.68103039894789,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "62b48b812677a5b3c5042d9fcd0113561e6cabc3f679586645aa1f2024cb7d00",
+      "first_canonical_hash_consolidated": "62b48b812677a5b3c5042d9fcd0113561e6cabc3f679586645aa1f2024cb7d00"
+    },
+    {
+      "name": "single_chunk_boundary_428058025",
+      "kind": "single",
+      "start_height": 428058025,
+      "end_height": 428058026,
+      "heights": [
+        428058025
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 681.192,
+          "p95_ms": 688.676,
+          "min_ms": 309.035,
+          "max_ms": 688.676
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2469318
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058025,
+          "last_height": 428058025
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 417.139,
+          "p95_ms": 441.671,
+          "min_ms": 344.894,
+          "max_ms": 441.671
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 2451210
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 7925570,
+          "metadata_uncompressed_bytes": 7925570,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058025,
+          "last_height": 428058025
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.6123662638433804,
+      "bytes_ratio_consolidated_vs_legacy": 0.9926668011167455,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "07f3cf2f7356f80d7f9b3928ff11888187c7c3af7d2f0d896a5e670643d66630",
+      "first_canonical_hash_consolidated": "07f3cf2f7356f80d7f9b3928ff11888187c7c3af7d2f0d896a5e670643d66630"
+    },
+    {
+      "name": "single_chunk_boundary_428058049",
+      "kind": "single",
+      "start_height": 428058049,
+      "end_height": 428058050,
+      "heights": [
+        428058049
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 190.734,
+          "p95_ms": 710.165,
+          "min_ms": 176.139,
+          "max_ms": 710.165
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2358117
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058049,
+          "last_height": 428058049
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 872.054,
+          "p95_ms": 897.705,
+          "min_ms": 782.807,
+          "max_ms": 897.705
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 33572286
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 7593128,
+          "metadata_uncompressed_bytes": 7593128,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058049,
+          "last_height": 428058049
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 4.572095169188503,
+      "bytes_ratio_consolidated_vs_legacy": 14.236904275742043,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "636c30d02e3390276e0091ca9928603d8f1e507ef5be9ccd818a99f644732028",
+      "first_canonical_hash_consolidated": "636c30d02e3390276e0091ca9928603d8f1e507ef5be9ccd818a99f644732028"
+    },
+    {
+      "name": "single_chunk_boundary_428058050",
+      "kind": "single",
+      "start_height": 428058050,
+      "end_height": 428058051,
+      "heights": [
+        428058050
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 658.691,
+          "p95_ms": 698.487,
+          "min_ms": 251.748,
+          "max_ms": 698.487
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2188680
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058050,
+          "last_height": 428058050
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 452.178,
+          "p95_ms": 471.371,
+          "min_ms": 360.972,
+          "max_ms": 471.371
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 2255577
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 7301670,
+          "metadata_uncompressed_bytes": 7301670,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058050,
+          "last_height": 428058050
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.6864796998896295,
+      "bytes_ratio_consolidated_vs_legacy": 1.0305649980810352,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "5c5d5d0db508d736390aaffd5a4470c3f7ffddb32a5967d280b0b556e59b4c19",
+      "first_canonical_hash_consolidated": "5c5d5d0db508d736390aaffd5a4470c3f7ffddb32a5967d280b0b556e59b4c19"
+    },
+    {
+      "name": "single_chunk_boundary_428058074",
+      "kind": "single",
+      "start_height": 428058074,
+      "end_height": 428058075,
+      "heights": [
+        428058074
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 208.264,
+          "p95_ms": 766.694,
+          "min_ms": 176.772,
+          "max_ms": 766.694
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 3051528
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058074,
+          "last_height": 428058074
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 912.411,
+          "p95_ms": 1308.56,
+          "min_ms": 875.434,
+          "max_ms": 1308.56
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 36464772
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 10799431,
+          "metadata_uncompressed_bytes": 10799431,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058074,
+          "last_height": 428058074
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 4.3810308070525865,
+      "bytes_ratio_consolidated_vs_legacy": 11.949676358860216,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "68f1ef051c791e532127a753fb58da3677d5bce8f7bb7c5bceca7ab9ff44ab7c",
+      "first_canonical_hash_consolidated": "68f1ef051c791e532127a753fb58da3677d5bce8f7bb7c5bceca7ab9ff44ab7c"
+    },
+    {
+      "name": "single_chunk_boundary_428058075",
+      "kind": "single",
+      "start_height": 428058075,
+      "end_height": 428058076,
+      "heights": [
+        428058075
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 684.618,
+          "p95_ms": 1262.177,
+          "min_ms": 199.987,
+          "max_ms": 1262.177
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2627094
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058075,
+          "last_height": 428058075
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 398.145,
+          "p95_ms": 501.07,
+          "min_ms": 382.178,
+          "max_ms": 501.07
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 2465205
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 8888611,
+          "metadata_uncompressed_bytes": 8888611,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058075,
+          "last_height": 428058075
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.5815578906777209,
+      "bytes_ratio_consolidated_vs_legacy": 0.9383771574218509,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "f0faa51f65d2278bfde95eb2444ccd22386d40d3c6b79bd4ff2a5e9b913edf57",
+      "first_canonical_hash_consolidated": "f0faa51f65d2278bfde95eb2444ccd22386d40d3c6b79bd4ff2a5e9b913edf57"
+    },
+    {
+      "name": "single_random_428058100",
+      "kind": "single",
+      "start_height": 428058100,
+      "end_height": 428058101,
+      "heights": [
+        428058100
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 718.612,
+          "p95_ms": 1282.682,
+          "min_ms": 700.807,
+          "max_ms": 1282.682
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2908002
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058100,
+          "last_height": 428058100
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 421.256,
+          "p95_ms": 423.046,
+          "min_ms": 349.698,
+          "max_ms": 423.046
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 2756445
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 9653365,
+          "metadata_uncompressed_bytes": 9653365,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058100,
+          "last_height": 428058100
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.5862078562562273,
+      "bytes_ratio_consolidated_vs_legacy": 0.9478827731205137,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "178de0a69cedd530d65e26b5c0657114e251d15dccb29e9c61955342e52dda83",
+      "first_canonical_hash_consolidated": "178de0a69cedd530d65e26b5c0657114e251d15dccb29e9c61955342e52dda83"
+    },
+    {
+      "name": "single_random_428058118",
+      "kind": "single",
+      "start_height": 428058118,
+      "end_height": 428058119,
+      "heights": [
+        428058118
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 1272.78,
+          "p95_ms": 1463.85,
+          "min_ms": 1212.492,
+          "max_ms": 1463.85
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 1939224
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058118,
+          "last_height": 428058118
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 3170.186,
+          "p95_ms": 6313.939,
+          "min_ms": 2924.594,
+          "max_ms": 6313.939
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 30511797
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 6627227,
+          "metadata_uncompressed_bytes": 6627227,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058118,
+          "last_height": 428058118
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 2.490757240057198,
+      "bytes_ratio_consolidated_vs_legacy": 15.734024021979925,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "382f8598c23a17710a3abb7162ecd9cdfebd5b15a7ef883ed22fbed73c086397",
+      "first_canonical_hash_consolidated": "382f8598c23a17710a3abb7162ecd9cdfebd5b15a7ef883ed22fbed73c086397"
+    },
+    {
+      "name": "single_random_428058141",
+      "kind": "single",
+      "start_height": 428058141,
+      "end_height": 428058142,
+      "heights": [
+        428058141
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 984.129,
+          "p95_ms": 1626.596,
+          "min_ms": 895.663,
+          "max_ms": 1626.596
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 3889650
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058141,
+          "last_height": 428058141
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 3797.58,
+          "p95_ms": 4665.425,
+          "min_ms": 2487.59,
+          "max_ms": 4665.425
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 36896916
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 11708771,
+          "metadata_uncompressed_bytes": 11708771,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058141,
+          "last_height": 428058141
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 3.858823385958548,
+      "bytes_ratio_consolidated_vs_legacy": 9.485921869576954,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "7f6b184b49151bdd44b8b2b2b1fe219d2678593ebf5cb7e384925921c4e3356b",
+      "first_canonical_hash_consolidated": "7f6b184b49151bdd44b8b2b2b1fe219d2678593ebf5cb7e384925921c4e3356b"
+    },
+    {
+      "name": "single_random_428058339",
+      "kind": "single",
+      "start_height": 428058339,
+      "end_height": 428058340,
+      "heights": [
+        428058339
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 913.407,
+          "p95_ms": 1296.782,
+          "min_ms": 888.824,
+          "max_ms": 1296.782
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 2794089
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058339,
+          "last_height": 428058339
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 1415.481,
+          "p95_ms": 2200.593,
+          "min_ms": 1096.766,
+          "max_ms": 2200.593
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 29017683
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 8447888,
+          "metadata_uncompressed_bytes": 8447888,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058339,
+          "last_height": 428058339
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 1.5496717235580633,
+      "bytes_ratio_consolidated_vs_legacy": 10.385382498553195,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "d7a2448d89026352190c721845f3f317e23311605a6112526ba7a739ae777066",
+      "first_canonical_hash_consolidated": "d7a2448d89026352190c721845f3f317e23311605a6112526ba7a739ae777066"
+    },
+    {
+      "name": "single_random_428058828",
+      "kind": "single",
+      "start_height": 428058828,
+      "end_height": 428058829,
+      "heights": [
+        428058828
+      ],
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 1492.801,
+          "p95_ms": 1633.386,
+          "min_ms": 881.652,
+          "max_ms": 1633.386
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 3594321
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058828,
+          "last_height": 428058828
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 922.264,
+          "p95_ms": 978.437,
+          "min_ms": 605.366,
+          "max_ms": 978.437
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 11397528
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1,
+          "skipped_count": 0,
+          "metadata_byte_length": 12007263,
+          "metadata_uncompressed_bytes": 12007263,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058828,
+          "last_height": 428058828
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.6178077319080039,
+      "bytes_ratio_consolidated_vs_legacy": 3.170982224459084,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "25ee3596b012244de477ca5a4d79864a0472cd6dcc8a985010d0ebf87b03bd5f",
+      "first_canonical_hash_consolidated": "25ee3596b012244de477ca5a4d79864a0472cd6dcc8a985010d0ebf87b03bd5f"
+    },
+    {
+      "name": "range_within_one_chunk",
+      "kind": "range",
+      "start_height": 428058005,
+      "end_height": 428058015,
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 2996.342,
+          "p95_ms": 3001.567,
+          "min_ms": 2891.89,
+          "max_ms": 3001.567
+        },
+        "http": {
+          "requests": 30,
+          "bytes": 22951683
+        },
+        "files": {
+          "count": 10,
+          "legacy_object_count": 10,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058005,
+          "last_height": 428058014
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 2013.972,
+          "p95_ms": 2089.991,
+          "min_ms": 1583.112,
+          "max_ms": 2089.991
+        },
+        "http": {
+          "requests": 9,
+          "bytes": 24104910
+        },
+        "files": {
+          "count": 10,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 10,
+          "skipped_count": 0,
+          "metadata_byte_length": 72347946,
+          "metadata_uncompressed_bytes": 72347946,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058005,
+          "last_height": 428058014
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.672143567056097,
+      "bytes_ratio_consolidated_vs_legacy": 1.0502458577874223,
+      "canonical_hashes_compared": 10,
+      "first_canonical_hash_legacy": "41960aeeec354c48c1f133a447f79cd4a96954187a76447e4683d91f5239ddad",
+      "first_canonical_hash_consolidated": "41960aeeec354c48c1f133a447f79cd4a96954187a76447e4683d91f5239ddad"
+    },
+    {
+      "name": "range_across_chunk_boundary",
+      "kind": "range",
+      "start_height": 428058020,
+      "end_height": 428058030,
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 2977.525,
+          "p95_ms": 3042.113,
+          "min_ms": 1368.422,
+          "max_ms": 3042.113
+        },
+        "http": {
+          "requests": 30,
+          "bytes": 21927276
+        },
+        "files": {
+          "count": 10,
+          "legacy_object_count": 10,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058020,
+          "last_height": 428058029
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 3097.036,
+          "p95_ms": 5206.642,
+          "min_ms": 2334.32,
+          "max_ms": 5206.642
+        },
+        "http": {
+          "requests": 12,
+          "bytes": 45903672
+        },
+        "files": {
+          "count": 10,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 10,
+          "skipped_count": 0,
+          "metadata_byte_length": 72287021,
+          "metadata_uncompressed_bytes": 72287021,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058020,
+          "last_height": 428058029
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 1.040137698256102,
+      "bytes_ratio_consolidated_vs_legacy": 2.093450732320786,
+      "canonical_hashes_compared": 10,
+      "first_canonical_hash_legacy": "a90299cae6b502a6bf518c887995fd04f680fef17b45e891371a078353ac7419",
+      "first_canonical_hash_consolidated": "a90299cae6b502a6bf518c887995fd04f680fef17b45e891371a078353ac7419"
+    },
+    {
+      "name": "range_two_chunks",
+      "kind": "range",
+      "start_height": 428058000,
+      "end_height": 428058050,
+      "iterations": 3,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 4055.683,
+          "p95_ms": 4705.356,
+          "min_ms": 3396.787,
+          "max_ms": 4705.356
+        },
+        "http": {
+          "requests": 150,
+          "bytes": 118865385
+        },
+        "files": {
+          "count": 50,
+          "legacy_object_count": 50,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058000,
+          "last_height": 428058049
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 4934.945,
+          "p95_ms": 5072.744,
+          "min_ms": 2676.124,
+          "max_ms": 5072.744
+        },
+        "http": {
+          "requests": 12,
+          "bytes": 72384303
+        },
+        "files": {
+          "count": 50,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 50,
+          "skipped_count": 0,
+          "metadata_byte_length": 385274802,
+          "metadata_uncompressed_bytes": 385274802,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058000,
+          "last_height": 428058049
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 1.2167975159794293,
+      "bytes_ratio_consolidated_vs_legacy": 0.6089603209546665,
+      "canonical_hashes_compared": 50,
+      "first_canonical_hash_legacy": "0e0e470e962f11735a8de95a692a8d5c0542cddace6f2c5f4e7481a889a11df7",
+      "first_canonical_hash_consolidated": "0e0e470e962f11735a8de95a692a8d5c0542cddace6f2c5f4e7481a889a11df7"
+    },
+    {
+      "name": "range_full_object",
+      "kind": "range",
+      "start_height": 428058000,
+      "end_height": 428059000,
+      "iterations": 1,
+      "expect_fallback": false,
+      "observed_fallback": false,
+      "observed_fallback_blocks": 0,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 1,
+          "p50_ms": 103929.955,
+          "p95_ms": 103929.955,
+          "min_ms": 103929.955,
+          "max_ms": 103929.955
+        },
+        "http": {
+          "requests": 1000,
+          "bytes": 907486583
+        },
+        "files": {
+          "count": 1000,
+          "legacy_object_count": 1000,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428058000,
+          "last_height": 428058999
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 1,
+          "p50_ms": 39572.801,
+          "p95_ms": 39572.801,
+          "min_ms": 39572.801,
+          "max_ms": 39572.801
+        },
+        "http": {
+          "requests": 43,
+          "bytes": 567346484
+        },
+        "files": {
+          "count": 1000,
+          "legacy_object_count": 0,
+          "consolidated_object_count": 1000,
+          "skipped_count": 0,
+          "metadata_byte_length": 8876157284,
+          "metadata_uncompressed_bytes": 8876157284,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_CSCB_BATCH"
+          ],
+          "first_height": 428058000,
+          "last_height": 428058999
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.3807641502394569,
+      "bytes_ratio_consolidated_vs_legacy": 0.6251844320655923,
+      "canonical_hashes_compared": 1000,
+      "first_canonical_hash_legacy": "0e0e470e962f11735a8de95a692a8d5c0542cddace6f2c5f4e7481a889a11df7",
+      "first_canonical_hash_consolidated": "0e0e470e962f11735a8de95a692a8d5c0542cddace6f2c5f4e7481a889a11df7"
+    },
+    {
+      "name": "single_consolidated_miss_fallback",
+      "kind": "single",
+      "start_height": 428057999,
+      "end_height": 428058000,
+      "heights": [
+        428057999
+      ],
+      "iterations": 3,
+      "expect_fallback": true,
+      "observed_fallback": true,
+      "observed_fallback_blocks": 1,
+      "correct": true,
+      "passed": true,
+      "legacy": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 447.05,
+          "p95_ms": 2794.868,
+          "min_ms": 420.81,
+          "max_ms": 2794.868
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 3351267
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428057999,
+          "last_height": 428057999
+        },
+        "error_count": 0
+      },
+      "consolidated": {
+        "latency": {
+          "samples": 3,
+          "p50_ms": 421.771,
+          "p95_ms": 805.597,
+          "min_ms": 412.696,
+          "max_ms": 805.597
+        },
+        "http": {
+          "requests": 3,
+          "bytes": 3351267
+        },
+        "files": {
+          "count": 1,
+          "legacy_object_count": 1,
+          "consolidated_object_count": 0,
+          "skipped_count": 0,
+          "metadata_byte_length": 0,
+          "metadata_uncompressed_bytes": 0,
+          "formats": [
+            "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"
+          ],
+          "first_height": 428057999,
+          "last_height": 428057999
+        },
+        "error_count": 0
+      },
+      "latency_ratio_consolidated_vs_legacy": 0.9434537523766916,
+      "bytes_ratio_consolidated_vs_legacy": 1,
+      "canonical_hashes_compared": 1,
+      "first_canonical_hash_legacy": "f1762d11493396aba7147080fa3f96964ddbd0daf07c06af08df04ef347973d2",
+      "first_canonical_hash_consolidated": "f1762d11493396aba7147080fa3f96964ddbd0daf07c06af08df04ef347973d2"
+    }
+  ]
+}

--- a/docs/reports/INF-914-cscb-dual-read-validation.md
+++ b/docs/reports/INF-914-cscb-dual-read-validation.md
@@ -1,0 +1,164 @@
+# CSCB Dual-Read Validation Report
+
+- generated_at: `2026-06-22T05:28:49Z`
+- target: `production/BLOCKCHAIN_SOLANA/NETWORK_SOLANA_MAINNET`
+- tag: `2`
+- canary_range: `[428058000, 428059000)`
+- chunk_blocks: `25`
+- server_address_override: `localhost:19090`
+- grpc_transport_override: `true`
+- client_id: `INF-914-cscb-dual-read-validation`
+- passed: `true`
+- cases: `18 passed / 18 total`
+- mismatch_heights: `0`
+- observed_fallback_blocks: `1`
+
+## Canary Object and Expected Profile
+
+- consolidated_object: `BLOCKCHAIN_SOLANA/NETWORK_SOLANA_MAINNET/consolidated/v=2/shard=00000000000428050000-00000000000428060000/00000000000428058000-00000000000428059000-20a1b269fb75137d829d4ade11b3cdf67bab5c3a8c9be046fd8069396607b906.cscb.zstd`
+- legacy_baseline: `1000 objects`, `907486583 bytes`, `865.45 MiB`
+- consolidated_object_size: `567346484 bytes`, `541.06 MiB`, `37.48% saving`
+- selected_config: `max_blocks=1000`, `compression_chunk_blocks=25`, `zstd_level=12`, `long_window_log=27`, `memory_budget=256MiB`
+
+## Production Execution Evidence
+
+- connection: read-only gRPC validation through `kubectl --context prod port-forward -n chainstorage-prod svc/chainstorage-solana-mainnet-prod-server-svc 19090:9090`
+- target_pod: `chainstorage-prod/chainstorage-solana-mainnet-prod-server-6f7bd7b5bb-9k7pr`
+- safety: prod operations were read-only (`get`, `top`, `logs`, `port-forward`, and Chainstorage read APIs); no database writes or object mutations were performed.
+- pre_validation_resources: `chainstorage-server CPU=2m RSS=15Mi restarts=0 ready=true`; `linkerd-proxy CPU=1m RSS=3Mi restarts=0 ready=true`
+- post_validation_resources: `chainstorage-server CPU=2m RSS=23Mi restarts=0 ready=true`; `linkerd-proxy CPU=1m RSS=3Mi restarts=0 ready=true`
+- post_validation_error_logs: no matching `error|panic|fatal|fallback|cscb|shadow|INF-914` lines in `chainstorage-server` logs over the validation window.
+- full_object_result: legacy `1000` HTTP reads / `907486583` bytes / p50 `103929.96ms`; consolidated `43` HTTP reads / `567346484` bytes / p50 `39572.80ms`; canonical hashes matched for all `1000` blocks.
+
+## Case Results
+
+| case | range | pass | fallback | legacy p50/p95 ms | consolidated p50/p95 ms | legacy bytes | consolidated bytes | mismatches |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| single_first_block | `[428058000,428058001)` | true | false | 1389.39 / 1728.34 | 553.34 / 571.62 | 2847939 | 2882226 |  |
+| single_last_block | `[428058999,428059000)` | true | false | 218.82 / 1013.84 | 399.04 / 521.44 | 2247348 | 3777807 |  |
+| single_chunk_boundary_428058024 | `[428058024,428058025)` | true | false | 207.55 / 288.99 | 1039.39 / 1052.37 | 3084087 | 39109401 |  |
+| single_chunk_boundary_428058025 | `[428058025,428058026)` | true | false | 681.19 / 688.68 | 417.14 / 441.67 | 2469318 | 2451210 |  |
+| single_chunk_boundary_428058049 | `[428058049,428058050)` | true | false | 190.73 / 710.16 | 872.05 / 897.71 | 2358117 | 33572286 |  |
+| single_chunk_boundary_428058050 | `[428058050,428058051)` | true | false | 658.69 / 698.49 | 452.18 / 471.37 | 2188680 | 2255577 |  |
+| single_chunk_boundary_428058074 | `[428058074,428058075)` | true | false | 208.26 / 766.69 | 912.41 / 1308.56 | 3051528 | 36464772 |  |
+| single_chunk_boundary_428058075 | `[428058075,428058076)` | true | false | 684.62 / 1262.18 | 398.14 / 501.07 | 2627094 | 2465205 |  |
+| single_random_428058100 | `[428058100,428058101)` | true | false | 718.61 / 1282.68 | 421.26 / 423.05 | 2908002 | 2756445 |  |
+| single_random_428058118 | `[428058118,428058119)` | true | false | 1272.78 / 1463.85 | 3170.19 / 6313.94 | 1939224 | 30511797 |  |
+| single_random_428058141 | `[428058141,428058142)` | true | false | 984.13 / 1626.60 | 3797.58 / 4665.43 | 3889650 | 36896916 |  |
+| single_random_428058339 | `[428058339,428058340)` | true | false | 913.41 / 1296.78 | 1415.48 / 2200.59 | 2794089 | 29017683 |  |
+| single_random_428058828 | `[428058828,428058829)` | true | false | 1492.80 / 1633.39 | 922.26 / 978.44 | 3594321 | 11397528 |  |
+| range_within_one_chunk | `[428058005,428058015)` | true | false | 2996.34 / 3001.57 | 2013.97 / 2089.99 | 22951683 | 24104910 |  |
+| range_across_chunk_boundary | `[428058020,428058030)` | true | false | 2977.53 / 3042.11 | 3097.04 / 5206.64 | 21927276 | 45903672 |  |
+| range_two_chunks | `[428058000,428058050)` | true | false | 4055.68 / 4705.36 | 4934.94 / 5072.74 | 118865385 | 72384303 |  |
+| range_full_object | `[428058000,428059000)` | true | false | 103929.96 / 103929.96 | 39572.80 / 39572.80 | 907486583 | 567346484 |  |
+| single_consolidated_miss_fallback | `[428057999,428058000)` | true | true | 447.05 / 2794.87 | 421.77 / 805.60 | 3351267 | 3351267 |  |
+
+## Source Summary
+
+### single_first_block
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2847939`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `2882226`
+- canonical hashes compared: `1`
+
+### single_last_block
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2247348`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `3777807`
+- canonical hashes compared: `1`
+
+### single_chunk_boundary_428058024
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `3084087`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `39109401`
+- canonical hashes compared: `1`
+
+### single_chunk_boundary_428058025
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2469318`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `2451210`
+- canonical hashes compared: `1`
+
+### single_chunk_boundary_428058049
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2358117`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `33572286`
+- canonical hashes compared: `1`
+
+### single_chunk_boundary_428058050
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2188680`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `2255577`
+- canonical hashes compared: `1`
+
+### single_chunk_boundary_428058074
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `3051528`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `36464772`
+- canonical hashes compared: `1`
+
+### single_chunk_boundary_428058075
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2627094`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `2465205`
+- canonical hashes compared: `1`
+
+### single_random_428058100
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2908002`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `2756445`
+- canonical hashes compared: `1`
+
+### single_random_428058118
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `1939224`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `30511797`
+- canonical hashes compared: `1`
+
+### single_random_428058141
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `3889650`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `36896916`
+- canonical hashes compared: `1`
+
+### single_random_428058339
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `2794089`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `29017683`
+- canonical hashes compared: `1`
+
+### single_random_428058828
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `3594321`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `11397528`
+- canonical hashes compared: `1`
+
+### range_within_one_chunk
+
+- legacy files: `10`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `30`, bytes: `22951683`
+- consolidated files: `10`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `9`, bytes: `24104910`
+- canonical hashes compared: `10`
+
+### range_across_chunk_boundary
+
+- legacy files: `10`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `30`, bytes: `21927276`
+- consolidated files: `10`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `12`, bytes: `45903672`
+- canonical hashes compared: `10`
+
+### range_two_chunks
+
+- legacy files: `50`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `150`, bytes: `118865385`
+- consolidated files: `50`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `12`, bytes: `72384303`
+- canonical hashes compared: `50`
+
+### range_full_object
+
+- legacy files: `1000`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `1000`, bytes: `907486583`
+- consolidated files: `1000`, formats: `BLOCK_OBJECT_FORMAT_CSCB_BATCH`, HTTP requests: `43`, bytes: `567346484`
+- canonical hashes compared: `1000`
+
+### single_consolidated_miss_fallback
+
+- legacy files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `3351267`
+- consolidated files: `1`, formats: `BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK`, HTTP requests: `3`, bytes: `3351267`
+- canonical hashes compared: `1`


### PR DESCRIPTION
## Summary

- Add `admin cscb validate`, a rerunnable read-only harness that compares explicit LEGACY and CONSOLIDATED Chainstorage reads.
- Cover first/last block, chunk-boundary blocks, deterministic random singles, within-chunk/across-chunk/full-object ranges, consolidated miss/fallback, and explicit source overrides.
- Commit durable Solana production canary validation artifacts for `[428058000, 428059000)` under `docs/reports/`.
- Address review feedback by avoiding whole-block `proto.Clone` during hashing, adding nil-safe block comparison, and capturing hash metadata on the first successful comparison.

## Validation Evidence

- `go test ./cmd/admin`
- `go test ./cmd/admin ./internal/storage/blobstorage/downloader`
- `go vet ./cmd/admin`
- Production read-only run through a verified `kubectl --context prod` port-forward to `chainstorage-prod/chainstorage-solana-mainnet-prod-server-svc:9090`.
- Full-object canary result: 18/18 cases passed, 0 mismatch heights, 1 expected fallback block.
- Full-object range: legacy 1000 HTTP reads / 907,486,583 bytes / p50 103,929.96 ms; consolidated 43 HTTP reads / 567,346,484 bytes / p50 39,572.80 ms.
- Pod evidence: `chainstorage-server` restarts stayed 0; RSS was 15Mi before validation and 23Mi after validation; no matching error/panic/fatal lines over the validation window.

## Safety

All production operations were read-only: service/pod discovery, `top`, `logs`, `port-forward`, and Chainstorage read APIs. No database writes, object mutations, or destructive kubectl/AWS operations were performed.

Linear: INF-914
