### PR TITLE
feat(INF-975): add legacy block retirement planner

### DIFF
--- a/cmd/admin/retirement.go
+++ b/cmd/admin/retirement.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/aws"
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/s3"
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
+)
+
+type retirementFlags struct {
+	tag                     uint32
+	startHeight             uint64
+	endHeight               uint64
+	limit                   uint64
+	gracePeriod             time.Duration
+	approveChain            string
+	approveStartHeight      uint64
+	approveEndHeight        uint64
+	clientMigrationApproved bool
+	fallbackErrorCount      uint64
+	execute                 bool
+	reportFile              string
+}
+
+var legacyRetirementFlags retirementFlags
+
+func newRetirementCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "retirement",
+		Short: "plan and execute guarded storage retirement operations",
+	}
+	cmd.AddCommand(newLegacyRetirementPlanCommand())
+	return cmd
+}
+
+func newLegacyRetirementPlanCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plan-legacy-single-blocks",
+		Short: "dry-run legacy single-block object retirement after CSCB validation",
+		Long: `Plan retirement for legacy single-block S3 objects that already have validated CSCB shadow metadata.
+
+The command is dry-run by default. It emits one auditable JSON report containing the bucket,
+legacy key, version id when available, height, hash, legacy bytes, consolidated key,
+validated_at, eligible_at, action, and skip reason for every scanned canonical row.
+
+Production deletion is disabled. Non-production execution deletes only an explicit S3 object
+version; rows without a version id are skipped to avoid delete-marker-only cleanup.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLegacyRetirementPlan(cmd.Context(), legacyRetirementFlags)
+		},
+	}
+
+	cmd.Flags().Uint32Var(&legacyRetirementFlags.tag, "tag", 0, "block tag; default zero resolves to the configured stable tag")
+	cmd.Flags().Uint64Var(&legacyRetirementFlags.startHeight, "start-height", 0, "inclusive block start height")
+	cmd.Flags().Uint64Var(&legacyRetirementFlags.endHeight, "end-height", 0, "exclusive block end height")
+	cmd.Flags().Uint64Var(&legacyRetirementFlags.limit, "limit", 0, "maximum rows to scan; default scans the full range")
+	cmd.Flags().DurationVar(&legacyRetirementFlags.gracePeriod, "grace-period", 7*24*time.Hour, "minimum age after validated_at before a row is eligible")
+	cmd.Flags().StringVar(&legacyRetirementFlags.approveChain, "approve-chain", "", "explicit chain approval, e.g. solana-mainnet")
+	cmd.Flags().Uint64Var(&legacyRetirementFlags.approveStartHeight, "approve-start-height", 0, "explicit approved start height")
+	cmd.Flags().Uint64Var(&legacyRetirementFlags.approveEndHeight, "approve-end-height", 0, "explicit approved end height")
+	cmd.Flags().BoolVar(&legacyRetirementFlags.clientMigrationApproved, "client-migration-approved", false, "confirm known file clients are migrated or out of scope")
+	cmd.Flags().Uint64Var(&legacyRetirementFlags.fallbackErrorCount, "fallback-read-errors", 0, "active fallback/read error count from the operator's observation window")
+	cmd.Flags().BoolVar(&legacyRetirementFlags.execute, "execute", false, "non-production only: delete eligible legacy object versions")
+	cmd.Flags().StringVar(&legacyRetirementFlags.reportFile, "report-file", "", "write JSON report to this file instead of stdout")
+
+	_ = cmd.MarkFlagRequired("start-height")
+	_ = cmd.MarkFlagRequired("end-height")
+	return cmd
+}
+
+func runLegacyRetirementPlan(ctx context.Context, flags retirementFlags) error {
+	if flags.endHeight <= flags.startHeight {
+		return xerrors.Errorf("end height must be greater than start height: start=%d end=%d", flags.startHeight, flags.endHeight)
+	}
+	if flags.execute && strings.EqualFold(commonFlags.env, string(config.EnvProduction)) {
+		return xerrors.New("production deletion is disabled; run without --execute for a dry-run report")
+	}
+
+	var deps struct {
+		fx.In
+		S3Client s3.Client
+	}
+	app := startApp(
+		aws.Module,
+		s3.Module,
+		fx.Populate(&deps),
+	)
+	defer app.Close()
+	cfg := app.Config()
+	if cfg.StorageType.MetaStorageType != config.MetaStorageType_POSTGRES {
+		return xerrors.Errorf("legacy retirement planner requires Postgres meta storage, got %v", cfg.StorageType.MetaStorageType)
+	}
+	if cfg.StorageType.BlobStorageType != config.BlobStorageType_UNSPECIFIED && cfg.StorageType.BlobStorageType != config.BlobStorageType_S3 {
+		return xerrors.Errorf("legacy retirement planner requires S3 blob storage, got %v", cfg.StorageType.BlobStorageType)
+	}
+	if cfg.AWS.Postgres == nil {
+		return xerrors.New("postgres config is required")
+	}
+
+	tag := cfg.GetEffectiveBlockTag(flags.tag)
+	targetChain := approvalChainFromFlags()
+	logger.Info("planning legacy single-block retirement",
+		zap.String("environment", string(cfg.Env())),
+		zap.String("chain", targetChain),
+		zap.String("bucket", cfg.AWS.Bucket),
+		zap.Uint32("tag", tag),
+		zap.Uint64("start_height", flags.startHeight),
+		zap.Uint64("end_height", flags.endHeight),
+		zap.Bool("execute", flags.execute),
+	)
+
+	db, err := openReadOnlyPostgres(ctx, cfg.AWS.Postgres)
+	if err != nil {
+		return xerrors.Errorf("failed to open read-only postgres connection: %w", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	planner := retirement.NewPlanner(
+		retirement.NewPostgresRepository(db),
+		retirement.NewS3ObjectStore(deps.S3Client),
+	)
+	req := retirement.PlanRequest{
+		Environment:             string(cfg.Env()),
+		Blockchain:              commonFlags.blockchain,
+		Network:                 commonFlags.network,
+		Sidechain:               commonFlags.sidechain,
+		Bucket:                  cfg.AWS.Bucket,
+		Tag:                     tag,
+		StartHeight:             flags.startHeight,
+		EndHeight:               flags.endHeight,
+		Limit:                   flags.limit,
+		Now:                     time.Now().UTC(),
+		GracePeriod:             flags.gracePeriod,
+		Execute:                 flags.execute,
+		ClientMigrationApproved: flags.clientMigrationApproved,
+		FallbackErrorCount:      flags.fallbackErrorCount,
+		Approval: retirement.Approval{
+			Chain:       flags.approveChain,
+			StartHeight: flags.approveStartHeight,
+			EndHeight:   flags.approveEndHeight,
+		},
+	}
+
+	report, err := planner.Plan(ctx, req)
+	if err != nil {
+		return xerrors.Errorf("failed to plan legacy retirement: %w", err)
+	}
+	if flags.execute {
+		if err := planner.Apply(ctx, req, report); err != nil {
+			return xerrors.Errorf("failed to execute legacy retirement: %w", err)
+		}
+	}
+	if err := writeRetirementReport(flags.reportFile, report); err != nil {
+		return err
+	}
+	return nil
+}
+
+func openReadOnlyPostgres(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, error) {
+	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
+		cfg.Host, cfg.Port, cfg.Database, cfg.User, cfg.Password, cfg.SSLMode)
+	if cfg.ConnectTimeout > 0 {
+		dsn += fmt.Sprintf(" connect_timeout=%d", int(cfg.ConnectTimeout.Seconds()))
+	}
+	dsn += " options='-c default_transaction_read_only=on'"
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.MaxConnections > 0 {
+		db.SetMaxOpenConns(cfg.MaxConnections)
+	}
+	if cfg.MinConnections > 0 {
+		db.SetMaxIdleConns(cfg.MinConnections)
+	}
+	db.SetConnMaxLifetime(cfg.MaxLifetime)
+	db.SetConnMaxIdleTime(cfg.MaxIdleTime)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func writeRetirementReport(path string, report *retirement.Report) error {
+	if path == "" {
+		return retirement.WriteReportJSON(os.Stdout, report)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return xerrors.Errorf("failed to create report file %s: %w", path, err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	if err := retirement.WriteReportJSON(file, report); err != nil {
+		return xerrors.Errorf("failed to write report file %s: %w", path, err)
+	}
+	return nil
+}
+
+func approvalChainFromFlags() string {
+	parts := []string{commonFlags.blockchain, commonFlags.network}
+	if commonFlags.sidechain != "" {
+		parts = append(parts, commonFlags.sidechain)
+	}
+	return strings.Join(parts, "-")
+}
+
+func init() {
+	rootCmd.AddCommand(newRetirementCommand())
+}

--- a/internal/s3/client.go
+++ b/internal/s3/client.go
@@ -23,6 +23,7 @@ type (
 		CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
 		DeleteBucket(ctx context.Context, params *s3.DeleteBucketInput, optFns ...func(*s3.Options)) (*s3.DeleteBucketOutput, error)
 		ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+		ListObjectVersions(ctx context.Context, params *s3.ListObjectVersionsInput, optFns ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
 		DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 		DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
 	}

--- a/internal/s3/mocks/mocks.go
+++ b/internal/s3/mocks/mocks.go
@@ -288,6 +288,26 @@ func (mr *MockClientMockRecorder) ListObjectsV2(arg0, arg1 any, arg2 ...any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsV2", reflect.TypeOf((*MockClient)(nil).ListObjectsV2), varargs...)
 }
 
+// ListObjectVersions mocks base method.
+func (m *MockClient) ListObjectVersions(arg0 context.Context, arg1 *s3.ListObjectVersionsInput, arg2 ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListObjectVersions", varargs...)
+	ret0, _ := ret[0].(*s3.ListObjectVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjectVersions indicates an expected call of ListObjectVersions.
+func (mr *MockClientMockRecorder) ListObjectVersions(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectVersions", reflect.TypeOf((*MockClient)(nil).ListObjectVersions), varargs...)
+}
+
 // PutObject mocks base method.
 func (m *MockClient) PutObject(arg0 context.Context, arg1 *s3.PutObjectInput, arg2 ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	m.ctrl.T.Helper()

--- a/internal/storage/retirement/output.go
+++ b/internal/storage/retirement/output.go
@@ -1,0 +1,12 @@
+package retirement
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func WriteReportJSON(w io.Writer, report *Report) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -1,0 +1,285 @@
+package retirement
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type Planner struct {
+	repo  Repository
+	store ObjectStore
+}
+
+func NewPlanner(repo Repository, store ObjectStore) *Planner {
+	return &Planner{
+		repo:  repo,
+		store: store,
+	}
+}
+
+func (p *Planner) Plan(ctx context.Context, req PlanRequest) (*Report, error) {
+	if req.EndHeight <= req.StartHeight {
+		return nil, xerrors.Errorf("end height must be greater than start height: start=%d end=%d", req.StartHeight, req.EndHeight)
+	}
+	if req.Bucket == "" {
+		return nil, xerrors.New("bucket is required")
+	}
+	if req.GracePeriod == 0 {
+		req.GracePeriod = 7 * 24 * time.Hour
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	}
+	rows, err := p.repo.ListMetadataRows(ctx, req.Tag, req.StartHeight, req.EndHeight, req.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &Report{
+		GeneratedAt: req.Now,
+		DryRun:      !req.Execute,
+		Environment: req.Environment,
+		Blockchain:  req.Blockchain,
+		Network:     req.Network,
+		Sidechain:   req.Sidechain,
+		Bucket:      req.Bucket,
+		Tag:         req.Tag,
+		StartHeight: req.StartHeight,
+		EndHeight:   req.EndHeight,
+		GracePeriod: req.GracePeriod.String(),
+		Approval:    req.Approval,
+		SafetyGates: SafetyGates{
+			ClientMigrationApproved: req.ClientMigrationApproved,
+			FallbackReadErrors:      req.FallbackErrorCount,
+			VersionedDeleteMode:     "explicit_object_version_only",
+			ProductionDeleteEnabled: false,
+		},
+		Items: make([]Candidate, 0, len(rows)),
+	}
+
+	cscbHeads := make(map[string]ObjectHead)
+	legacyVersions := make(map[string]ObjectVersion)
+	for _, row := range rows {
+		item := p.planRow(ctx, req, row, cscbHeads, legacyVersions)
+		report.Items = append(report.Items, item)
+	}
+	report.Summary = summarize(report.Items)
+	return report, nil
+}
+
+func (p *Planner) Apply(ctx context.Context, req PlanRequest, report *Report) error {
+	if report == nil {
+		return xerrors.New("report is required")
+	}
+	if isProduction(req.Environment) {
+		return xerrors.New("production deletion is disabled; run dry-run/report only")
+	}
+	for i := range report.Items {
+		item := &report.Items[i]
+		if item.Action != ActionDeleteObjectVersion {
+			continue
+		}
+		if item.VersionID == "" {
+			item.Action = ActionSkip
+			item.SkipReason = SkipLegacyVersionIDUnavailable
+			continue
+		}
+		if err := p.store.DeleteObjectVersion(ctx, item.Bucket, item.Key, item.VersionID); err != nil {
+			item.Action = ActionSkip
+			item.SkipReason = SkipVersionedDeleteFailed
+			return xerrors.Errorf("failed to delete object version (bucket=%s key=%s version_id=%s): %w", item.Bucket, item.Key, item.VersionID, err)
+		}
+		item.Action = ActionDeletedObjectVersion
+	}
+	report.Summary = summarize(report.Items)
+	return nil
+}
+
+func (p *Planner) planRow(
+	ctx context.Context,
+	req PlanRequest,
+	row MetadataRow,
+	cscbHeads map[string]ObjectHead,
+	legacyVersions map[string]ObjectVersion,
+) Candidate {
+	item := Candidate{
+		Bucket: req.Bucket,
+		Key:    row.LegacyObjectKey,
+		Height: row.Height,
+		Hash:   row.Hash,
+		Action: ActionSkip,
+	}
+
+	if row.Skipped {
+		item.SkipReason = SkipSkippedBlock
+		return item
+	}
+	if row.PrimaryObjectFormat == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH || row.PrimaryByteLength > 0 {
+		item.SkipReason = SkipPrimaryNotLegacySingleBlock
+		return item
+	}
+	if row.LegacyObjectKey == "" {
+		item.SkipReason = SkipMissingLegacyKey
+		return item
+	}
+	if row.Shadow == nil {
+		item.SkipReason = SkipMissingConsolidationShadow
+		return item
+	}
+	shadow := row.Shadow
+	item.ConsolidatedKey = shadow.ConsolidatedObjectKey
+	item.ValidatedAt = shadow.ValidatedAt
+	if shadow.ValidatedAt != nil {
+		eligibleAt := shadow.ValidatedAt.Add(req.GracePeriod)
+		item.EligibleAt = &eligibleAt
+	}
+	if shadow.ValidatedAt == nil {
+		item.SkipReason = SkipValidationNotPassed
+		return item
+	}
+	if !validShadowReference(row, shadow) {
+		item.SkipReason = SkipInvalidMetadataReference
+		return item
+	}
+	if item.EligibleAt != nil && req.Now.Before(*item.EligibleAt) {
+		item.SkipReason = SkipGracePeriodActive
+		return item
+	}
+	if !approvalMatches(req) {
+		item.SkipReason = SkipChainRangeNotApproved
+		return item
+	}
+	if req.FallbackErrorCount > 0 {
+		item.SkipReason = SkipActiveFallbackOrReadErrors
+		return item
+	}
+	if !req.ClientMigrationApproved {
+		item.SkipReason = SkipFileClientsNotApproved
+		return item
+	}
+
+	version, ok := legacyVersions[row.LegacyObjectKey]
+	if !ok {
+		var err error
+		version, err = p.store.CurrentObjectVersion(ctx, req.Bucket, row.LegacyObjectKey)
+		if err != nil {
+			item.SkipReason = SkipObjectInspectionFailed
+			return item
+		}
+		legacyVersions[row.LegacyObjectKey] = version
+	}
+	if !version.Exists {
+		item.SkipReason = SkipLegacyObjectMissing
+		return item
+	}
+	if version.CurrentDeleteMarker {
+		item.SkipReason = SkipLegacyCurrentDeleteMarker
+		return item
+	}
+	item.VersionID = version.VersionID
+	item.LegacyBytes = version.Bytes
+	if item.VersionID == "" {
+		item.SkipReason = SkipLegacyVersionIDUnavailable
+		return item
+	}
+
+	head, ok := cscbHeads[shadow.ConsolidatedObjectKey]
+	if !ok {
+		var err error
+		head, err = p.store.HeadObject(ctx, req.Bucket, shadow.ConsolidatedObjectKey)
+		if err != nil {
+			item.SkipReason = SkipObjectInspectionFailed
+			return item
+		}
+		cscbHeads[shadow.ConsolidatedObjectKey] = head
+	}
+	if !head.Exists || head.DeleteMark {
+		item.SkipReason = SkipMissingCSCBObject
+		return item
+	}
+	if shadow.ByteOffset > head.Bytes || shadow.ByteLength > head.Bytes-shadow.ByteOffset {
+		item.SkipReason = SkipInvalidMetadataReference
+		return item
+	}
+
+	if req.Execute {
+		if isProduction(req.Environment) {
+			item.SkipReason = SkipProductionDeletionDisabled
+			return item
+		}
+		item.Action = ActionDeleteObjectVersion
+		item.SkipReason = ""
+		return item
+	}
+	item.Action = ActionReportOnly
+	item.SkipReason = ""
+	return item
+}
+
+func validShadowReference(row MetadataRow, shadow *ConsolidationShadow) bool {
+	if shadow == nil {
+		return false
+	}
+	if shadow.Tag != row.Tag || shadow.Height != row.Height || shadow.Hash != row.Hash {
+		return false
+	}
+	if shadow.LegacyObjectKey != row.LegacyObjectKey {
+		return false
+	}
+	if shadow.ConsolidatedObjectKey == "" {
+		return false
+	}
+	if shadow.ObjectFormat != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH {
+		return false
+	}
+	if shadow.ByteLength == 0 {
+		return false
+	}
+	return true
+}
+
+func approvalMatches(req PlanRequest) bool {
+	return normalizeApprovalChain(req.Approval.Chain) == normalizeApprovalChain(actualChain(req)) &&
+		req.Approval.StartHeight == req.StartHeight &&
+		req.Approval.EndHeight == req.EndHeight
+}
+
+func actualChain(req PlanRequest) string {
+	parts := []string{req.Blockchain, req.Network}
+	if req.Sidechain != "" {
+		parts = append(parts, req.Sidechain)
+	}
+	return strings.Join(parts, "-")
+}
+
+func normalizeApprovalChain(value string) string {
+	return strings.ToLower(strings.ReplaceAll(value, "_", "-"))
+}
+
+func isProduction(env string) bool {
+	env = strings.ToLower(env)
+	return env == "production" || env == "prod"
+}
+
+func summarize(items []Candidate) Summary {
+	var summary Summary
+	summary.TotalRows = len(items)
+	for _, item := range items {
+		summary.LegacyBytes += item.LegacyBytes
+		if item.SkipReason == SkipLegacyCurrentDeleteMarker {
+			summary.DeleteMarkerRows++
+		}
+		if item.Action == ActionReportOnly || item.Action == ActionDeleteObjectVersion || item.Action == ActionDeletedObjectVersion {
+			summary.EligibleRows++
+			summary.EligibleBytes += item.LegacyBytes
+			continue
+		}
+		summary.SkippedRows++
+	}
+	return summary
+}

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -112,6 +112,39 @@ func TestPlannerPlan_InvalidMetadataReference(t *testing.T) {
 	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
 }
 
+func TestPlannerPlan_ValidationAndApprovalGates(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+
+	t.Run("validation not passed", func(t *testing.T) {
+		row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+		row.Shadow.ValidatedAt = nil
+		store := newFakeStore()
+		report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+		require.NoError(err)
+		require.Len(report.Items, 1)
+		require.Equal(ActionSkip, report.Items[0].Action)
+		require.Equal(SkipValidationNotPassed, report.Items[0].SkipReason)
+		require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+		require.Zero(store.versionCalls[row.LegacyObjectKey])
+	})
+
+	t.Run("range not approved", func(t *testing.T) {
+		row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+		store := newFakeStore()
+		req := testRequest(now, false)
+		req.Approval.EndHeight = req.EndHeight - 1
+		report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), req)
+		require.NoError(err)
+		require.Len(report.Items, 1)
+		require.Equal(ActionSkip, report.Items[0].Action)
+		require.Equal(SkipChainRangeNotApproved, report.Items[0].SkipReason)
+		require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+		require.Zero(store.versionCalls[row.LegacyObjectKey])
+	})
+}
+
 func TestPlannerPlan_FallbackAndClientMigrationGates(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -1,0 +1,328 @@
+package retirement
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type fakeRepo struct {
+	rows []MetadataRow
+}
+
+func (r *fakeRepo) ListMetadataRows(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]MetadataRow, error) {
+	if limit > 0 && uint64(len(r.rows)) > limit {
+		return r.rows[:limit], nil
+	}
+	return r.rows, nil
+}
+
+type fakeStore struct {
+	heads        map[string]ObjectHead
+	versions     map[string]ObjectVersion
+	headCalls    map[string]int
+	versionCalls map[string]int
+	deleted      []Candidate
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		heads:        make(map[string]ObjectHead),
+		versions:     make(map[string]ObjectVersion),
+		headCalls:    make(map[string]int),
+		versionCalls: make(map[string]int),
+	}
+}
+
+func (s *fakeStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {
+	s.headCalls[key]++
+	return s.heads[key], nil
+}
+
+func (s *fakeStore) CurrentObjectVersion(ctx context.Context, bucket string, key string) (ObjectVersion, error) {
+	s.versionCalls[key]++
+	return s.versions[key], nil
+}
+
+func (s *fakeStore) DeleteObjectVersion(ctx context.Context, bucket string, key string, versionID string) error {
+	s.deleted = append(s.deleted, Candidate{
+		Bucket:    bucket,
+		Key:       key,
+		VersionID: versionID,
+	})
+	return nil
+}
+
+func TestPlannerPlan_NotEligibleGracePeriod(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-time.Hour)
+	store := newFakeStore()
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	planner := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store)
+
+	report, err := planner.Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipGracePeriodActive, report.Items[0].SkipReason)
+	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+	require.Zero(store.versionCalls[row.LegacyObjectKey])
+}
+
+func TestPlannerPlan_MissingCSCBObject(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/missing.cscb.zstd", validatedAt)
+	store := newFakeStore()
+	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
+	planner := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store)
+
+	report, err := planner.Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipMissingCSCBObject, report.Items[0].SkipReason)
+	require.Equal("legacy-v1", report.Items[0].VersionID)
+	require.Equal(uint64(42), report.Items[0].LegacyBytes)
+}
+
+func TestPlannerPlan_InvalidMetadataReference(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	row.Shadow.LegacyObjectKey = "legacy/stale.zstd"
+	store := newFakeStore()
+	planner := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store)
+
+	report, err := planner.Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipInvalidMetadataReference, report.Items[0].SkipReason)
+	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+}
+
+func TestPlannerPlan_FallbackAndClientMigrationGates(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+
+	t.Run("fallback errors", func(t *testing.T) {
+		req := testRequest(now, false)
+		req.FallbackErrorCount = 1
+		report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, newFakeStore()).Plan(context.Background(), req)
+		require.NoError(err)
+		require.Equal(SkipActiveFallbackOrReadErrors, report.Items[0].SkipReason)
+	})
+
+	t.Run("file clients not approved", func(t *testing.T) {
+		req := testRequest(now, false)
+		req.ClientMigrationApproved = false
+		report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, newFakeStore()).Plan(context.Background(), req)
+		require.NoError(err)
+		require.Equal(SkipFileClientsNotApproved, report.Items[0].SkipReason)
+	})
+}
+
+func TestPlannerPlan_SkippedReorgAndPromotedRows(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	skipped := testRow(100, "hash-100", "", "consolidated/canary.cscb.zstd", validatedAt)
+	skipped.Skipped = true
+
+	stale := testRow(101, "hash-101", "legacy/101.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	stale.Shadow.Hash = "hash-before-reorg"
+
+	promoted := testRow(102, "hash-102", "consolidated/primary.cscb.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	promoted.PrimaryObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH
+	promoted.PrimaryByteLength = 123
+
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{skipped, stale, promoted}}, newFakeStore()).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 3)
+	require.Equal(SkipSkippedBlock, report.Items[0].SkipReason)
+	require.Equal(SkipInvalidMetadataReference, report.Items[1].SkipReason)
+	require.Equal(SkipPrimaryNotLegacySingleBlock, report.Items[2].SkipReason)
+}
+
+func TestPlannerPlan_VersionedDeleteMarkerBehavior(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	store := newFakeStore()
+	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, CurrentDeleteMarker: true, VersionID: "delete-marker-v1"}
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipLegacyCurrentDeleteMarker, report.Items[0].SkipReason)
+	require.Equal(1, report.Summary.DeleteMarkerRows)
+	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+}
+
+func TestPlannerPlan_DryRunOutput(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	store := newFakeStore()
+	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
+	store.heads[row.Shadow.ConsolidatedObjectKey] = ObjectHead{Exists: true, Bytes: 1024}
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+
+	var buf bytes.Buffer
+	require.NoError(WriteReportJSON(&buf, report))
+	var decoded Report
+	require.NoError(json.Unmarshal(buf.Bytes(), &decoded))
+	require.True(decoded.DryRun)
+	require.Equal("production", decoded.Environment)
+	require.Equal("solana", decoded.Blockchain)
+	require.Equal("mainnet", decoded.Network)
+	require.Equal(uint64(428058000), decoded.StartHeight)
+	require.Equal(uint64(428059000), decoded.EndHeight)
+	require.Equal(1, decoded.Summary.EligibleRows)
+	require.Equal(ActionReportOnly, decoded.Items[0].Action)
+	require.Equal("legacy-v1", decoded.Items[0].VersionID)
+	require.Empty(decoded.Items[0].SkipReason)
+}
+
+func TestPlannerPlan_ExactSolanaCanaryReportShape(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	const (
+		startHeight     = uint64(428058000)
+		endHeight       = uint64(428059000)
+		cscbKey         = "BLOCKCHAIN_SOLANA/NETWORK_SOLANA_MAINNET/consolidated/v=7/shard=00000000042805000000-00000000042806000000/00000000000428058000-00000000000428059000-deadbeef.cscb.zstd"
+		bucket          = "co-chainstorage-solana-mainnet-prod"
+		legacyBytesEach = uint64(123)
+	)
+
+	rows := make([]MetadataRow, 0, endHeight-startHeight)
+	store := newFakeStore()
+	store.heads[cscbKey] = ObjectHead{Exists: true, Bytes: 2 << 20}
+	for height := startHeight; height < endHeight; height++ {
+		hash := fmt.Sprintf("solana-hash-%d", height)
+		key := fmt.Sprintf("BLOCKCHAIN_SOLANA/NETWORK_SOLANA_MAINNET/0/%d/%s.zstd", height, hash)
+		rows = append(rows, testRow(height, hash, key, cscbKey, validatedAt))
+		store.versions[key] = ObjectVersion{
+			Exists:    true,
+			VersionID: fmt.Sprintf("legacy-version-%d", height),
+			Bytes:     legacyBytesEach,
+		}
+	}
+	req := testRequest(now, false)
+	req.Bucket = bucket
+	req.StartHeight = startHeight
+	req.EndHeight = endHeight
+	report, err := NewPlanner(&fakeRepo{rows: rows}, store).Plan(context.Background(), req)
+	require.NoError(err)
+
+	require.Equal(bucket, report.Bucket)
+	require.Equal(startHeight, report.StartHeight)
+	require.Equal(endHeight, report.EndHeight)
+	require.Len(report.Items, 1000)
+	require.Equal(1000, report.Summary.TotalRows)
+	require.Equal(1000, report.Summary.EligibleRows)
+	require.Zero(report.Summary.SkippedRows)
+	require.Equal(uint64(1000)*legacyBytesEach, report.Summary.LegacyBytes)
+	require.Equal(uint64(1000)*legacyBytesEach, report.Summary.EligibleBytes)
+	require.Equal(1, store.headCalls[cscbKey])
+
+	first := report.Items[0]
+	require.Equal(startHeight, first.Height)
+	require.Equal("solana-hash-428058000", first.Hash)
+	require.Equal("legacy-version-428058000", first.VersionID)
+	require.Equal(legacyBytesEach, first.LegacyBytes)
+	require.Equal(cscbKey, first.ConsolidatedKey)
+	require.Equal(ActionReportOnly, first.Action)
+	require.Empty(first.SkipReason)
+
+	last := report.Items[len(report.Items)-1]
+	require.Equal(endHeight-1, last.Height)
+	require.Equal("solana-hash-428058999", last.Hash)
+	require.Equal("legacy-version-428058999", last.VersionID)
+	require.Equal(cscbKey, last.ConsolidatedKey)
+	require.Equal(ActionReportOnly, last.Action)
+}
+
+func TestPlannerApply_ProductionDisabledAndNonProdDeletesVersionIDOnly(t *testing.T) {
+	require := require.New(t)
+	store := newFakeStore()
+	planner := NewPlanner(&fakeRepo{}, store)
+	report := &Report{Items: []Candidate{{
+		Bucket:    "bucket",
+		Key:       "legacy/100.zstd",
+		VersionID: "legacy-v1",
+		Action:    ActionDeleteObjectVersion,
+	}}}
+
+	err := planner.Apply(context.Background(), PlanRequest{Environment: "production"}, report)
+	require.Error(err)
+	require.Empty(store.deleted)
+
+	err = planner.Apply(context.Background(), PlanRequest{Environment: "development"}, report)
+	require.NoError(err)
+	require.Len(store.deleted, 1)
+	require.Equal("legacy-v1", store.deleted[0].VersionID)
+	require.Equal(ActionDeletedObjectVersion, report.Items[0].Action)
+}
+
+func testRequest(now time.Time, execute bool) PlanRequest {
+	return PlanRequest{
+		Environment:             "production",
+		Blockchain:              "solana",
+		Network:                 "mainnet",
+		Bucket:                  "co-chainstorage-solana-mainnet-prod",
+		Tag:                     0,
+		StartHeight:             428058000,
+		EndHeight:               428059000,
+		Now:                     now,
+		GracePeriod:             7 * 24 * time.Hour,
+		Execute:                 execute,
+		ClientMigrationApproved: true,
+		Approval: Approval{
+			Chain:       "solana-mainnet",
+			StartHeight: 428058000,
+			EndHeight:   428059000,
+		},
+	}
+}
+
+func testRow(height uint64, hash string, legacyKey string, cscbKey string, validatedAt time.Time) MetadataRow {
+	return MetadataRow{
+		BlockMetadataID:     int64(height),
+		Tag:                 0,
+		Height:              height,
+		Hash:                hash,
+		LegacyObjectKey:     legacyKey,
+		PrimaryObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK,
+		Shadow: &ConsolidationShadow{
+			Tag:                   0,
+			Height:                height,
+			Hash:                  hash,
+			LegacyObjectKey:       legacyKey,
+			ConsolidatedObjectKey: cscbKey,
+			ObjectFormat:          api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:            100,
+			ByteLength:            200,
+			UncompressedLength:    300,
+			ValidatedAt:           &validatedAt,
+			FormatVersion:         1,
+		},
+	}
+}

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -1,0 +1,142 @@
+package retirement
+
+import (
+	"context"
+	"database/sql"
+
+	"golang.org/x/xerrors"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type PostgresRepository struct {
+	db *sql.DB
+}
+
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]MetadataRow, error) {
+	if r.db == nil {
+		return nil, xerrors.New("postgres db is required")
+	}
+	if endHeight <= startHeight {
+		return nil, nil
+	}
+	if limit == 0 {
+		limit = endHeight - startHeight
+	}
+
+	const query = `
+		SELECT
+			bm.id,
+			bm.tag,
+			bm.height,
+			COALESCE(bm.hash, ''),
+			bm.skipped,
+			COALESCE(bm.object_key_main, ''),
+			bm.object_format,
+			bm.byte_length,
+			shadow.tag,
+			shadow.height,
+			shadow.hash,
+			shadow.legacy_object_key_main,
+			shadow.consolidated_object_key_main,
+			shadow.object_format,
+			shadow.byte_offset,
+			shadow.byte_length,
+			shadow.uncompressed_length,
+			shadow.validated_at,
+			shadow.format_version
+		FROM canonical_blocks cb
+		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+		LEFT JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+		WHERE cb.tag = $1
+			AND cb.height >= $2
+			AND cb.height < $3
+		ORDER BY cb.height ASC
+		LIMIT $4`
+
+	rows, err := r.db.QueryContext(ctx, query, tag, startHeight, endHeight, limit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query retirement metadata rows: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	result := make([]MetadataRow, 0)
+	for rows.Next() {
+		var row MetadataRow
+		var primaryObjectFormat int64
+		var primaryByteLength sql.NullInt64
+		var shadowTag sql.NullInt64
+		var shadowHeight sql.NullInt64
+		var shadowHash sql.NullString
+		var shadowLegacyKey sql.NullString
+		var shadowConsolidatedKey sql.NullString
+		var shadowObjectFormat sql.NullInt64
+		var shadowByteOffset sql.NullInt64
+		var shadowByteLength sql.NullInt64
+		var shadowUncompressedLength sql.NullInt64
+		var shadowValidatedAt sql.NullTime
+		var shadowFormatVersion sql.NullInt64
+		if err := rows.Scan(
+			&row.BlockMetadataID,
+			&row.Tag,
+			&row.Height,
+			&row.Hash,
+			&row.Skipped,
+			&row.LegacyObjectKey,
+			&primaryObjectFormat,
+			&primaryByteLength,
+			&shadowTag,
+			&shadowHeight,
+			&shadowHash,
+			&shadowLegacyKey,
+			&shadowConsolidatedKey,
+			&shadowObjectFormat,
+			&shadowByteOffset,
+			&shadowByteLength,
+			&shadowUncompressedLength,
+			&shadowValidatedAt,
+			&shadowFormatVersion,
+		); err != nil {
+			return nil, xerrors.Errorf("failed to scan retirement metadata row: %w", err)
+		}
+		row.PrimaryObjectFormat = api.BlockObjectFormat(primaryObjectFormat)
+		row.PrimaryByteLength = nullableUint64(primaryByteLength)
+		if shadowTag.Valid {
+			shadow := &ConsolidationShadow{
+				Tag:                   uint32(shadowTag.Int64),
+				Height:                uint64(shadowHeight.Int64),
+				Hash:                  shadowHash.String,
+				LegacyObjectKey:       shadowLegacyKey.String,
+				ConsolidatedObjectKey: shadowConsolidatedKey.String,
+				ObjectFormat:          api.BlockObjectFormat(shadowObjectFormat.Int64),
+				ByteOffset:            nullableUint64(shadowByteOffset),
+				ByteLength:            nullableUint64(shadowByteLength),
+				UncompressedLength:    nullableUint64(shadowUncompressedLength),
+				FormatVersion:         int(shadowFormatVersion.Int64),
+			}
+			if shadowValidatedAt.Valid {
+				value := shadowValidatedAt.Time
+				shadow.ValidatedAt = &value
+			}
+			row.Shadow = shadow
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate retirement metadata rows: %w", err)
+	}
+	return result, nil
+}
+
+func nullableUint64(value sql.NullInt64) uint64 {
+	if !value.Valid {
+		return 0
+	}
+	return uint64(value.Int64)
+}

--- a/internal/storage/retirement/s3_store.go
+++ b/internal/storage/retirement/s3_store.go
@@ -1,0 +1,137 @@
+package retirement
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	awss3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/s3"
+)
+
+type S3ObjectStore struct {
+	client s3.Client
+}
+
+func NewS3ObjectStore(client s3.Client) *S3ObjectStore {
+	return &S3ObjectStore{client: client}
+}
+
+func (s *S3ObjectStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {
+	out, err := s.client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isObjectNotFound(err) {
+			return ObjectHead{}, nil
+		}
+		return ObjectHead{}, xerrors.Errorf("failed to head object (bucket=%s key=%s): %w", bucket, key, err)
+	}
+	head := ObjectHead{
+		Exists:     true,
+		VersionID:  aws.ToString(out.VersionId),
+		Metadata:   out.Metadata,
+		DeleteMark: aws.ToBool(out.DeleteMarker),
+	}
+	if out.ContentLength != nil && *out.ContentLength > 0 {
+		head.Bytes = uint64(*out.ContentLength)
+	}
+	return head, nil
+}
+
+func (s *S3ObjectStore) CurrentObjectVersion(ctx context.Context, bucket string, key string) (ObjectVersion, error) {
+	out, err := s.client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{
+		Bucket:  aws.String(bucket),
+		Prefix:  aws.String(key),
+		MaxKeys: aws.Int32(10),
+	})
+	if err != nil {
+		return ObjectVersion{}, xerrors.Errorf("failed to list object versions (bucket=%s key=%s): %w", bucket, key, err)
+	}
+
+	for _, marker := range out.DeleteMarkers {
+		if aws.ToString(marker.Key) == key && aws.ToBool(marker.IsLatest) {
+			return ObjectVersion{
+				Exists:              true,
+				CurrentDeleteMarker: true,
+				VersionID:           aws.ToString(marker.VersionId),
+				LastModified:        cloneTime(marker.LastModified),
+			}, nil
+		}
+	}
+	for _, version := range out.Versions {
+		if aws.ToString(version.Key) == key && aws.ToBool(version.IsLatest) {
+			result := ObjectVersion{
+				Exists:       true,
+				VersionID:    aws.ToString(version.VersionId),
+				LastModified: cloneTime(version.LastModified),
+			}
+			if version.Size != nil && *version.Size > 0 {
+				result.Bytes = uint64(*version.Size)
+			}
+			return result, nil
+		}
+	}
+
+	head, err := s.HeadObject(ctx, bucket, key)
+	if err != nil {
+		return ObjectVersion{}, err
+	}
+	if !head.Exists {
+		return ObjectVersion{}, nil
+	}
+	return ObjectVersion{
+		Exists:              true,
+		CurrentDeleteMarker: head.DeleteMark,
+		VersionID:           head.VersionID,
+		Bytes:               head.Bytes,
+	}, nil
+}
+
+func (s *S3ObjectStore) DeleteObjectVersion(ctx context.Context, bucket string, key string, versionID string) error {
+	if versionID == "" {
+		return xerrors.New("version id is required for retirement delete")
+	}
+	_, err := s.client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket:    aws.String(bucket),
+		Key:       aws.String(key),
+		VersionId: aws.String(versionID),
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to delete object version (bucket=%s key=%s version_id=%s): %w", bucket, key, versionID, err)
+	}
+	return nil
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func isObjectNotFound(err error) bool {
+	var notFound *awss3types.NotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var noSuchKey *awss3types.NoSuchKey
+	if errors.As(err, &noSuchKey) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NotFound", "NoSuchKey", "404":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/retirement/types.go
+++ b/internal/storage/retirement/types.go
@@ -1,0 +1,159 @@
+package retirement
+
+import (
+	"context"
+	"time"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type (
+	Repository interface {
+		ListMetadataRows(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]MetadataRow, error)
+	}
+
+	ObjectStore interface {
+		HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error)
+		CurrentObjectVersion(ctx context.Context, bucket string, key string) (ObjectVersion, error)
+		DeleteObjectVersion(ctx context.Context, bucket string, key string, versionID string) error
+	}
+
+	MetadataRow struct {
+		BlockMetadataID     int64
+		Tag                 uint32
+		Height              uint64
+		Hash                string
+		Skipped             bool
+		LegacyObjectKey     string
+		PrimaryObjectFormat api.BlockObjectFormat
+		PrimaryByteLength   uint64
+		Shadow              *ConsolidationShadow
+	}
+
+	ConsolidationShadow struct {
+		Tag                   uint32
+		Height                uint64
+		Hash                  string
+		LegacyObjectKey       string
+		ConsolidatedObjectKey string
+		ObjectFormat          api.BlockObjectFormat
+		ByteOffset            uint64
+		ByteLength            uint64
+		UncompressedLength    uint64
+		ValidatedAt           *time.Time
+		FormatVersion         int
+	}
+
+	ObjectHead struct {
+		Exists     bool
+		Bytes      uint64
+		VersionID  string
+		Metadata   map[string]string
+		DeleteMark bool
+	}
+
+	ObjectVersion struct {
+		Exists              bool
+		CurrentDeleteMarker bool
+		VersionID           string
+		Bytes               uint64
+		LastModified        *time.Time
+	}
+
+	PlanRequest struct {
+		Environment             string
+		Blockchain              string
+		Network                 string
+		Sidechain               string
+		Bucket                  string
+		Tag                     uint32
+		StartHeight             uint64
+		EndHeight               uint64
+		Limit                   uint64
+		Now                     time.Time
+		GracePeriod             time.Duration
+		Execute                 bool
+		ClientMigrationApproved bool
+		FallbackErrorCount      uint64
+		Approval                Approval
+	}
+
+	Approval struct {
+		Chain       string `json:"chain"`
+		StartHeight uint64 `json:"start_height"`
+		EndHeight   uint64 `json:"end_height"`
+	}
+
+	Report struct {
+		GeneratedAt time.Time   `json:"generated_at"`
+		DryRun      bool        `json:"dry_run"`
+		Environment string      `json:"environment"`
+		Blockchain  string      `json:"blockchain"`
+		Network     string      `json:"network"`
+		Sidechain   string      `json:"sidechain,omitempty"`
+		Bucket      string      `json:"bucket"`
+		Tag         uint32      `json:"tag"`
+		StartHeight uint64      `json:"start_height"`
+		EndHeight   uint64      `json:"end_height"`
+		GracePeriod string      `json:"grace_period"`
+		Approval    Approval    `json:"approval"`
+		SafetyGates SafetyGates `json:"safety_gates"`
+		Summary     Summary     `json:"summary"`
+		Items       []Candidate `json:"items"`
+	}
+
+	SafetyGates struct {
+		ClientMigrationApproved bool   `json:"client_migration_approved"`
+		FallbackReadErrors      uint64 `json:"fallback_read_errors"`
+		VersionedDeleteMode     string `json:"versioned_delete_mode"`
+		ProductionDeleteEnabled bool   `json:"production_delete_enabled"`
+	}
+
+	Summary struct {
+		TotalRows        int    `json:"total_rows"`
+		EligibleRows     int    `json:"eligible_rows"`
+		SkippedRows      int    `json:"skipped_rows"`
+		LegacyBytes      uint64 `json:"legacy_bytes"`
+		EligibleBytes    uint64 `json:"eligible_bytes"`
+		DeleteMarkerRows int    `json:"delete_marker_rows"`
+	}
+
+	Candidate struct {
+		Bucket          string     `json:"bucket"`
+		Key             string     `json:"key"`
+		VersionID       string     `json:"version_id,omitempty"`
+		Height          uint64     `json:"height"`
+		Hash            string     `json:"hash"`
+		LegacyBytes     uint64     `json:"legacy_bytes"`
+		ConsolidatedKey string     `json:"consolidated_key"`
+		ValidatedAt     *time.Time `json:"validated_at"`
+		EligibleAt      *time.Time `json:"eligible_at"`
+		Action          string     `json:"action"`
+		SkipReason      string     `json:"skip_reason"`
+	}
+)
+
+const (
+	ActionSkip                 = "skip"
+	ActionReportOnly           = "report_only"
+	ActionDeleteObjectVersion  = "delete_object_version"
+	ActionDeletedObjectVersion = "deleted_object_version"
+
+	SkipSkippedBlock                = "skipped_block"
+	SkipPrimaryNotLegacySingleBlock = "primary_not_legacy_single_block"
+	SkipMissingLegacyKey            = "missing_legacy_key"
+	SkipMissingConsolidationShadow  = "missing_consolidation_shadow"
+	SkipValidationNotPassed         = "validation_not_passed"
+	SkipInvalidMetadataReference    = "invalid_metadata_reference"
+	SkipGracePeriodActive           = "grace_period_active"
+	SkipChainRangeNotApproved       = "chain_range_not_approved"
+	SkipActiveFallbackOrReadErrors  = "active_fallback_or_read_errors"
+	SkipFileClientsNotApproved      = "file_clients_not_approved"
+	SkipMissingCSCBObject           = "missing_cscb_object"
+	SkipLegacyObjectMissing         = "legacy_object_missing"
+	SkipLegacyCurrentDeleteMarker   = "legacy_current_delete_marker"
+	SkipLegacyVersionIDUnavailable  = "legacy_version_id_unavailable"
+	SkipProductionDeletionDisabled  = "production_deletion_disabled"
+	SkipObjectInspectionFailed      = "object_inspection_failed"
+	SkipVersionedDeleteFailed       = "versioned_delete_failed"
+)


### PR DESCRIPTION
## Summary

Implements INF-975's dry-run-first legacy single-block retirement workflow for CSCB consolidation follow-up.

- adds `admin retirement plan-legacy-single-blocks` to emit an auditable JSON report for an approved chain/range
- reads canonical metadata plus consolidation shadow rows without running migrations, then applies gates for validation, grace period, approval, fallback/read errors, client migration, CSCB object existence, and versioned legacy object state
- models versioned S3 behavior by requiring an explicit current object version id; production deletion is disabled, and non-production execution deletes only `DeleteObject` with `VersionId`
- adds focused tests for non-eligibility, missing CSCB, invalid/stale metadata, fallback/client gates, skipped/reorg/promoted rows, delete markers, JSON output, Solana canary report shape, and production deletion refusal

## Safety

No production deletion path is enabled. In production the command is report-only; `--execute` is rejected before planning, and the planner/apply layer also refuses production deletion.

## Validation

- `PATH="$HOME/go/bin:$PATH" make test`
- `TEST_TYPE=unit go test ./cmd/admin ./internal/storage/retirement ./internal/s3 ./internal/storage/blobstorage/s3 -count=1`
- `TEST_TYPE=unit go test ./...`

Linear: INF-975
