### PR TITLE
feat(INF-917): add promote_finalized consolidator mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -687,6 +687,12 @@ func New(opts ...ConfigOption) (*Config, error) {
 	v.SetDefault("aws.storage.consolidation.shard_size", 10000)
 	v.SetDefault("aws.storage.consolidation.multipart_threshold", 134217728)
 	v.SetDefault("aws.storage.consolidation.read_shadow_first", false)
+	if err := v.BindEnv("aws.storage.consolidation.promotion_gate_height"); err != nil {
+		return nil, xerrors.Errorf("failed to bind promotion_gate_height env: %w", err)
+	}
+	if err := v.BindEnv("aws.storage.consolidation.safe_promotion_lag"); err != nil {
+		return nil, xerrors.Errorf("failed to bind safe_promotion_lag env: %w", err)
+	}
 
 	// Read the data in base.yml
 	if err := v.ReadConfig(configReader); err != nil {
@@ -814,6 +820,9 @@ func (c *Config) validateConsolidationConfig() error {
 	}
 	if consolidation.Mode == ConsolidationModePromoteFinalized && consolidation.PromotionGateHeight == nil {
 		return xerrors.New("consolidation promote_finalized requires promotion_gate_height")
+	}
+	if consolidation.Mode == ConsolidationModePromoteFinalized && consolidation.SafePromotionLag == nil {
+		return xerrors.New("consolidation promote_finalized requires safe_promotion_lag")
 	}
 	if consolidation.SafePromotionLag != nil && *consolidation.SafePromotionLag < c.Chain.IrreversibleDistance {
 		return xerrors.Errorf(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -875,6 +875,66 @@ func TestConsolidationReadShadowFirstRejectsDynamoDB(t *testing.T) {
 	require.Contains(err.Error(), "requires Postgres meta storage")
 }
 
+func TestConsolidationPromoteFinalizedRequiresOperatorGates(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         map[string]string
+		expectedErr string
+	}{
+		{
+			name: "missing promotion gate",
+			env: map[string]string{
+				"CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_SAFE_PROMOTION_LAG": "100000",
+			},
+			expectedErr: "requires promotion_gate_height",
+		},
+		{
+			name: "missing safe promotion lag",
+			env: map[string]string{
+				"CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_PROMOTION_GATE_HEIGHT": "100000",
+			},
+			expectedErr: "requires safe_promotion_lag",
+		},
+		{
+			name: "safe promotion lag below irreversible distance",
+			env: map[string]string{
+				"CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_PROMOTION_GATE_HEIGHT": "100000",
+				"CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_SAFE_PROMOTION_LAG":    "1",
+			},
+			expectedErr: "must be at least irreversible_distance",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := testutil.Require(t)
+			t.Setenv("CHAINSTORAGE_STORAGE_TYPE_META", "POSTGRES")
+			t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_ENABLED", "true")
+			t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_MODE", string(config.ConsolidationModePromoteFinalized))
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
+
+			_, err := config.New()
+			require.Error(err)
+			require.Contains(err.Error(), test.expectedErr)
+		})
+	}
+}
+
+func TestConsolidationPromoteFinalizedRejectsDynamoDB(t *testing.T) {
+	require := testutil.Require(t)
+
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_ENABLED", "true")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_MODE", string(config.ConsolidationModePromoteFinalized))
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_PROMOTION_GATE_HEIGHT", "100000")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_SAFE_PROMOTION_LAG", "100000")
+
+	_, err := config.New()
+	require.Error(err)
+	require.Contains(err.Error(), "requires Postgres meta storage")
+}
+
 func TestParseConfigName(t *testing.T) {
 	tests := []struct {
 		configName string

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -297,6 +297,10 @@ func (a *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for DynamoDB")
 }
 
+func (a *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*internal.ConsolidationPromotionResult, error) {
+	return nil, xerrors.New("PromoteBlockConsolidationShadows not implemented for DynamoDB")
+}
+
 func makeBlockMetaDataDDBEntry(block *api.BlockMetadata) *model.BlockMetaDataDDBEntry {
 	blockMetaDataDDBEntry := model.BlockMetaDataDDBEntry{
 		BlockPid:           getBlockPidForHeight(block.Tag, block.Height),

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -270,6 +270,10 @@ func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for Firestore")
 }
 
+func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*internal.ConsolidationPromotionResult, error) {
+	return nil, xerrors.New("PromoteBlockConsolidationShadows not implemented for Firestore")
+}
+
 func (b *blockStorageImpl) getLatestBlockDocRef(tag uint32) *firestore.DocumentRef {
 	return b.client.Doc(fmt.Sprintf("env/%s/blocks/%d-latest", b.env, tag))
 }

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -29,6 +29,7 @@ type (
 		GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*BlockMetadataRecord, error)
 		GetBlockConsolidationShadowStats(ctx context.Context, tag uint32, startHeight, endHeight uint64) (*ConsolidationShadowStats, error)
 		PersistBlockConsolidationShadows(ctx context.Context, placements []*ConsolidationShadowPlacement) error
+		PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*ConsolidationPromotionResult, error)
 	}
 
 	EventStorage interface {
@@ -91,6 +92,10 @@ type (
 	ConsolidationShadowStats struct {
 		Objects uint64
 		Blocks  uint64
+	}
+
+	ConsolidationPromotionResult struct {
+		Blocks uint64
 	}
 
 	MetaStorageFactory interface {

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -367,6 +367,21 @@ func (mr *MockMetaStorageMockRecorder) PersistBlockMetas(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistBlockMetas", reflect.TypeOf((*MockMetaStorage)(nil).PersistBlockMetas), arg0, arg1, arg2, arg3)
 }
 
+// PromoteBlockConsolidationShadows mocks base method.
+func (m *MockMetaStorage) PromoteBlockConsolidationShadows(arg0 context.Context, arg1 uint32, arg2, arg3, arg4 uint64) (*internal.ConsolidationPromotionResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PromoteBlockConsolidationShadows", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*internal.ConsolidationPromotionResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PromoteBlockConsolidationShadows indicates an expected call of PromoteBlockConsolidationShadows.
+func (mr *MockMetaStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockMetaStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4)
+}
+
 // SetMaxEventId mocks base method.
 func (m *MockMetaStorage) SetMaxEventId(arg0 context.Context, arg1 uint32, arg2 int64) error {
 	m.ctrl.T.Helper()
@@ -735,6 +750,21 @@ func (m *MockBlockStorage) PersistBlockMetas(arg0 context.Context, arg1 bool, ar
 func (mr *MockBlockStorageMockRecorder) PersistBlockMetas(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistBlockMetas", reflect.TypeOf((*MockBlockStorage)(nil).PersistBlockMetas), arg0, arg1, arg2, arg3)
+}
+
+// PromoteBlockConsolidationShadows mocks base method.
+func (m *MockBlockStorage) PromoteBlockConsolidationShadows(arg0 context.Context, arg1 uint32, arg2, arg3, arg4 uint64) (*internal.ConsolidationPromotionResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PromoteBlockConsolidationShadows", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*internal.ConsolidationPromotionResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PromoteBlockConsolidationShadows indicates an expected call of PromoteBlockConsolidationShadows.
+func (mr *MockBlockStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockBlockStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MockTransactionStorage is a mock of TransactionStorage interface.

--- a/internal/storage/metastorage/module.go
+++ b/internal/storage/metastorage/module.go
@@ -19,6 +19,7 @@ type (
 	BlockMetadataRecord          = internal.BlockMetadataRecord
 	ConsolidationShadowPlacement = internal.ConsolidationShadowPlacement
 	ConsolidationShadowStats     = internal.ConsolidationShadowStats
+	ConsolidationPromotionResult = internal.ConsolidationPromotionResult
 )
 
 const (

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -843,6 +843,158 @@ func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 	return nil
 }
 
+func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*internal.ConsolidationPromotionResult, error) {
+	if endHeight <= startHeight {
+		return &internal.ConsolidationPromotionResult{}, nil
+	}
+	if limit == 0 {
+		return nil, xerrors.New("consolidation promotion limit must be positive")
+	}
+	if err := b.validateHeight(startHeight); err != nil {
+		return nil, err
+	}
+
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin consolidation promotion transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	const invalidShadowQuery = `
+		SELECT shadow.block_metadata_id, shadow.height
+		FROM canonical_blocks cb
+		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+		JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+			AND shadow.tag = bm.tag
+			AND shadow.height = bm.height
+			AND shadow.hash = bm.hash
+			AND shadow.legacy_object_key_main = bm.object_key_main
+		WHERE cb.tag = $1
+			AND cb.height >= $2
+			AND cb.height < $3
+			AND bm.skipped = false
+			AND bm.byte_length IS NULL
+			AND bm.object_key_main IS NOT NULL
+			AND bm.object_key_main <> ''
+			AND shadow.validated_at IS NOT NULL
+			AND (
+				shadow.consolidated_object_key_main IS NULL
+				OR shadow.consolidated_object_key_main = ''
+				OR shadow.object_format <> $4
+				OR shadow.byte_offset < 0
+				OR shadow.byte_length <= 0
+				OR shadow.uncompressed_length IS NULL
+				OR shadow.uncompressed_length <= 0
+			)
+		ORDER BY cb.height ASC
+		LIMIT 1`
+	var invalidMetadataID int64
+	var invalidHeight uint64
+	err = tx.QueryRowContext(
+		ctx,
+		invalidShadowQuery,
+		tag,
+		startHeight,
+		endHeight,
+		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
+	).Scan(&invalidMetadataID, &invalidHeight)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, xerrors.Errorf("failed to validate consolidation promotion shadows: %w", err)
+	}
+	if err == nil {
+		return nil, xerrors.Errorf("invalid consolidation shadow metadata for metadata_id=%d height=%d", invalidMetadataID, invalidHeight)
+	}
+
+	const promoteQuery = `
+		WITH candidates AS (
+			SELECT
+				bm.id AS block_metadata_id,
+				bm.tag,
+				bm.height,
+				bm.hash,
+				bm.object_key_main AS legacy_object_key_main,
+				shadow.consolidated_object_key_main,
+				shadow.object_format,
+				shadow.byte_offset,
+				shadow.byte_length,
+				shadow.uncompressed_length
+			FROM canonical_blocks cb
+			JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+			JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+				AND shadow.tag = bm.tag
+				AND shadow.height = bm.height
+				AND shadow.hash = bm.hash
+				AND shadow.legacy_object_key_main = bm.object_key_main
+			WHERE cb.tag = $1
+				AND cb.height >= $2
+				AND cb.height < $3
+				AND bm.skipped = false
+				AND bm.byte_length IS NULL
+				AND bm.object_key_main IS NOT NULL
+				AND bm.object_key_main <> ''
+				AND shadow.validated_at IS NOT NULL
+				AND shadow.consolidated_object_key_main IS NOT NULL
+				AND shadow.consolidated_object_key_main <> ''
+				AND shadow.object_format = $5
+				AND shadow.byte_offset >= 0
+				AND shadow.byte_length > 0
+				AND shadow.uncompressed_length IS NOT NULL
+				AND shadow.uncompressed_length > 0
+			ORDER BY cb.height ASC
+			LIMIT $4
+			FOR UPDATE OF cb, bm, shadow
+		),
+		updated AS (
+			UPDATE block_metadata bm
+			SET
+				object_key_main = candidates.consolidated_object_key_main,
+				object_format = candidates.object_format,
+				byte_offset = candidates.byte_offset,
+				byte_length = candidates.byte_length,
+				uncompressed_length = candidates.uncompressed_length
+			FROM candidates
+			WHERE bm.id = candidates.block_metadata_id
+				AND bm.tag = candidates.tag
+				AND bm.height = candidates.height
+				AND bm.hash = candidates.hash
+				AND bm.object_key_main = candidates.legacy_object_key_main
+				AND bm.skipped = false
+				AND bm.byte_length IS NULL
+			RETURNING bm.id
+		)
+		SELECT
+			(SELECT COUNT(*) FROM candidates),
+			(SELECT COUNT(*) FROM updated)`
+
+	var candidates, promoted uint64
+	if err := tx.QueryRowContext(
+		ctx,
+		promoteQuery,
+		tag,
+		startHeight,
+		endHeight,
+		limit,
+		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
+	).Scan(&candidates, &promoted); err != nil {
+		return nil, xerrors.Errorf("failed to promote consolidation shadows: %w", err)
+	}
+	if candidates != promoted {
+		return nil, xerrors.Errorf("consolidation promotion guard failed: selected %d rows but promoted %d", candidates, promoted)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit consolidation promotion: %w", err)
+	}
+	committed = true
+	return &internal.ConsolidationPromotionResult{
+		Blocks: promoted,
+	}, nil
+}
+
 func makeConsolidationShadowBlockMetadata(
 	block *api.BlockMetadata,
 	objectKey string,

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -365,6 +365,37 @@ func (s *blockStorageTestSuite) insertConsolidationShadow(
 	require.NoError(err)
 }
 
+func (s *blockStorageTestSuite) insertInvalidConsolidationShadow(
+	ctx context.Context,
+	block *api.BlockMetadata,
+	consolidatedObjectKey string,
+	objectFormat api.BlockObjectFormat,
+	byteOffset uint64,
+	byteLength uint64,
+	uncompressedLength uint64,
+) {
+	require := testutil.Require(s.T())
+	_, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO block_consolidation_shadow (
+			block_metadata_id, tag, height, hash, legacy_object_key_main, consolidated_object_key_main,
+			object_format, byte_offset, byte_length, uncompressed_length, validated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		s.getBlockMetadataID(ctx, block),
+		block.GetTag(),
+		block.GetHeight(),
+		block.GetHash(),
+		block.GetObjectKeyMain(),
+		consolidatedObjectKey,
+		int32(objectFormat),
+		byteOffset,
+		byteLength,
+		uncompressedLength,
+		time.Now().UTC(),
+	)
+	require.NoError(err)
+}
+
 func expectedConsolidationShadow(
 	block *api.BlockMetadata,
 	consolidatedObjectKey string,
@@ -542,6 +573,162 @@ func (s *blockStorageTestSuite) TestPersistBlockConsolidationShadowsGuardsPrimar
 	_, err = s.accessor.GetBlockConsolidationShadow(ctx, blocks[1])
 	require.Error(err)
 	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+}
+
+func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsPromotesValidatedShadows() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 3, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20, true, "")
+	s.insertConsolidationShadow(ctx, blocks[1], "consolidated/second.cscb.zstd", 30, 40, 40, true, "")
+
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+3, 10)
+	require.NoError(err)
+	require.Equal(uint64(2), result.Blocks)
+
+	primary, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
+	require.NoError(err)
+	s.equalProto(expectedConsolidationShadow(blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20), primary)
+
+	primary, err = s.accessor.GetBlockByHeight(ctx, tag, blocks[1].GetHeight())
+	require.NoError(err)
+	s.equalProto(expectedConsolidationShadow(blocks[1], "consolidated/second.cscb.zstd", 30, 40, 40), primary)
+
+	primary, err = s.accessor.GetBlockByHeight(ctx, tag, blocks[2].GetHeight())
+	require.NoError(err)
+	s.equalProto(blocks[2], primary)
+}
+
+func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsMissingShadowNoOps() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 1, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	require.NoError(err)
+	require.Equal(uint64(0), result.Blocks)
+
+	primary, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
+	require.NoError(err)
+	s.equalProto(blocks[0], primary)
+}
+
+func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsRejectsInvalidShadowMetadata() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 1, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+	s.insertInvalidConsolidationShadow(
+		ctx,
+		blocks[0],
+		"consolidated/invalid.cscb.zstd",
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK,
+		10,
+		20,
+		20,
+	)
+
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	require.Error(err)
+	require.Nil(result)
+	require.Contains(err.Error(), "invalid consolidation shadow metadata")
+
+	primary, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
+	require.NoError(err)
+	s.equalProto(blocks[0], primary)
+}
+
+func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsSkipsStaleReorgMetadata() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 4, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+	s.insertConsolidationShadow(ctx, blocks[3], "consolidated/stale.cscb.zstd", 10, 20, 20, true, "")
+
+	reorgBlock := proto.Clone(blocks[3]).(*api.BlockMetadata)
+	reorgBlock.Hash = "0xreorg"
+	reorgBlock.ParentHash = blocks[2].GetHash()
+	reorgBlock.ObjectKeyMain = "legacy/reorg.gzip"
+	err = s.accessor.PersistBlockMetas(ctx, true, []*api.BlockMetadata{reorgBlock}, blocks[2])
+	require.NoError(err)
+
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, reorgBlock.GetHeight(), reorgBlock.GetHeight()+1, 10)
+	require.NoError(err)
+	require.Equal(uint64(0), result.Blocks)
+
+	primary, err := s.accessor.GetBlockByHeight(ctx, tag, reorgBlock.GetHeight())
+	require.NoError(err)
+	s.equalProto(reorgBlock, primary)
+}
+
+func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsIdempotentRetry() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 1, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20, true, "")
+
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	require.NoError(err)
+	require.Equal(uint64(1), result.Blocks)
+
+	result, err = s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	require.NoError(err)
+	require.Equal(uint64(0), result.Blocks)
+
+	primary, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
+	require.NoError(err)
+	s.equalProto(expectedConsolidationShadow(blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20), primary)
+}
+
+func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsRollsBackOnInvalidCandidate() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 2, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/valid.cscb.zstd", 10, 20, 20, true, "")
+	s.insertInvalidConsolidationShadow(
+		ctx,
+		blocks[1],
+		"consolidated/invalid.cscb.zstd",
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		30,
+		0,
+		40,
+	)
+
+	_, err = s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+2, 10)
+	require.Error(err)
+	require.Contains(err.Error(), "invalid consolidation shadow metadata")
+
+	primary, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
+	require.NoError(err)
+	s.equalProto(blocks[0], primary)
+
+	primary, err = s.accessor.GetBlockByHeight(ctx, tag, blocks[1].GetHeight())
+	require.NoError(err)
+	s.equalProto(blocks[1], primary)
 }
 
 func (s *blockStorageTestSuite) TestWatermarkVisibilityControl() {

--- a/internal/workflow/activity/activity.go
+++ b/internal/workflow/activity/activity.go
@@ -31,6 +31,7 @@ const (
 	ActivityLatestBlock            = "activity.latest_block"
 	ActivityBatchConsolidator      = "activity.batch_consolidator"
 	ActivityBatchConsolidatorStats = "activity.batch_consolidator.stats"
+	ActivityBatchConsolidatorPlan  = "activity.batch_consolidator.plan"
 
 	loggerMsg = "activity.request"
 

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -25,6 +25,7 @@ type (
 	BatchConsolidator struct {
 		baseActivity
 		statsActivity baseActivity
+		planActivity  baseActivity
 		config        *config.Config
 		metaStorage   metastorage.MetaStorage
 		blobStorage   blobstorage.BlobStorage
@@ -65,18 +66,34 @@ type (
 		ShadowObjects uint64
 		ShadowBlocks  uint64
 	}
+
+	BatchConsolidatorPlanRequest struct {
+		Tag         uint32
+		StartHeight uint64
+		EndHeight   uint64 `validate:"gtfield=StartHeight"`
+	}
+
+	BatchConsolidatorPlanResponse struct {
+		StartHeight         uint64
+		EndHeight           uint64
+		LatestHeight        uint64
+		SafePromotionHeight uint64
+		PromotionGateHeight uint64
+	}
 )
 
 func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 	a := &BatchConsolidator{
 		baseActivity:  newBaseActivity(ActivityBatchConsolidator, params.Runtime),
 		statsActivity: newBaseActivity(ActivityBatchConsolidatorStats, params.Runtime),
+		planActivity:  newBaseActivity(ActivityBatchConsolidatorPlan, params.Runtime),
 		config:        params.Config,
 		metaStorage:   params.MetaStorage,
 		blobStorage:   params.BlobStorage,
 	}
 	a.register(a.execute)
 	a.statsActivity.register(a.executeStats)
+	a.planActivity.register(a.executePlan)
 	return a
 }
 
@@ -92,11 +109,17 @@ func (a *BatchConsolidator) GetShadowStats(ctx workflow.Context, request *BatchC
 	return &response, err
 }
 
+func (a *BatchConsolidator) GetPromotionPlan(ctx workflow.Context, request *BatchConsolidatorPlanRequest) (*BatchConsolidatorPlanResponse, error) {
+	var response BatchConsolidatorPlanResponse
+	err := a.planActivity.executeActivity(ctx, request, &response)
+	return &response, err
+}
+
 func (a *BatchConsolidator) executeStats(ctx context.Context, request *BatchConsolidatorStatsRequest) (*BatchConsolidatorStatsResponse, error) {
 	if err := a.statsActivity.validateRequest(request); err != nil {
 		return nil, err
 	}
-	if err := a.validateConsolidationMode(); err != nil {
+	if err := a.validateShadowDualWriteMode(); err != nil {
 		return nil, err
 	}
 	stats, err := a.getConsolidationShadowStats(ctx, request.Tag, request.StartHeight, request.EndHeight)
@@ -111,11 +134,37 @@ func (a *BatchConsolidator) executeStats(ctx context.Context, request *BatchCons
 	}, nil
 }
 
+func (a *BatchConsolidator) executePlan(ctx context.Context, request *BatchConsolidatorPlanRequest) (*BatchConsolidatorPlanResponse, error) {
+	if err := a.planActivity.validateRequest(request); err != nil {
+		return nil, err
+	}
+	return a.planPromoteFinalized(ctx, request.Tag, request.StartHeight, request.EndHeight)
+}
+
 func (a *BatchConsolidator) execute(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {
 	if err := a.validateRequest(request); err != nil {
 		return nil, err
 	}
-	if err := a.validateConsolidationMode(); err != nil {
+	switch a.config.AWS.Storage.Consolidation.Mode {
+	case config.ConsolidationModeShadowDualWrite:
+		return a.executeShadowDualWrite(ctx, request)
+	case config.ConsolidationModePromoteFinalized:
+		return a.executePromoteFinalized(ctx, request)
+	default:
+		if err := a.validateConsolidationEnabled(); err != nil {
+			return nil, err
+		}
+		return nil, xerrors.Errorf(
+			"batch consolidator requires consolidation mode %q or %q, got %q",
+			config.ConsolidationModeShadowDualWrite,
+			config.ConsolidationModePromoteFinalized,
+			a.config.AWS.Storage.Consolidation.Mode,
+		)
+	}
+}
+
+func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {
+	if err := a.validateShadowDualWriteMode(); err != nil {
 		return nil, err
 	}
 	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.started")
@@ -173,6 +222,93 @@ func (a *BatchConsolidator) execute(ctx context.Context, request *BatchConsolida
 	return response, nil
 }
 
+func (a *BatchConsolidator) executePromoteFinalized(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {
+	if err := a.validatePromoteFinalizedMode(); err != nil {
+		return nil, err
+	}
+	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.promote_finalized.started")
+
+	plan, err := a.planPromoteFinalized(ctx, request.Tag, request.StartHeight, request.EndHeight)
+	if err != nil {
+		return nil, err
+	}
+	if plan.EndHeight <= request.StartHeight {
+		return &BatchConsolidatorResponse{
+			StartHeight: request.StartHeight,
+			EndHeight:   request.StartHeight,
+		}, nil
+	}
+	result, err := a.metaStorage.PromoteBlockConsolidationShadows(
+		ctx,
+		request.Tag,
+		request.StartHeight,
+		plan.EndHeight,
+		request.MaxBlocks,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to promote consolidation shadows: %w", err)
+	}
+	promotedBlocks := uint64(0)
+	if result != nil {
+		promotedBlocks = result.Blocks
+	}
+	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.promote_finalized.promoted", promotedBlocks)
+	a.getLogger(ctx).Info(
+		"promoted finalized consolidation shadows",
+		zap.Reflect("request", request),
+		zap.Uint64("promoted_blocks", promotedBlocks),
+	)
+	return &BatchConsolidatorResponse{
+		StartHeight:        request.StartHeight,
+		EndHeight:          plan.EndHeight,
+		ScannedBlocks:      promotedBlocks,
+		ConsolidatedBlocks: promotedBlocks,
+	}, nil
+}
+
+func (a *BatchConsolidator) planPromoteFinalized(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*BatchConsolidatorPlanResponse, error) {
+	if err := a.validatePromoteFinalizedMode(); err != nil {
+		return nil, err
+	}
+	latest, err := a.metaStorage.GetLatestBlock(ctx, tag)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get latest block for consolidation promotion: %w", err)
+	}
+
+	consolidation := a.config.AWS.Storage.Consolidation
+	safeLag := *consolidation.SafePromotionLag
+	gateHeight := *consolidation.PromotionGateHeight
+	safeEnd, safeHeight, ok := promotionSafeEndHeight(latest.GetHeight(), safeLag)
+	if !ok {
+		return &BatchConsolidatorPlanResponse{
+			StartHeight:         startHeight,
+			EndHeight:           startHeight,
+			LatestHeight:        latest.GetHeight(),
+			SafePromotionHeight: 0,
+			PromotionGateHeight: gateHeight,
+		}, nil
+	}
+
+	effectiveEndHeight := endHeight
+	if gateHeight < effectiveEndHeight {
+		effectiveEndHeight = gateHeight
+	}
+	if safeEnd < effectiveEndHeight {
+		effectiveEndHeight = safeEnd
+	}
+	if effectiveEndHeight < startHeight {
+		effectiveEndHeight = startHeight
+	}
+
+	return &BatchConsolidatorPlanResponse{
+		StartHeight:         startHeight,
+		EndHeight:           effectiveEndHeight,
+		LatestHeight:        latest.GetHeight(),
+		SafePromotionHeight: safeHeight,
+		PromotionGateHeight: gateHeight,
+	}, nil
+}
+
 func (a *BatchConsolidator) getConsolidationShadowStats(
 	ctx context.Context,
 	tag uint32,
@@ -189,15 +325,51 @@ func (a *BatchConsolidator) getConsolidationShadowStats(
 	return stats, nil
 }
 
-func (a *BatchConsolidator) validateConsolidationMode() error {
+func (a *BatchConsolidator) validateConsolidationEnabled() error {
 	consolidation := a.config.AWS.Storage.Consolidation
 	if !consolidation.Enabled {
 		return xerrors.New("batch consolidator requires aws.storage.consolidation.enabled=true")
 	}
+	return nil
+}
+
+func (a *BatchConsolidator) validateShadowDualWriteMode() error {
+	if err := a.validateConsolidationEnabled(); err != nil {
+		return err
+	}
+	consolidation := a.config.AWS.Storage.Consolidation
 	if consolidation.Mode != config.ConsolidationModeShadowDualWrite {
 		return xerrors.Errorf("batch consolidator requires consolidation mode %q, got %q", config.ConsolidationModeShadowDualWrite, consolidation.Mode)
 	}
 	return nil
+}
+
+func (a *BatchConsolidator) validatePromoteFinalizedMode() error {
+	if err := a.validateConsolidationEnabled(); err != nil {
+		return err
+	}
+	consolidation := a.config.AWS.Storage.Consolidation
+	if consolidation.Mode != config.ConsolidationModePromoteFinalized {
+		return xerrors.Errorf("batch consolidator requires consolidation mode %q, got %q", config.ConsolidationModePromoteFinalized, consolidation.Mode)
+	}
+	if consolidation.PromotionGateHeight == nil {
+		return xerrors.New("batch consolidator promote_finalized requires promotion_gate_height")
+	}
+	if consolidation.SafePromotionLag == nil {
+		return xerrors.New("batch consolidator promote_finalized requires safe_promotion_lag")
+	}
+	return nil
+}
+
+func promotionSafeEndHeight(latestHeight uint64, safePromotionLag uint64) (uint64, uint64, bool) {
+	if latestHeight < safePromotionLag {
+		return 0, 0, false
+	}
+	safeHeight := latestHeight - safePromotionLag
+	if safeHeight == ^uint64(0) {
+		return safeHeight, safeHeight, true
+	}
+	return safeHeight + 1, safeHeight, true
 }
 
 func (a *BatchConsolidator) buildPayloads(

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -223,6 +223,120 @@ func (s *BatchConsolidatorTestSuite) TestGetShadowStatsReturnsPersistedShadowSta
 	}, response)
 }
 
+func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPromotesShadows() {
+	require := testutil.Require(s.T())
+	gateHeight := uint64(2_000)
+	safeLag := uint64(100)
+	s.batchConsolidator.config.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.batchConsolidator.config.AWS.Storage.Consolidation.PromotionGateHeight = &gateHeight
+	s.batchConsolidator.config.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+	request := &BatchConsolidatorRequest{
+		Tag:         2,
+		StartHeight: 1_000,
+		EndHeight:   1_100,
+		MaxBlocks:   25,
+	}
+	s.metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), request.Tag).
+		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_300}, nil)
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
+		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:        request.StartHeight,
+		EndHeight:          request.EndHeight,
+		ScannedBlocks:      12,
+		ConsolidatedBlocks: 12,
+	}, response)
+}
+
+func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteCapsAtGateAndSafeHeight() {
+	require := testutil.Require(s.T())
+	gateHeight := uint64(1_050)
+	safeLag := uint64(10)
+	s.batchConsolidator.config.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.batchConsolidator.config.AWS.Storage.Consolidation.PromotionGateHeight = &gateHeight
+	s.batchConsolidator.config.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+	request := &BatchConsolidatorRequest{
+		Tag:         2,
+		StartHeight: 1_000,
+		EndHeight:   1_200,
+		MaxBlocks:   25,
+	}
+	s.metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), request.Tag).
+		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_080}, nil)
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, gateHeight, request.MaxBlocks).
+		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:        request.StartHeight,
+		EndHeight:          gateHeight,
+		ScannedBlocks:      12,
+		ConsolidatedBlocks: 12,
+	}, response)
+}
+
+func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPlanCapsAtGateAndSafeHeight() {
+	require := testutil.Require(s.T())
+	gateHeight := uint64(1_050)
+	safeLag := uint64(10)
+	s.batchConsolidator.config.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.batchConsolidator.config.AWS.Storage.Consolidation.PromotionGateHeight = &gateHeight
+	s.batchConsolidator.config.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+	request := &BatchConsolidatorPlanRequest{
+		Tag:         2,
+		StartHeight: 1_000,
+		EndHeight:   1_200,
+	}
+	s.metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), request.Tag).
+		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_080}, nil)
+
+	response, err := s.batchConsolidator.GetPromotionPlan(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorPlanResponse{
+		StartHeight:         request.StartHeight,
+		EndHeight:           gateHeight,
+		LatestHeight:        1_080,
+		SafePromotionHeight: 1_070,
+		PromotionGateHeight: gateHeight,
+	}, response)
+}
+
+func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPlanNoOpsWhenLatestBelowSafeLag() {
+	require := testutil.Require(s.T())
+	gateHeight := uint64(1_050)
+	safeLag := uint64(100)
+	s.batchConsolidator.config.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.batchConsolidator.config.AWS.Storage.Consolidation.PromotionGateHeight = &gateHeight
+	s.batchConsolidator.config.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+	request := &BatchConsolidatorPlanRequest{
+		Tag:         2,
+		StartHeight: 1_000,
+		EndHeight:   1_200,
+	}
+	s.metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), request.Tag).
+		Return(&api.BlockMetadata{Tag: request.Tag, Height: 50}, nil)
+
+	response, err := s.batchConsolidator.GetPromotionPlan(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorPlanResponse{
+		StartHeight:         request.StartHeight,
+		EndHeight:           request.StartHeight,
+		LatestHeight:        50,
+		SafePromotionHeight: 0,
+		PromotionGateHeight: gateHeight,
+	}, response)
+}
+
 type consolidatedPayloadsMatcher struct {
 	blocks        []*api.Block
 	metadataIDs   []int64

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -115,6 +115,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		if shardSize == 0 {
 			return xerrors.New("batch_consolidator storage consolidation shard_size must be positive")
 		}
+		mode := cfg.Storage.Consolidation.Mode
 
 		tag := cfg.GetEffectiveBlockTag(request.Tag)
 		metrics := w.getMetricsHandler(ctx).WithTags(map[string]string{
@@ -129,6 +130,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			zap.Uint64("max_blocks", maxBlocks),
 			zap.Uint64("storage_max_blocks", storageMaxBlocks),
 			zap.Uint64("shard_size", shardSize),
+			zap.String("mode", string(mode)),
 		)
 		logger.Info("workflow started")
 		ctx = w.withActivityOptions(ctx)
@@ -138,9 +140,34 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			batchConsolidatorShadowStatsChangeID,
 			workflow.DefaultVersion,
 			batchConsolidatorShadowStatsVersion,
-		) != workflow.DefaultVersion
+		) != workflow.DefaultVersion && mode != config.ConsolidationModePromoteFinalized
 
