### PR TITLE
feat(INF-925): add raw payload streaming API

### DIFF
--- a/internal/storage/blobstorage/cscb/reader.go
+++ b/internal/storage/blobstorage/cscb/reader.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/binary"
+	"hash"
 	"hash/crc32"
 	"io"
 	"sort"
@@ -307,6 +308,16 @@ type blockPayloadRead struct {
 	end           uint64
 }
 
+type blockPayloadStream struct {
+	frame     io.Closer
+	reader    io.ReadCloser
+	block     *BlockDescriptor
+	remaining uint64
+	crc       hash.Hash32
+	validated bool
+	closed    bool
+}
+
 // ExtractBlockPayloadsFromChunkFrame streams a compressed chunk and returns
 // only the requested block payloads in the same order as blocks. It validates
 // each requested block CRC without materializing the full decompressed chunk.
@@ -395,6 +406,42 @@ func ExtractBlockPayloadsFromChunkFrame(frame io.Reader, codec api.Compression, 
 	return payloads, nil
 }
 
+// OpenBlockPayloadFromChunkFrame streams one block payload out of a compressed
+// CSCB chunk frame. The returned reader validates the block payload length and
+// CRC when read to EOF. Close drains unread payload bytes before closing so
+// callers that stop early can still observe validation/short-read errors.
+func OpenBlockPayloadFromChunkFrame(frame io.ReadCloser, codec api.Compression, chunk *ChunkDescriptor, block *BlockDescriptor) (io.ReadCloser, error) {
+	if frame == nil {
+		return nil, xerrors.New("CSCB chunk frame is required")
+	}
+	if chunk == nil {
+		_ = frame.Close()
+		return nil, xerrors.New("CSCB chunk descriptor is required")
+	}
+	if err := validateBlockPayloadBounds(chunk, block); err != nil {
+		_ = frame.Close()
+		return nil, err
+	}
+
+	reader, err := NewChunkDecompressor(frame, codec)
+	if err != nil {
+		_ = frame.Close()
+		return nil, err
+	}
+	if err := discardExactly(reader, block.ChunkRelativeOffset); err != nil {
+		_ = reader.Close()
+		_ = frame.Close()
+		return nil, err
+	}
+	return &blockPayloadStream{
+		frame:     frame,
+		reader:    reader,
+		block:     block,
+		remaining: block.PayloadLength,
+		crc:       crc32.NewIEEE(),
+	}, nil
+}
+
 func NewChunkDecompressor(frame io.Reader, codec api.Compression) (io.ReadCloser, error) {
 	switch codec {
 	case api.Compression_GZIP:
@@ -417,6 +464,94 @@ func NewChunkDecompressor(frame io.Reader, codec api.Compression) (io.ReadCloser
 	default:
 		return nil, xerrors.Errorf("unsupported CSCB codec: %v", codec)
 	}
+}
+
+func validateBlockPayloadBounds(chunk *ChunkDescriptor, block *BlockDescriptor) error {
+	if block == nil {
+		return xerrors.New("CSCB block descriptor is required")
+	}
+	if block.ChunkIndex != chunk.Index {
+		return xerrors.Errorf("CSCB block chunk mismatch at height %d: block=%d chunk=%d", block.Height, block.ChunkIndex, chunk.Index)
+	}
+	end, err := checkedAdd(block.ChunkRelativeOffset, block.PayloadLength)
+	if err != nil {
+		return err
+	}
+	if end > chunk.UncompressedLength {
+		return xerrors.Errorf("CSCB block payload exceeds chunk bounds: end=%d chunk_length=%d", end, chunk.UncompressedLength)
+	}
+	return nil
+}
+
+func (r *blockPayloadStream) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, xerrors.New("CSCB block payload reader is closed")
+	}
+	if r.remaining == 0 {
+		if err := r.validate(); err != nil {
+			return 0, err
+		}
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if uint64(len(p)) > r.remaining {
+		p = p[:int(r.remaining)]
+	}
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		if _, writeErr := r.crc.Write(p[:n]); writeErr != nil {
+			return n, writeErr
+		}
+		r.remaining -= uint64(n)
+	}
+	if err != nil && r.remaining > 0 {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+		return n, err
+	}
+	if r.remaining == 0 {
+		if validateErr := r.validate(); validateErr != nil {
+			return n, validateErr
+		}
+	}
+	return n, err
+}
+
+func (r *blockPayloadStream) Close() error {
+	if r.closed {
+		return nil
+	}
+	var closeErr error
+	if !r.validated {
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			closeErr = err
+		}
+	}
+	r.closed = true
+	if err := r.reader.Close(); closeErr == nil && err != nil {
+		closeErr = err
+	}
+	if err := r.frame.Close(); closeErr == nil && err != nil {
+		closeErr = err
+	}
+	return closeErr
+}
+
+func (r *blockPayloadStream) validate() error {
+	if r.validated {
+		return nil
+	}
+	r.validated = true
+	if r.remaining != 0 {
+		return xerrors.Errorf("CSCB block payload length mismatch at height %d: missing %d bytes", r.block.Height, r.remaining)
+	}
+	if crc := r.crc.Sum32(); crc != r.block.PayloadCRC32 {
+		return xerrors.Errorf("CSCB block CRC mismatch at height %d: got %08x want %08x", r.block.Height, crc, r.block.PayloadCRC32)
+	}
+	return nil
 }
 
 func ExtractBlockPayload(chunkPayload []byte, block *BlockDescriptor) ([]byte, error) {

--- a/internal/storage/blobstorage/cscb/reader_test.go
+++ b/internal/storage/blobstorage/cscb/reader_test.go
@@ -3,6 +3,7 @@ package cscb
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -52,6 +53,50 @@ func TestParseIndexAndExtractBlockPayload(t *testing.T) {
 	require.NoError(err)
 	require.Len(streamedPayloads, 1)
 	require.Equal([]byte("bravo-bravo"), streamedPayloads[0])
+
+	stream, err := OpenBlockPayloadFromChunkFrame(io.NopCloser(bytes.NewReader(frame)), index.Header.Codec, chunk, block)
+	require.NoError(err)
+	buf := make([]byte, 5)
+	n, err := stream.Read(buf)
+	require.NoError(err)
+	require.Equal(5, n)
+	require.Equal([]byte("bravo"), buf)
+	require.NoError(stream.Close())
+}
+
+func TestOpenBlockPayloadFromChunkFrameReportsCRCMismatch(t *testing.T) {
+	require := testutil.Require(t)
+
+	object, err := Encode(context.Background(), testEncodeConfig(api.Compression_ZSTD), testPayloads())
+	require.NoError(err)
+	defer object.Close()
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := ParseIndex(data)
+	require.NoError(err)
+
+	metadata := &api.BlockMetadata{
+		Tag:                7,
+		Height:             101,
+		Hash:               "hash-101",
+		ObjectKeyMain:      object.Key,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteOffset:         object.Placements[1].ByteOffset,
+		ByteLength:         object.Placements[1].ByteLength,
+		UncompressedLength: object.Placements[1].UncompressedLength,
+	}
+	block, chunk, err := index.LookupBlock(metadata)
+	require.NoError(err)
+	corruptBlock := *block
+	corruptBlock.PayloadCRC32 ^= 0x1
+
+	frame := data[chunk.CompressedPayloadOffset : chunk.CompressedPayloadOffset+chunk.CompressedLength]
+	stream, err := OpenBlockPayloadFromChunkFrame(io.NopCloser(bytes.NewReader(frame)), index.Header.Codec, chunk, &corruptBlock)
+	require.NoError(err)
+	_, err = io.ReadAll(stream)
+	require.Error(err)
+	require.Contains(err.Error(), "CRC mismatch")
 }
 
 func TestExtractBlockPayloadsFromChunkFramePreservesInputOrder(t *testing.T) {

--- a/internal/storage/blobstorage/downloader/block.go
+++ b/internal/storage/blobstorage/downloader/block.go
@@ -35,6 +35,18 @@ type (
 		Download(ctx context.Context, blockFile *api.BlockFile) (*api.Block, error)
 		DownloadMany(ctx context.Context, blockFiles []*api.BlockFile) ([]*api.Block, error)
 
+		// OpenRawBlockPayload opens the validated, decompressed protobuf
+		// payload bytes for one raw block without unmarshaling api.Block.
+		// Callers MUST close the returned payload.
+		OpenRawBlockPayload(ctx context.Context, blockFile *api.BlockFile) (*RawBlockPayload, error)
+
+		// OpenRawBlockPayloads opens an iterator over validated,
+		// decompressed protobuf payload bytes in blockFiles order without
+		// unmarshaling api.Block. The iterator returns io.EOF when
+		// exhausted. Callers MUST close each returned payload and the
+		// iterator.
+		OpenRawBlockPayloads(ctx context.Context, blockFiles []*api.BlockFile) (RawBlockPayloadIterator, error)
+
 		// DownloadStream spools the compressed block to a local temp
 		// file, decompresses to a second temp file, and returns a
 		// chain-agnostic SpooledBlock handle. The decompressed spool
@@ -96,6 +108,7 @@ type (
 		retry         retry.RetryWithResult[*api.Block]
 		retryBytes    retry.RetryWithResult[[]byte]
 		retryPayloads retry.RetryWithResult[[][]byte]
+		retryRaw      retry.RetryWithResult[*RawBlockPayload]
 	}
 
 	downloadRef struct {
@@ -141,6 +154,7 @@ func NewBlockDownloader(params BlockDownloaderParams) BlockDownloader {
 		retry:         retry.NewWithResult[*api.Block](retry.WithLogger(logger)),
 		retryBytes:    retry.NewWithResult[[]byte](retry.WithLogger(logger)),
 		retryPayloads: retry.NewWithResult[[][]byte](retry.WithLogger(logger)),
+		retryRaw:      retry.NewWithResult[*RawBlockPayload](retry.WithLogger(logger)),
 	}
 }
 

--- a/internal/storage/blobstorage/downloader/block_test.go
+++ b/internal/storage/blobstorage/downloader/block_test.go
@@ -605,6 +605,170 @@ func (s *blockDownloaderTestSuite) TestDownloadStream_CSCB() {
 	}
 }
 
+func (s *blockDownloaderTestSuite) TestOpenRawBlockPayload_LegacyGzip() {
+	require := testutil.Require(s.T())
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(s.newHttpServerFunc(http.MethodGet, http.StatusOK, expectedBlockCompressedBytes)),
+		fx.Populate(&s.httpServer),
+		fx.Provide(s.newHttpClientFunc()),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+	s.blockFile.Compression = api.Compression_GZIP
+
+	payload, err := s.downloader.OpenRawBlockPayload(context.Background(), s.blockFile)
+	require.NoError(err)
+	defer payload.Close()
+	require.Equal(s.blockFile, payload.BlockFile)
+
+	got, err := io.ReadAll(payload)
+	require.NoError(err)
+	require.Equal(expectedBlockBytes, got)
+}
+
+func (s *blockDownloaderTestSuite) TestOpenRawBlockPayload_CSCBStreamsSinglePayload() {
+	require := testutil.Require(s.T())
+	fixture := newCSCBDownloaderFixture(s.T(), 2, 2)
+	defer fixture.close()
+
+	server, recorder := newRangeHTTPServer(fixture.data)
+	defer server.Close()
+	for _, file := range fixture.blockFiles {
+		file.FileUrl = server.URL
+	}
+
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(func() HTTPClient { return server.Client() }),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+
+	payload, err := s.downloader.OpenRawBlockPayload(context.Background(), fixture.blockFiles[1])
+	require.NoError(err)
+	defer payload.Close()
+	require.Equal(fixture.blockFiles[1], payload.BlockFile)
+	require.Equal(fixture.blockFiles[1].GetByteLength(), payload.Length)
+
+	gotBytes, err := io.ReadAll(payload)
+	require.NoError(err)
+	var rawBlock api.Block
+	require.NoError(proto.Unmarshal(gotBytes, &rawBlock))
+	expected := proto.Clone(fixture.blocks[1]).(*api.Block)
+	if diff := cmp.Diff(expected, &rawBlock, protocmp.Transform()); diff != "" {
+		require.FailNow(diff)
+	}
+
+	require.Equal([]string{
+		"bytes=0-65535",
+		rangeHeader(fixture.index.Chunks[0].CompressedPayloadOffset, fixture.index.Chunks[0].CompressedLength),
+	}, recorder.rangesSnapshot())
+}
+
+func (s *blockDownloaderTestSuite) TestOpenRawBlockPayloads_CSCBGroupsByChunk() {
+	require := testutil.Require(s.T())
+	fixture := newCSCBDownloaderFixture(s.T(), 4, 2)
+	defer fixture.close()
+
+	server, recorder := newRangeHTTPServer(fixture.data)
+	defer server.Close()
+	for _, file := range fixture.blockFiles {
+		file.FileUrl = server.URL
+	}
+
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(func() HTTPClient { return server.Client() }),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+
+	blockFiles := []*api.BlockFile{
+		fixture.blockFiles[1],
+		fixture.blockFiles[0],
+		fixture.blockFiles[3],
+	}
+	iter, err := s.downloader.OpenRawBlockPayloads(context.Background(), blockFiles)
+	require.NoError(err)
+	defer iter.Close()
+
+	for i, blockFile := range blockFiles {
+		payload, err := iter.Next(context.Background())
+		require.NoError(err)
+		require.Equal(blockFile, payload.BlockFile)
+		gotBytes, err := io.ReadAll(payload)
+		require.NoError(err)
+		require.NoError(payload.Close())
+
+		var rawBlock api.Block
+		require.NoError(proto.Unmarshal(gotBytes, &rawBlock))
+		sourceIndex := int(blockFile.GetHeight() - 100)
+		expected := proto.Clone(fixture.blocks[sourceIndex]).(*api.Block)
+		if diff := cmp.Diff(expected, &rawBlock, protocmp.Transform()); diff != "" {
+			require.FailNow(fmt.Sprintf("payload %d mismatch: %s", i, diff))
+		}
+	}
+	_, err = iter.Next(context.Background())
+	require.ErrorIs(err, io.EOF)
+
+	require.ElementsMatch([]string{
+		"bytes=0-65535",
+		rangeHeader(fixture.index.Chunks[0].CompressedPayloadOffset, fixture.index.Chunks[0].CompressedLength),
+		rangeHeader(fixture.index.Chunks[1].CompressedPayloadOffset, fixture.index.Chunks[1].CompressedLength),
+	}, recorder.rangesSnapshot())
+}
+
+func BenchmarkOpenRawBlockPayload_CSCB_vs_Download(b *testing.B) {
+	fixture := newCSCBDownloaderFixtureWithPayloadSize(b, 2, 2, 4*1024*1024)
+	defer fixture.close()
+
+	server, _ := newRangeHTTPServer(fixture.data)
+	defer server.Close()
+	for _, file := range fixture.blockFiles {
+		file.FileUrl = server.URL
+	}
+
+	var dl BlockDownloader
+	app := testapp.New(
+		b,
+		fx.Provide(func() HTTPClient { return server.Client() }),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&dl),
+	)
+	defer app.Close()
+
+	blockFile := fixture.blockFiles[1]
+	b.Run("download_unmarshal", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			block, err := dl.Download(context.Background(), blockFile)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if got := len(block.GetSolana().GetHeader()); got == 0 {
+				b.Fatalf("expected solana payload, got %d bytes", got)
+			}
+		}
+	})
+	b.Run("open_raw_payload", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			payload, err := dl.OpenRawBlockPayload(context.Background(), blockFile)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := io.Copy(io.Discard, payload); err != nil {
+				_ = payload.Close()
+				b.Fatal(err)
+			}
+			if err := payload.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 func (s *blockDownloaderTestSuite) newHttpClientFunc() httpClientFunc {
 	return func() HTTPClient {
 		return s.httpServer.Client()
@@ -636,6 +800,10 @@ type cscbDownloaderFixture struct {
 }
 
 func newCSCBDownloaderFixture(t *testing.T, blockCount int, chunkBlocks uint64) *cscbDownloaderFixture {
+	return newCSCBDownloaderFixtureWithPayloadSize(t, blockCount, chunkBlocks, 0)
+}
+
+func newCSCBDownloaderFixtureWithPayloadSize(t testing.TB, blockCount int, chunkBlocks uint64, payloadSize int) *cscbDownloaderFixture {
 	t.Helper()
 	require := testutil.Require(t)
 
@@ -653,6 +821,15 @@ func newCSCBDownloaderFixture(t *testing.T, blockCount int, chunkBlocks uint64) 
 				Height:       height,
 				ParentHeight: height - 1,
 			},
+		}
+		if payloadSize > 0 {
+			block.Blockchain = common.Blockchain_BLOCKCHAIN_SOLANA
+			block.Network = common.Network_NETWORK_SOLANA_MAINNET
+			block.Blobdata = &api.Block_Solana{
+				Solana: &api.SolanaBlobdata{
+					Header: bytes.Repeat([]byte{byte('a' + i)}, payloadSize),
+				},
+			}
 		}
 		blockBytes, err := proto.Marshal(block)
 		require.NoError(err)

--- a/internal/storage/blobstorage/downloader/block_test.go
+++ b/internal/storage/blobstorage/downloader/block_test.go
@@ -616,15 +616,59 @@ func (s *blockDownloaderTestSuite) TestOpenRawBlockPayload_LegacyGzip() {
 		fx.Populate(&s.downloader),
 	)
 	s.blockFile.Compression = api.Compression_GZIP
+	s.blockFile.UncompressedLength = uint64(len(expectedBlockBytes))
 
 	payload, err := s.downloader.OpenRawBlockPayload(context.Background(), s.blockFile)
 	require.NoError(err)
 	defer payload.Close()
 	require.Equal(s.blockFile, payload.BlockFile)
+	require.Equal(uint64(len(expectedBlockBytes)), payload.Length)
 
 	got, err := io.ReadAll(payload)
 	require.NoError(err)
 	require.Equal(expectedBlockBytes, got)
+}
+
+func (s *blockDownloaderTestSuite) TestOpenRawBlockPayload_LegacyDetectsShortPayload() {
+	require := testutil.Require(s.T())
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(s.newHttpServerFunc(http.MethodGet, http.StatusOK, expectedBlockBytes[:len(expectedBlockBytes)-1])),
+		fx.Populate(&s.httpServer),
+		fx.Provide(s.newHttpClientFunc()),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+	s.blockFile.UncompressedLength = uint64(len(expectedBlockBytes))
+
+	payload, err := s.downloader.OpenRawBlockPayload(context.Background(), s.blockFile)
+	require.NoError(err)
+	defer payload.Close()
+
+	_, err = io.ReadAll(payload)
+	require.Error(err)
+	require.Contains(err.Error(), "length mismatch")
+}
+
+func (s *blockDownloaderTestSuite) TestOpenRawBlockPayload_LegacyDetectsOversizedPayload() {
+	require := testutil.Require(s.T())
+	s.app = testapp.New(
+		s.T(),
+		fx.Provide(s.newHttpServerFunc(http.MethodGet, http.StatusOK, append(append([]byte(nil), expectedBlockBytes...), []byte("extra")...))),
+		fx.Populate(&s.httpServer),
+		fx.Provide(s.newHttpClientFunc()),
+		fx.Provide(NewBlockDownloader),
+		fx.Populate(&s.downloader),
+	)
+	s.blockFile.UncompressedLength = uint64(len(expectedBlockBytes))
+
+	payload, err := s.downloader.OpenRawBlockPayload(context.Background(), s.blockFile)
+	require.NoError(err)
+	defer payload.Close()
+
+	_, err = io.ReadAll(payload)
+	require.Error(err)
+	require.Contains(err.Error(), "exceeds expected length")
 }
 
 func (s *blockDownloaderTestSuite) TestOpenRawBlockPayload_CSCBStreamsSinglePayload() {

--- a/internal/storage/blobstorage/downloader/mocks/mocks.go
+++ b/internal/storage/blobstorage/downloader/mocks/mocks.go
@@ -85,3 +85,33 @@ func (mr *MockBlockDownloaderMockRecorder) DownloadStream(arg0, arg1 any) *gomoc
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadStream", reflect.TypeOf((*MockBlockDownloader)(nil).DownloadStream), arg0, arg1)
 }
+
+// OpenRawBlockPayload mocks base method.
+func (m *MockBlockDownloader) OpenRawBlockPayload(arg0 context.Context, arg1 *chainstorage.BlockFile) (*downloader.RawBlockPayload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenRawBlockPayload", arg0, arg1)
+	ret0, _ := ret[0].(*downloader.RawBlockPayload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenRawBlockPayload indicates an expected call of OpenRawBlockPayload.
+func (mr *MockBlockDownloaderMockRecorder) OpenRawBlockPayload(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenRawBlockPayload", reflect.TypeOf((*MockBlockDownloader)(nil).OpenRawBlockPayload), arg0, arg1)
+}
+
+// OpenRawBlockPayloads mocks base method.
+func (m *MockBlockDownloader) OpenRawBlockPayloads(arg0 context.Context, arg1 []*chainstorage.BlockFile) (downloader.RawBlockPayloadIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenRawBlockPayloads", arg0, arg1)
+	ret0, _ := ret[0].(downloader.RawBlockPayloadIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenRawBlockPayloads indicates an expected call of OpenRawBlockPayloads.
+func (mr *MockBlockDownloaderMockRecorder) OpenRawBlockPayloads(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenRawBlockPayloads", reflect.TypeOf((*MockBlockDownloader)(nil).OpenRawBlockPayloads), arg0, arg1)
+}

--- a/internal/storage/blobstorage/downloader/raw_payload.go
+++ b/internal/storage/blobstorage/downloader/raw_payload.go
@@ -51,6 +51,14 @@ type (
 		closeOnce sync.Once
 	}
 
+	exactLengthReadCloser struct {
+		reader    io.ReadCloser
+		height    uint64
+		remaining uint64
+		validated bool
+		closed    bool
+	}
+
 	limitedReadCloser struct {
 		io.Reader
 		closer io.Closer
@@ -258,14 +266,19 @@ func (d *blockDownloaderImpl) openRawLegacyBlockPayload(ctx context.Context, blo
 		_ = httpResp.Body.Close()
 		return nil, xerrors.Errorf("wrap decompressor: %w", err)
 	}
-	return newRawBlockPayload(
-		blockFile,
-		blockFile.GetUncompressedLength(),
-		&multiCloserReadCloser{
-			Reader:  decoder,
-			closers: []io.Closer{decoder, httpResp.Body},
-		},
-	), nil
+	reader := io.ReadCloser(&multiCloserReadCloser{
+		Reader:  decoder,
+		closers: []io.Closer{decoder, httpResp.Body},
+	})
+	length := blockFile.GetUncompressedLength()
+	if length != 0 {
+		reader = &exactLengthReadCloser{
+			reader:    reader,
+			height:    blockFile.GetHeight(),
+			remaining: length,
+		}
+	}
+	return newRawBlockPayload(blockFile, length, reader), nil
 }
 
 func (d *blockDownloaderImpl) openRawCSCBBlockPayload(ctx context.Context, blockFile *api.BlockFile) (*RawBlockPayload, error) {
@@ -327,6 +340,76 @@ func (r *multiCloserReadCloser) Close() error {
 		}
 	})
 	return closeErr
+}
+
+func (r *exactLengthReadCloser) Read(buf []byte) (int, error) {
+	if r.closed {
+		return 0, xerrors.New("legacy raw block payload reader is closed")
+	}
+	if r.remaining == 0 {
+		return 0, r.validateEOF()
+	}
+	if len(buf) == 0 {
+		return 0, nil
+	}
+	if uint64(len(buf)) > r.remaining {
+		buf = buf[:int(r.remaining)]
+	}
+
+	n, err := r.reader.Read(buf)
+	if n > 0 {
+		r.remaining -= uint64(n)
+	}
+	if err != nil {
+		if r.remaining > 0 {
+			if err == io.EOF {
+				err = io.ErrUnexpectedEOF
+			}
+			return n, xerrors.Errorf("legacy raw block payload length mismatch at height %d: missing %d bytes: %w", r.height, r.remaining, err)
+		}
+		if err == io.EOF {
+			r.validated = true
+		}
+		return n, err
+	}
+	return n, nil
+}
+
+func (r *exactLengthReadCloser) Close() error {
+	if r.closed {
+		return nil
+	}
+	var closeErr error
+	if !r.validated {
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			closeErr = err
+		}
+	}
+	r.closed = true
+	if err := r.reader.Close(); closeErr == nil && err != nil {
+		closeErr = err
+	}
+	return closeErr
+}
+
+func (r *exactLengthReadCloser) validateEOF() error {
+	if r.validated {
+		return io.EOF
+	}
+	var extra [1]byte
+	n, err := r.reader.Read(extra[:])
+	if n > 0 {
+		r.validated = true
+		return xerrors.Errorf("legacy raw block payload length mismatch at height %d: payload exceeds expected length", r.height)
+	}
+	if err == nil {
+		return nil
+	}
+	if err == io.EOF {
+		r.validated = true
+		return io.EOF
+	}
+	return err
 }
 
 func (r *limitedReadCloser) Close() error {

--- a/internal/storage/blobstorage/downloader/raw_payload.go
+++ b/internal/storage/blobstorage/downloader/raw_payload.go
@@ -1,0 +1,334 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"sync"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage/cscb"
+	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
+	storage_utils "github.com/coinbase/chainstorage/internal/storage/utils"
+	"github.com/coinbase/chainstorage/internal/utils/retry"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type (
+	// RawBlockPayload is an open reader for one validated, decompressed
+	// protobuf-serialized api.Block payload. It deliberately does not unmarshal
+	// the payload.
+	RawBlockPayload struct {
+		BlockFile *api.BlockFile
+		Length    uint64
+
+		reader    io.ReadCloser
+		closeOnce sync.Once
+	}
+
+	// RawBlockPayloadIterator yields raw block payloads in input order and
+	// returns io.EOF when exhausted. The caller owns each returned payload and
+	// must close it before advancing if it wants bounded resources.
+	RawBlockPayloadIterator interface {
+		Next(ctx context.Context) (*RawBlockPayload, error)
+		Close() error
+	}
+
+	rawBlockPayloadIteratorImpl struct {
+		downloader *blockDownloaderImpl
+		blockFiles []*api.BlockFile
+		current    int
+		pending    []*RawBlockPayload
+		indexByURL map[string]*cscb.Index
+		closed     bool
+	}
+
+	multiCloserReadCloser struct {
+		io.Reader
+		closers   []io.Closer
+		closeOnce sync.Once
+	}
+
+	limitedReadCloser struct {
+		io.Reader
+		closer io.Closer
+	}
+)
+
+func (d *blockDownloaderImpl) OpenRawBlockPayload(ctx context.Context, blockFile *api.BlockFile) (*RawBlockPayload, error) {
+	if blockFile == nil {
+		return nil, xerrors.New("block file is required")
+	}
+	if blockFile.GetSkipped() {
+		return newBytesRawBlockPayload(blockFile, nil), nil
+	}
+	if isCSCBBlockFile(blockFile) {
+		return d.openRawCSCBBlockPayload(ctx, blockFile)
+	}
+	return d.retryRaw.Retry(ctx, func(ctx context.Context) (*RawBlockPayload, error) {
+		payload, err := d.openRawLegacyBlockPayload(ctx, blockFile)
+		if err != nil && (xerrors.Is(err, io.EOF) || xerrors.Is(err, io.ErrUnexpectedEOF)) {
+			return nil, retry.Retryable(err)
+		}
+		return payload, err
+	})
+}
+
+func (d *blockDownloaderImpl) OpenRawBlockPayloads(ctx context.Context, blockFiles []*api.BlockFile) (RawBlockPayloadIterator, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &rawBlockPayloadIteratorImpl{
+		downloader: d,
+		blockFiles: blockFiles,
+		indexByURL: make(map[string]*cscb.Index),
+	}, nil
+}
+
+func (p *RawBlockPayload) Read(buf []byte) (int, error) {
+	if p == nil || p.reader == nil {
+		return 0, xerrors.New("raw block payload is closed")
+	}
+	return p.reader.Read(buf)
+}
+
+func (p *RawBlockPayload) Close() error {
+	if p == nil {
+		return nil
+	}
+	var err error
+	p.closeOnce.Do(func() {
+		if p.reader != nil {
+			err = p.reader.Close()
+		}
+		p.reader = nil
+	})
+	return err
+}
+
+func (i *rawBlockPayloadIteratorImpl) Next(ctx context.Context) (*RawBlockPayload, error) {
+	if i.closed {
+		return nil, xerrors.New("raw block payload iterator is closed")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(i.pending) > 0 {
+		next := i.pending[0]
+		i.pending = i.pending[1:]
+		return next, nil
+	}
+	if i.current >= len(i.blockFiles) {
+		return nil, io.EOF
+	}
+
+	blockFile := i.blockFiles[i.current]
+	if blockFile.GetSkipped() || !isCSCBBlockFile(blockFile) {
+		i.current++
+		return i.downloader.OpenRawBlockPayload(ctx, blockFile)
+	}
+	if err := i.loadNextCSCBGroup(ctx); err != nil {
+		return nil, err
+	}
+	return i.Next(ctx)
+}
+
+func (i *rawBlockPayloadIteratorImpl) Close() error {
+	if i.closed {
+		return nil
+	}
+	i.closed = true
+	var closeErr error
+	for _, payload := range i.pending {
+		if err := payload.Close(); closeErr == nil && err != nil {
+			closeErr = err
+		}
+	}
+	i.pending = nil
+	return closeErr
+}
+
+func (i *rawBlockPayloadIteratorImpl) loadNextCSCBGroup(ctx context.Context) error {
+	firstFile := i.blockFiles[i.current]
+	fileURL := firstFile.GetFileUrl()
+	if fileURL == "" {
+		return xerrors.Errorf("missing CSCB file url for height %d", firstFile.GetHeight())
+	}
+	index, err := i.getCSCBIndex(ctx, fileURL)
+	if err != nil {
+		return err
+	}
+	firstBlock, firstChunk, err := index.LookupBlock(blockFileToMetadata(firstFile))
+	if err != nil {
+		return err
+	}
+
+	downloads := []cscbBlockDownload{{
+		ref: downloadRef{
+			index:     i.current,
+			blockFile: firstFile,
+		},
+		block: firstBlock,
+		chunk: firstChunk,
+	}}
+	nextIndex := i.current + 1
+	for nextIndex < len(i.blockFiles) {
+		nextFile := i.blockFiles[nextIndex]
+		if nextFile.GetSkipped() || !isCSCBBlockFile(nextFile) || nextFile.GetFileUrl() != fileURL {
+			break
+		}
+		nextBlock, nextChunk, err := index.LookupBlock(blockFileToMetadata(nextFile))
+		if err != nil {
+			return err
+		}
+		if nextChunk.Index != firstChunk.Index {
+			break
+		}
+		downloads = append(downloads, cscbBlockDownload{
+			ref: downloadRef{
+				index:     nextIndex,
+				blockFile: nextFile,
+			},
+			block: nextBlock,
+			chunk: nextChunk,
+		})
+		nextIndex++
+	}
+
+	blocks := make([]*cscb.BlockDescriptor, len(downloads))
+	for j, download := range downloads {
+		blocks[j] = download.block
+	}
+	payloads, err := i.downloader.downloadCSCBChunkPayloads(ctx, fileURL, index.Header.Codec, firstChunk, blocks)
+	if err != nil {
+		return err
+	}
+	if len(payloads) != len(downloads) {
+		return xerrors.Errorf("CSCB raw payload count mismatch: got %d want %d", len(payloads), len(downloads))
+	}
+
+	i.pending = make([]*RawBlockPayload, len(payloads))
+	for j, payload := range payloads {
+		i.pending[j] = newBytesRawBlockPayload(downloads[j].ref.blockFile, payload)
+	}
+	i.current = nextIndex
+	return nil
+}
+
+func (i *rawBlockPayloadIteratorImpl) getCSCBIndex(ctx context.Context, fileURL string) (*cscb.Index, error) {
+	if index, ok := i.indexByURL[fileURL]; ok {
+		return index, nil
+	}
+	index, err := i.downloader.readCSCBIndex(ctx, nil, fileURL)
+	if err != nil {
+		return nil, err
+	}
+	i.indexByURL[fileURL] = index
+	return index, nil
+}
+
+func (d *blockDownloaderImpl) openRawLegacyBlockPayload(ctx context.Context, blockFile *api.BlockFile) (*RawBlockPayload, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blockFile.GetFileUrl(), nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create download request: %w", err)
+	}
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, retry.Retryable(xerrors.Errorf("failed to download block file: %w", err))
+	}
+	if statusCode := httpResp.StatusCode; statusCode != http.StatusOK {
+		if httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
+		if statusCode == http.StatusRequestTimeout ||
+			statusCode == http.StatusTooManyRequests ||
+			statusCode >= http.StatusInternalServerError {
+			return nil, retry.Retryable(xerrors.Errorf("received %d status code: %w", statusCode, errors.ErrDownloadFailure))
+		}
+		return nil, xerrors.Errorf("received non-retryable %d status code: %w", statusCode, errors.ErrDownloadFailure)
+	}
+	if httpResp.Body == nil {
+		return nil, xerrors.Errorf("empty body for %s", blockFile.GetFileUrl())
+	}
+	decoder, err := storage_utils.DecompressReader(httpResp.Body, blockFile.GetCompression())
+	if err != nil {
+		_ = httpResp.Body.Close()
+		return nil, xerrors.Errorf("wrap decompressor: %w", err)
+	}
+	return newRawBlockPayload(
+		blockFile,
+		blockFile.GetUncompressedLength(),
+		&multiCloserReadCloser{
+			Reader:  decoder,
+			closers: []io.Closer{decoder, httpResp.Body},
+		},
+	), nil
+}
+
+func (d *blockDownloaderImpl) openRawCSCBBlockPayload(ctx context.Context, blockFile *api.BlockFile) (*RawBlockPayload, error) {
+	fileURL := blockFile.GetFileUrl()
+	if fileURL == "" {
+		return nil, xerrors.Errorf("missing CSCB file url for height %d", blockFile.GetHeight())
+	}
+	index, err := d.readCSCBIndex(ctx, nil, fileURL)
+	if err != nil {
+		return nil, err
+	}
+	block, chunk, err := index.LookupBlock(blockFileToMetadata(blockFile))
+	if err != nil {
+		return nil, err
+	}
+	return d.retryRaw.Retry(ctx, func(ctx context.Context) (*RawBlockPayload, error) {
+		body, err := d.openHTTPRangeByLengthUnthrottled(ctx, fileURL, chunk.CompressedPayloadOffset, chunk.CompressedLength)
+		if err != nil {
+			return nil, err
+		}
+		limitedBody, err := limitReaderByLength(body, chunk.CompressedLength)
+		if err != nil {
+			_ = body.Close()
+			return nil, err
+		}
+		reader, err := cscb.OpenBlockPayloadFromChunkFrame(&limitedReadCloser{
+			Reader: limitedBody,
+			closer: body,
+		}, index.Header.Codec, chunk, block)
+		if err != nil {
+			return nil, err
+		}
+		return newRawBlockPayload(blockFile, block.PayloadLength, reader), nil
+	})
+}
+
+func newBytesRawBlockPayload(blockFile *api.BlockFile, payload []byte) *RawBlockPayload {
+	return newRawBlockPayload(blockFile, uint64(len(payload)), io.NopCloser(bytes.NewReader(payload)))
+}
+
+func newRawBlockPayload(blockFile *api.BlockFile, length uint64, reader io.ReadCloser) *RawBlockPayload {
+	return &RawBlockPayload{
+		BlockFile: blockFile,
+		Length:    length,
+		reader:    reader,
+	}
+}
+
+func (r *multiCloserReadCloser) Close() error {
+	var closeErr error
+	r.closeOnce.Do(func() {
+		for _, closer := range r.closers {
+			if closer == nil {
+				continue
+			}
+			if err := closer.Close(); closeErr == nil && err != nil {
+				closeErr = err
+			}
+		}
+	})
+	return closeErr
+}
+
+func (r *limitedReadCloser) Close() error {
+	return r.closer.Close()
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -73,6 +73,22 @@ type (
 		// and thus you may get back FailedPrecondition errors if it goes beyond current tip due to reorg, especially for streaming case.
 		GetBlocksByRangeWithTag(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) ([]*api.Block, error)
 
+		// OpenRawBlockPayload opens the validated, decompressed protobuf payload bytes for one raw block
+		// without unmarshaling api.Block. height is required and hash is optional.
+		OpenRawBlockPayload(ctx context.Context, height uint64, hash string) (*RawBlockPayload, error)
+
+		// OpenRawBlockPayloadWithTag opens the validated, decompressed protobuf payload bytes for one raw block
+		// without unmarshaling api.Block. tag and hash are optional.
+		OpenRawBlockPayloadWithTag(ctx context.Context, tag uint32, height uint64, hash string) (*RawBlockPayload, error)
+
+		// OpenRawBlockPayloadsByRange opens an iterator over raw block payloads between [startHeight, endHeight)
+		// without unmarshaling api.Block. endHeight is optional and defaults to startHeight + 1.
+		OpenRawBlockPayloadsByRange(ctx context.Context, startHeight uint64, endHeight uint64) (RawBlockPayloadIterator, error)
+
+		// OpenRawBlockPayloadsByRangeWithTag opens an iterator over raw block payloads between [startHeight, endHeight)
+		// without unmarshaling api.Block. tag is optional and defaults to stable tag.
+		OpenRawBlockPayloadsByRangeWithTag(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (RawBlockPayloadIterator, error)
+
 		// GetBlockByTransaction returns the raw block(s) where the transaction resides,
 		// or an empty list if the transaction is not found.
 		// In most networks a transaction belongs to a single block, but there are exceptions.
@@ -120,6 +136,14 @@ type (
 
 		// GetBlocksByRangeWithTagAndReadSource returns raw blocks using the requested blob read source.
 		GetBlocksByRangeWithTagAndReadSource(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, readSource api.BlockReadSource) ([]*api.Block, error)
+	}
+
+	RawPayloadReadSourceClient interface {
+		// OpenRawBlockPayloadWithTagAndReadSource opens raw block payload bytes using the requested blob read source.
+		OpenRawBlockPayloadWithTagAndReadSource(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*RawBlockPayload, error)
+
+		// OpenRawBlockPayloadsByRangeWithTagAndReadSource opens raw block payload bytes using the requested blob read source.
+		OpenRawBlockPayloadsByRangeWithTagAndReadSource(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, readSource api.BlockReadSource) (RawBlockPayloadIterator, error)
 	}
 
 	ChainEventResult struct {
@@ -310,6 +334,106 @@ func (c *clientImpl) downloadBlocksByRange(ctx context.Context, tag uint32, star
 
 func (c *clientImpl) GetBlocksByRange(ctx context.Context, startHeight uint64, endHeight uint64) ([]*api.Block, error) {
 	return c.GetBlocksByRangeWithTag(ctx, c.tag, startHeight, endHeight)
+}
+
+func (c *clientImpl) OpenRawBlockPayload(ctx context.Context, height uint64, hash string) (*RawBlockPayload, error) {
+	return c.OpenRawBlockPayloadWithTag(ctx, c.tag, height, hash)
+}
+
+func (c *clientImpl) OpenRawBlockPayloadWithTag(ctx context.Context, tag uint32, height uint64, hash string) (*RawBlockPayload, error) {
+	return c.OpenRawBlockPayloadWithTagAndReadSource(ctx, tag, height, hash, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
+}
+
+func (c *clientImpl) OpenRawBlockPayloadWithTagAndReadSource(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*RawBlockPayload, error) {
+	payload, err := c.openRawBlockPayload(ctx, tag, height, hash, readSource)
+	if err == nil || readSource != api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED {
+		return payload, err
+	}
+
+	c.logger.Warn(
+		"consolidated raw block payload open failed; retrying legacy",
+		zap.Uint32("tag", tag),
+		zap.Uint64("height", height),
+		zap.String("hash", hash),
+		zap.Error(err),
+	)
+	payload, fallbackErr := c.openRawBlockPayload(ctx, tag, height, hash, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
+	if fallbackErr != nil {
+		return nil, xerrors.Errorf("failed to open consolidated raw block payload and legacy fallback failed (originalErr=%v): %w", err, fallbackErr)
+	}
+	return payload, nil
+}
+
+func (c *clientImpl) openRawBlockPayload(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*RawBlockPayload, error) {
+	blockFile, err := c.client.GetBlockFile(ctx, &api.GetBlockFileRequest{
+		Tag:        tag,
+		Height:     height,
+		Hash:       hash,
+		ReadSource: readSource,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query block file (tag=%v, height=%v, hash=%v): %w", tag, height, hash, err)
+	}
+
+	payload, err := c.blockDownloader.OpenRawBlockPayload(ctx, blockFile.GetFile())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open raw block payload (blockFile={%+v}): %w", blockFile.GetFile(), err)
+	}
+	return wrapRawBlockPayload(payload), nil
+}
+
+func (c *clientImpl) OpenRawBlockPayloadsByRange(ctx context.Context, startHeight uint64, endHeight uint64) (RawBlockPayloadIterator, error) {
+	return c.OpenRawBlockPayloadsByRangeWithTag(ctx, c.tag, startHeight, endHeight)
+}
+
+func (c *clientImpl) OpenRawBlockPayloadsByRangeWithTag(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (RawBlockPayloadIterator, error) {
+	return c.OpenRawBlockPayloadsByRangeWithTagAndReadSource(ctx, tag, startHeight, endHeight, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
+}
+
+func (c *clientImpl) OpenRawBlockPayloadsByRangeWithTagAndReadSource(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, readSource api.BlockReadSource) (RawBlockPayloadIterator, error) {
+	if endHeight == 0 {
+		endHeight = startHeight + 1
+	}
+
+	iter, err := c.openRawBlockPayloadsByRange(ctx, tag, startHeight, endHeight, readSource)
+	if err == nil || readSource != api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED {
+		return iter, err
+	}
+
+	c.logger.Warn(
+		"consolidated raw block payload range open failed; retrying legacy",
+		zap.Uint32("tag", tag),
+		zap.Uint64("start_height", startHeight),
+		zap.Uint64("end_height", endHeight),
+		zap.Error(err),
+	)
+	iter, fallbackErr := c.openRawBlockPayloadsByRange(ctx, tag, startHeight, endHeight, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
+	if fallbackErr != nil {
+		return nil, xerrors.Errorf("failed to open consolidated raw block payload range and legacy fallback failed (originalErr=%v): %w", err, fallbackErr)
+	}
+	return iter, nil
+}
+
+func (c *clientImpl) openRawBlockPayloadsByRange(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, readSource api.BlockReadSource) (RawBlockPayloadIterator, error) {
+	resp, err := c.client.GetBlockFilesByRange(ctx, &api.GetBlockFilesByRangeRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+		ReadSource:  readSource,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get block file metadata (tag=%d, startHeight=%d, endHeight=%d): %w", tag, startHeight, endHeight, err)
+	}
+	blockFiles := resp.GetFiles()
+	if len(blockFiles) == 0 {
+		return nil, xerrors.Errorf("no block file metadata found")
+	}
+
+	iter, err := c.blockDownloader.OpenRawBlockPayloads(ctx, blockFiles)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open raw block payload iterator: %w", err)
+	}
+	return &rawBlockPayloadIterator{inner: iter}, nil
 }
 
 func (c *clientImpl) StreamChainEvents(ctx context.Context, cfg StreamingConfiguration) (<-chan *ChainEventResult, error) {

--- a/sdk/client_interceptor.go
+++ b/sdk/client_interceptor.go
@@ -228,6 +228,46 @@ func (c *timeoutableClient) getBlocksByRangeWithTagAndReadSource(
 	})
 }
 
+// OpenRawBlockPayload passes through to the wrapped client. No timeout
+// wrapping: the returned reader lifetime is user-controlled.
+func (c *timeoutableClient) OpenRawBlockPayload(ctx context.Context, height uint64, hash string) (*RawBlockPayload, error) {
+	return c.client.OpenRawBlockPayload(ctx, height, hash)
+}
+
+// OpenRawBlockPayloadWithTag passes through to the wrapped client. No timeout
+// wrapping: the returned reader lifetime is user-controlled.
+func (c *timeoutableClient) OpenRawBlockPayloadWithTag(ctx context.Context, tag uint32, height uint64, hash string) (*RawBlockPayload, error) {
+	return c.client.OpenRawBlockPayloadWithTag(ctx, tag, height, hash)
+}
+
+func (c *timeoutableClient) OpenRawBlockPayloadWithTagAndReadSource(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*RawBlockPayload, error) {
+	rawPayloadClient, ok := c.client.(RawPayloadReadSourceClient)
+	if !ok {
+		return nil, xerrors.Errorf("client %T does not support raw payload read source override", c.client)
+	}
+	return rawPayloadClient.OpenRawBlockPayloadWithTagAndReadSource(ctx, tag, height, hash, readSource)
+}
+
+// OpenRawBlockPayloadsByRange passes through to the wrapped client. No timeout
+// wrapping: iterator reads are user-controlled.
+func (c *timeoutableClient) OpenRawBlockPayloadsByRange(ctx context.Context, startHeight uint64, endHeight uint64) (RawBlockPayloadIterator, error) {
+	return c.client.OpenRawBlockPayloadsByRange(ctx, startHeight, endHeight)
+}
+
+// OpenRawBlockPayloadsByRangeWithTag passes through to the wrapped client. No
+// timeout wrapping: iterator reads are user-controlled.
+func (c *timeoutableClient) OpenRawBlockPayloadsByRangeWithTag(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (RawBlockPayloadIterator, error) {
+	return c.client.OpenRawBlockPayloadsByRangeWithTag(ctx, tag, startHeight, endHeight)
+}
+
+func (c *timeoutableClient) OpenRawBlockPayloadsByRangeWithTagAndReadSource(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, readSource api.BlockReadSource) (RawBlockPayloadIterator, error) {
+	rawPayloadClient, ok := c.client.(RawPayloadReadSourceClient)
+	if !ok {
+		return nil, xerrors.Errorf("client %T does not support raw payload read source override", c.client)
+	}
+	return rawPayloadClient.OpenRawBlockPayloadsByRangeWithTagAndReadSource(ctx, tag, startHeight, endHeight, readSource)
+}
+
 func (c *timeoutableClient) GetBlockByTransaction(ctx context.Context, tag uint32, transactionHash string) ([]*api.Block, error) {
 	return intercept(ctx, c.logger, func(ctx context.Context) ([]*api.Block, error) {
 		ctx, cancel := context.WithTimeout(ctx, c.mediumTimeout)

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -346,6 +349,63 @@ func (s *clientTestSuite) TestGetBlocksByRangeWithTagAndReadSource_FallsBackToLe
 	s.require.NoError(err)
 	s.require.Equal(numBlocks, len(fetchedBlocks))
 	s.require.Equal(blocks, fetchedBlocks)
+}
+
+func TestClientOpenRawBlockPayloadWithTag(t *testing.T) {
+	require := testutil.Require(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const (
+		tag    = uint32(2)
+		height = uint64(12345)
+		hash   = "0xabcde"
+	)
+	block := testutil.MakeBlock(height, tag)
+	blockBytes, err := proto.Marshal(block)
+	require.NoError(err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(http.MethodGet, request.Method)
+		_, _ = writer.Write(blockBytes)
+	}))
+	defer server.Close()
+
+	gatewayClient := apimocks.NewMockChainStorageClient(ctrl)
+	blockFile := &api.BlockFile{
+		Tag:     tag,
+		Height:  height,
+		Hash:    hash,
+		FileUrl: server.URL,
+	}
+	gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+		Tag:    tag,
+		Height: height,
+		Hash:   hash,
+	}).Return(&api.GetBlockFileResponse{
+		File: blockFile,
+	}, nil)
+
+	var client Client
+	app := testapp.New(
+		t,
+		Module,
+		parser.Module,
+		fx.Provide(func() downloader.HTTPClient { return server.Client() }),
+		fx.Provide(downloader.NewBlockDownloader),
+		fx.Provide(func() gateway.Client { return gatewayClient }),
+		fx.Populate(&client),
+	)
+	defer app.Close()
+
+	payload, err := client.OpenRawBlockPayloadWithTag(context.Background(), tag, height, hash)
+	require.NoError(err)
+	defer payload.Close()
+	require.Equal(blockFile, payload.BlockFile)
+
+	got, err := io.ReadAll(payload)
+	require.NoError(err)
+	require.Equal(blockBytes, got)
 }
 
 func (s *clientTestSuite) TestStreamBlocks() {

--- a/sdk/mocks/mocks.go
+++ b/sdk/mocks/mocks.go
@@ -248,6 +248,66 @@ func (mr *MockClientMockRecorder) GetTag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTag", reflect.TypeOf((*MockClient)(nil).GetTag))
 }
 
+// OpenRawBlockPayload mocks base method.
+func (m *MockClient) OpenRawBlockPayload(arg0 context.Context, arg1 uint64, arg2 string) (*sdk.RawBlockPayload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenRawBlockPayload", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*sdk.RawBlockPayload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenRawBlockPayload indicates an expected call of OpenRawBlockPayload.
+func (mr *MockClientMockRecorder) OpenRawBlockPayload(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenRawBlockPayload", reflect.TypeOf((*MockClient)(nil).OpenRawBlockPayload), arg0, arg1, arg2)
+}
+
+// OpenRawBlockPayloadWithTag mocks base method.
+func (m *MockClient) OpenRawBlockPayloadWithTag(arg0 context.Context, arg1 uint32, arg2 uint64, arg3 string) (*sdk.RawBlockPayload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenRawBlockPayloadWithTag", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*sdk.RawBlockPayload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenRawBlockPayloadWithTag indicates an expected call of OpenRawBlockPayloadWithTag.
+func (mr *MockClientMockRecorder) OpenRawBlockPayloadWithTag(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenRawBlockPayloadWithTag", reflect.TypeOf((*MockClient)(nil).OpenRawBlockPayloadWithTag), arg0, arg1, arg2, arg3)
+}
+
+// OpenRawBlockPayloadsByRange mocks base method.
+func (m *MockClient) OpenRawBlockPayloadsByRange(arg0 context.Context, arg1, arg2 uint64) (sdk.RawBlockPayloadIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenRawBlockPayloadsByRange", arg0, arg1, arg2)
+	ret0, _ := ret[0].(sdk.RawBlockPayloadIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenRawBlockPayloadsByRange indicates an expected call of OpenRawBlockPayloadsByRange.
+func (mr *MockClientMockRecorder) OpenRawBlockPayloadsByRange(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenRawBlockPayloadsByRange", reflect.TypeOf((*MockClient)(nil).OpenRawBlockPayloadsByRange), arg0, arg1, arg2)
+}
+
+// OpenRawBlockPayloadsByRangeWithTag mocks base method.
+func (m *MockClient) OpenRawBlockPayloadsByRangeWithTag(arg0 context.Context, arg1 uint32, arg2, arg3 uint64) (sdk.RawBlockPayloadIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenRawBlockPayloadsByRangeWithTag", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(sdk.RawBlockPayloadIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenRawBlockPayloadsByRangeWithTag indicates an expected call of OpenRawBlockPayloadsByRangeWithTag.
+func (mr *MockClientMockRecorder) OpenRawBlockPayloadsByRangeWithTag(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenRawBlockPayloadsByRangeWithTag", reflect.TypeOf((*MockClient)(nil).OpenRawBlockPayloadsByRangeWithTag), arg0, arg1, arg2, arg3)
+}
+
 // SetBlockValidation mocks base method.
 func (m *MockClient) SetBlockValidation(arg0 bool) {
 	m.ctrl.T.Helper()

--- a/sdk/raw_payload.go
+++ b/sdk/raw_payload.go
@@ -1,0 +1,85 @@
+package sdk
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type (
+	// RawBlockPayload is an open reader for one validated, decompressed
+	// protobuf-serialized api.Block payload. It deliberately does not unmarshal
+	// the payload. Callers must read it to EOF or close it to complete
+	// downloader-side validation and release resources.
+	RawBlockPayload struct {
+		BlockFile *api.BlockFile
+		Length    uint64
+
+		reader    io.ReadCloser
+		closeOnce sync.Once
+	}
+
+	// RawBlockPayloadIterator yields raw block payloads in height/range order
+	// and returns io.EOF when exhausted. Callers must close every returned
+	// payload and then close the iterator.
+	RawBlockPayloadIterator interface {
+		Next(ctx context.Context) (*RawBlockPayload, error)
+		Close() error
+	}
+
+	rawBlockPayloadIterator struct {
+		inner downloader.RawBlockPayloadIterator
+	}
+)
+
+func (p *RawBlockPayload) Read(buf []byte) (int, error) {
+	if p == nil || p.reader == nil {
+		return 0, xerrors.New("raw block payload is closed")
+	}
+	return p.reader.Read(buf)
+}
+
+func (p *RawBlockPayload) Close() error {
+	if p == nil {
+		return nil
+	}
+	var err error
+	p.closeOnce.Do(func() {
+		if p.reader != nil {
+			err = p.reader.Close()
+		}
+		p.reader = nil
+	})
+	return err
+}
+
+func (i *rawBlockPayloadIterator) Next(ctx context.Context) (*RawBlockPayload, error) {
+	payload, err := i.inner.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return wrapRawBlockPayload(payload), nil
+}
+
+func (i *rawBlockPayloadIterator) Close() error {
+	if i == nil || i.inner == nil {
+		return nil
+	}
+	return i.inner.Close()
+}
+
+func wrapRawBlockPayload(payload *downloader.RawBlockPayload) *RawBlockPayload {
+	if payload == nil {
+		return nil
+	}
+	return &RawBlockPayload{
+		BlockFile: payload.BlockFile,
+		Length:    payload.Length,
+		reader:    payload,
+	}
+}


### PR DESCRIPTION
## Summary
- Add SDK raw payload readers and range iterators that expose validated decompressed protobuf payload bytes without unmarshaling `api.Block`.
- Add CSCB target-payload streaming from compressed chunk ranges with payload CRC/hash/length validation.
- Group CSCB range reads by object/chunk and keep legacy/skipped block behavior additive.
- Adversarial review follow-up: validate legacy raw payload length when `UncompressedLength` metadata is available.

## Validation
- `PATH="$(go env GOPATH)/bin:$PATH" make lint`
- `PATH="$(go env GOPATH)/bin:$PATH" make test > /tmp/chainstorage-make-test.log 2>&1`
- `go test ./internal/storage/blobstorage/... ./sdk/...`
- `go test ./internal/storage/blobstorage/downloader -run '^$' -bench 'BenchmarkOpenRawBlockPayload_CSCB_vs_Download' -benchtime=1x`
  - `download_unmarshal`: 93508083 ns/op, 13916040 B/op, 411 allocs/op
  - `open_raw_payload`: 5626875 ns/op, 5450264 B/op, 247 allocs/op