-		for batchStart := request.StartHeight; batchStart < request.EndHeight; {
+		workflowEndHeight := request.EndHeight
+		if mode == config.ConsolidationModePromoteFinalized {
+			plan, err := w.batchConsolidator.GetPromotionPlan(ctx, &activity.BatchConsolidatorPlanRequest{
+				Tag:         tag,
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			})
+			if err != nil {
+				return xerrors.Errorf("failed to plan promote_finalized range: %w", err)
+			}
+			workflowEndHeight = plan.EndHeight
+			logger.Info(
+				"planned promote_finalized range",
+				zap.Uint64("requested_end_height", request.EndHeight),
+				zap.Uint64("effective_end_height", workflowEndHeight),
+				zap.Uint64("latest_height", plan.LatestHeight),
+				zap.Uint64("safe_promotion_height", plan.SafePromotionHeight),
+				zap.Uint64("promotion_gate_height", plan.PromotionGateHeight),
+			)
+			if workflowEndHeight <= request.StartHeight {
+				logger.Info("promote_finalized range has no currently safe heights")
+				return nil
+			}
+		}
+
+		for batchStart := request.StartHeight; batchStart < workflowEndHeight; {
 			if batchStart-request.StartHeight >= checkpointSize {
 				newRequest := *request
 				newRequest.StartHeight = batchStart
@@ -148,7 +175,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				return w.continueAsNew(ctx, &newRequest)
 			}
 
-			batchEnd := batchConsolidatorWindowEnd(batchStart, request.EndHeight, batchSize, shardSize)
+			batchEnd := batchConsolidatorWindowEnd(batchStart, workflowEndHeight, batchSize, shardSize)
 			if batchEnd <= batchStart {
 				return xerrors.Errorf("batch_consolidator made no height progress from %d to %d", batchStart, batchEnd)
 			}

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -242,6 +242,73 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRepeatsHeightBatchUnti
 	}
 }
 
+func (s *batchConsolidatorTestSuite) TestPromoteFinalizedProcessesOnlyPlannedRange() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	var requests []*activity.BatchConsolidatorRequest
+	s.env.OnActivity(activity.ActivityBatchConsolidatorPlan, mock.Anything, mock.Anything).
+		Return(&activity.BatchConsolidatorPlanResponse{
+			StartHeight:         1000,
+			EndHeight:           1100,
+			LatestHeight:        1200,
+			SafePromotionHeight: 1190,
+			PromotionGateHeight: 1100,
+		}, nil)
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+			}, nil
+		}).Once()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		}).Once()
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1300,
+		MaxBlocks:   100,
+	})
+	require.NoError(err)
+	require.Equal([]*activity.BatchConsolidatorRequest{
+		{Tag: 2, StartHeight: 1000, EndHeight: 1100, MaxBlocks: 100},
+		{Tag: 2, StartHeight: 1000, EndHeight: 1100, MaxBlocks: 100},
+	}, requests)
+}
+
+func (s *batchConsolidatorTestSuite) TestPromoteFinalizedNoOpsWhenPlanHasNoSafeRange() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.env.OnActivity(activity.ActivityBatchConsolidatorPlan, mock.Anything, mock.Anything).
+		Return(&activity.BatchConsolidatorPlanResponse{
+			StartHeight:         1000,
+			EndHeight:           1000,
+			LatestHeight:        900,
+			SafePromotionHeight: 0,
+			PromotionGateHeight: 1200,
+		}, nil)
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1300,
+		MaxBlocks:   100,
+	})
+	require.NoError(err)
+}
+
 func (s *batchConsolidatorTestSuite) TestBatchConsolidatorAccountsLostActivityCompletionFromShadowStats() {
 	require := testutil.Require(s.T())
 


### PR DESCRIPTION
### What changed? Why?

Implements guarded `promote_finalized` support for the batch consolidator so validated CSCB shadow rows can be promoted from legacy primary metadata to consolidated primary metadata without deleting legacy objects or stopping legacy writes.

Key pieces:
- Adds explicit operator gates: `promotion_gate_height` and `safe_promotion_lag` are required for `promote_finalized`.
- Caps promotion to the lower of requested end, exclusive gate height, and latest watermarked block minus safe lag.
- Adds a Postgres guarded promotion path that locks canonical metadata, primary metadata, and shadow rows, validates CSCB shadow fields, updates only legacy primary rows, and rolls back on invalid candidates.
- Leaves DynamoDB and Firestore promotion explicitly unsupported, with config validation keeping active consolidation promotion on Postgres until safe guarded promotion exists there.
- Keeps legacy fallback intact: promotion updates primary metadata only; it does not delete legacy objects or disable legacy writes.

### How did you test the change?

- [x] unit test
- [x] integration test
- [ ] functional test
- [x] adhoc test (described below)

Commands run:

```bash
TEST_TYPE=unit go test ./internal/config ./internal/workflow/activity ./internal/workflow ./internal/storage/metastorage/...
CHAINSTORAGE_AWS_POSTGRES_PASSWORD=worker_password make integration TARGET=internal/storage/metastorage/postgres TEST_FILTER='TestIntegrationBlockStorageTestSuite/TestPromoteBlockConsolidationShadows'
PATH="$(go env GOPATH)/bin:$PATH" make lint
git diff --check
```

Notes:
- A full local `make test` run failed in existing `internal/workflow` `TestBackfillerTestSuite/TestBackfiller` with Temporal's `[TMPRL1101] Potential deadlock detected` under local Go 1.26.3. The exact test also reproduced with `TEST_TYPE=unit go test ./internal/workflow -run 'TestBackfillerTestSuite/TestBackfiller$' -count=10`. Focused changed-package tests passed.