### PR TITLE
fix(INF-984): bound CSCB validator memory

### DIFF
--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -674,12 +674,16 @@ func (v *cscbValidator) getFiles(ctx context.Context, validationCase cscbValidat
 	return resp.GetFiles(), nil
 }
 
-func (v *cscbValidator) hashFiles(ctx context.Context, files []*api.BlockFile) ([]cscbBlockDigest, error) {
+func (v *cscbValidator) hashFiles(ctx context.Context, files []*api.BlockFile) (_ []cscbBlockDigest, retErr error) {
 	iter, err := v.downloader.OpenRawBlockPayloads(ctx, files)
 	if err != nil {
 		return nil, xerrors.Errorf("OpenRawBlockPayloads failed: %w", err)
 	}
-	defer iter.Close()
+	defer func() {
+		if closeErr := iter.Close(); retErr == nil && closeErr != nil {
+			retErr = xerrors.Errorf("close raw block payload iterator failed: %w", closeErr)
+		}
+	}()
 
 	digests := make([]cscbBlockDigest, 0, len(files))
 	for {

--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -162,10 +162,15 @@ type (
 
 	cscbFetchResult struct {
 		files    []*api.BlockFile
-		blocks   []*api.Block
+		digests  []cscbBlockDigest
 		duration time.Duration
 		http     cscbHTTPSnapshot
 		err      error
+	}
+
+	cscbBlockDigest struct {
+		height uint64
+		hash   string
 	}
 
 	cscbHTTPSnapshot struct {
@@ -586,7 +591,7 @@ func (v *cscbValidator) runCase(ctx context.Context, validationCase cscbValidati
 			continue
 		}
 
-		comparison := compareCSCBBlocks(legacy.blocks, consolidated.blocks)
+		comparison := compareCSCBDigests(legacy.digests, consolidated.digests)
 		if !comparison.correct {
 			result.Correct = false
 			result.Passed = false
@@ -628,10 +633,10 @@ func (v *cscbValidator) fetch(ctx context.Context, validationCase cscbValidation
 	if err != nil {
 		return cscbFetchResult{duration: time.Since(start), http: v.counter.Snapshot(), err: err}
 	}
-	blocks, err := v.downloadFiles(ctx, files)
+	digests, err := v.hashFiles(ctx, files)
 	return cscbFetchResult{
 		files:    files,
-		blocks:   blocks,
+		digests:  digests,
 		duration: time.Since(start),
 		http:     v.counter.Snapshot(),
 		err:      err,
@@ -669,19 +674,37 @@ func (v *cscbValidator) getFiles(ctx context.Context, validationCase cscbValidat
 	return resp.GetFiles(), nil
 }
 
-func (v *cscbValidator) downloadFiles(ctx context.Context, files []*api.BlockFile) ([]*api.Block, error) {
-	if len(files) == 1 {
-		block, err := v.downloader.Download(ctx, files[0])
-		if err != nil {
-			return nil, xerrors.Errorf("Download failed: %w", err)
-		}
-		return []*api.Block{block}, nil
-	}
-	blocks, err := v.downloader.DownloadMany(ctx, files)
+func (v *cscbValidator) hashFiles(ctx context.Context, files []*api.BlockFile) ([]cscbBlockDigest, error) {
+	iter, err := v.downloader.OpenRawBlockPayloads(ctx, files)
 	if err != nil {
-		return nil, xerrors.Errorf("DownloadMany failed: %w", err)
+		return nil, xerrors.Errorf("OpenRawBlockPayloads failed: %w", err)
 	}
-	return blocks, nil
+	defer iter.Close()
+
+	digests := make([]cscbBlockDigest, 0, len(files))
+	for {
+		payload, err := iter.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, xerrors.Errorf("read raw block payload failed: %w", err)
+		}
+
+		digest, digestErr := canonicalRawPayloadHash(payload)
+		var closeErr error
+		if payload != nil {
+			closeErr = payload.Close()
+		}
+		if digestErr != nil {
+			return nil, digestErr
+		}
+		if closeErr != nil {
+			return nil, xerrors.Errorf("close raw block payload failed: %w", closeErr)
+		}
+		digests = append(digests, digest)
+	}
+	return digests, nil
 }
 
 type cscbBlockComparison struct {
@@ -717,6 +740,42 @@ func compareCSCBBlocks(legacy []*api.Block, consolidated []*api.Block) cscbBlock
 	}
 	comparison.mismatchHeights = uniqueSortedHeights(comparison.mismatchHeights, 0, ^uint64(0))
 	return comparison
+}
+
+func compareCSCBDigests(legacy []cscbBlockDigest, consolidated []cscbBlockDigest) cscbBlockComparison {
+	comparison := cscbBlockComparison{correct: true}
+	if len(legacy) != len(consolidated) {
+		comparison.correct = false
+		comparison.mismatchHeights = append(comparison.mismatchHeights, collectDigestHeights(legacy)...)
+		comparison.mismatchHeights = append(comparison.mismatchHeights, collectDigestHeights(consolidated)...)
+		comparison.mismatchHeights = uniqueSortedHeights(comparison.mismatchHeights, 0, ^uint64(0))
+		return comparison
+	}
+
+	for i := range legacy {
+		if comparison.hashesCompared == 0 {
+			comparison.firstLegacyHash = legacy[i].hash
+			comparison.firstConsolidatedHash = consolidated[i].hash
+		}
+		comparison.hashesCompared++
+
+		if legacy[i].height != consolidated[i].height || legacy[i].hash != consolidated[i].hash {
+			comparison.correct = false
+			comparison.mismatchHeights = append(comparison.mismatchHeights, legacy[i].height, consolidated[i].height)
+		}
+	}
+	comparison.mismatchHeights = uniqueSortedHeights(comparison.mismatchHeights, 0, ^uint64(0))
+	return comparison
+}
+
+func collectDigestHeights(digests []cscbBlockDigest) []uint64 {
+	heights := make([]uint64, 0, len(digests))
+	for _, digest := range digests {
+		if digest.height > 0 {
+			heights = append(heights, digest.height)
+		}
+	}
+	return heights
 }
 
 func collectBlockHeights(blocks []*api.Block) []uint64 {
@@ -772,6 +831,61 @@ func canonicalBlockHash(block *api.Block) (string, error) {
 	}
 	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+func canonicalRawPayloadHash(payload *downloader.RawBlockPayload) (cscbBlockDigest, error) {
+	if payload == nil || payload.BlockFile == nil {
+		return cscbBlockDigest{}, xerrors.New("nil raw block payload")
+	}
+	data, err := io.ReadAll(payload)
+	if err != nil {
+		return cscbBlockDigest{}, xerrors.Errorf("read raw block payload for height %d failed: %w", payload.BlockFile.GetHeight(), err)
+	}
+	hash, err := canonicalRawBlockDataHash(payload.BlockFile, data)
+	if err != nil {
+		return cscbBlockDigest{}, err
+	}
+	return cscbBlockDigest{height: payload.BlockFile.GetHeight(), hash: hash}, nil
+}
+
+func canonicalRawBlockDataHash(blockFile *api.BlockFile, data []byte) (string, error) {
+	if blockFile == nil {
+		return "", xerrors.New("nil block file")
+	}
+	if blockFile.GetSkipped() {
+		return canonicalBlockHash(&api.Block{
+			Metadata: &api.BlockMetadata{
+				Tag:     blockFile.GetTag(),
+				Height:  blockFile.GetHeight(),
+				Skipped: true,
+			},
+		})
+	}
+
+	var block api.Block
+	if err := proto.Unmarshal(data, &block); err != nil {
+		return "", xerrors.Errorf("unmarshal raw block payload for height %d failed: %w", blockFile.GetHeight(), err)
+	}
+	if isCSCBFile(blockFile) {
+		block.Metadata = cscbMetadataFromBlockFile(blockFile)
+	}
+	return canonicalBlockHash(&block)
+}
+
+func cscbMetadataFromBlockFile(blockFile *api.BlockFile) *api.BlockMetadata {
+	return &api.BlockMetadata{
+		Tag:                blockFile.GetTag(),
+		Hash:               blockFile.GetHash(),
+		ParentHash:         blockFile.GetParentHash(),
+		Height:             blockFile.GetHeight(),
+		ParentHeight:       blockFile.GetParentHeight(),
+		Skipped:            blockFile.GetSkipped(),
+		Timestamp:          blockFile.GetBlockTimestamp(),
+		ObjectFormat:       blockFile.GetObjectFormat(),
+		ByteOffset:         blockFile.GetByteOffset(),
+		ByteLength:         blockFile.GetByteLength(),
+		UncompressedLength: blockFile.GetUncompressedLength(),
+	}
 }
 
 func summarizeDurations(durations []time.Duration) cscbLatencySummary {

--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -775,9 +775,7 @@ func compareCSCBDigests(legacy []cscbBlockDigest, consolidated []cscbBlockDigest
 func collectDigestHeights(digests []cscbBlockDigest) []uint64 {
 	heights := make([]uint64, 0, len(digests))
 	for _, digest := range digests {
-		if digest.height > 0 {
-			heights = append(heights, digest.height)
-		}
+		heights = append(heights, digest.height)
 	}
 	return heights
 }

--- a/cmd/admin/cscb_validate_test.go
+++ b/cmd/admin/cscb_validate_test.go
@@ -214,12 +214,12 @@ func TestCompareCSCBDigestsDetectsMismatch(t *testing.T) {
 func TestCompareCSCBDigestsHandlesLengthMismatch(t *testing.T) {
 	require := require.New(t)
 	comparison := compareCSCBDigests(
-		[]cscbBlockDigest{{height: 42, hash: "hash"}},
-		[]cscbBlockDigest{{height: 42, hash: "hash"}, {height: 43, hash: "hash"}},
+		[]cscbBlockDigest{{height: 0, hash: "hash"}},
+		[]cscbBlockDigest{{height: 0, hash: "hash"}, {height: 1, hash: "hash"}},
 	)
 
 	require.False(comparison.correct)
-	require.Equal([]uint64{42, 43}, comparison.mismatchHeights)
+	require.Equal([]uint64{0, 1}, comparison.mismatchHeights)
 	require.Zero(comparison.hashesCompared)
 }
 

--- a/cmd/admin/cscb_validate_test.go
+++ b/cmd/admin/cscb_validate_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
@@ -117,6 +118,109 @@ func TestCanonicalBlockHashRestoresMetadata(t *testing.T) {
 	require.Equal(uint64(10), block.Metadata.ByteOffset)
 	require.Equal(uint64(20), block.Metadata.ByteLength)
 	require.Equal(uint64(30), block.Metadata.UncompressedLength)
+}
+
+func TestCanonicalRawBlockDataHashIgnoresSourceSpecificMetadata(t *testing.T) {
+	require := require.New(t)
+	block := &api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:                1,
+			Height:             42,
+			Hash:               "hash",
+			ParentHash:         "parent",
+			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:         1024,
+			ByteLength:         2048,
+			UncompressedLength: 4096,
+		},
+	}
+	payload, err := proto.Marshal(block)
+	require.NoError(err)
+
+	rawHash, err := canonicalRawBlockDataHash(&api.BlockFile{Height: 42}, payload)
+	require.NoError(err)
+	expectedHash, err := canonicalBlockHash(block)
+	require.NoError(err)
+	require.Equal(expectedHash, rawHash)
+}
+
+func TestCanonicalRawBlockDataHashUsesCSCBBlockFileMetadata(t *testing.T) {
+	require := require.New(t)
+	block := &api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:        1,
+			Height:     42,
+			Hash:       "stale-embedded-hash",
+			ParentHash: "stale-embedded-parent",
+		},
+	}
+	payload, err := proto.Marshal(block)
+	require.NoError(err)
+
+	blockFile := &api.BlockFile{
+		Tag:          1,
+		Height:       42,
+		Hash:         "metadata-hash",
+		ParentHash:   "metadata-parent",
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteLength:   uint64(len(payload)),
+	}
+	rawHash, err := canonicalRawBlockDataHash(blockFile, payload)
+	require.NoError(err)
+
+	expectedHash, err := canonicalBlockHash(&api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:          1,
+			Height:       42,
+			Hash:         "metadata-hash",
+			ParentHash:   "metadata-parent",
+			ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteLength:   uint64(len(payload)),
+		},
+	})
+	require.NoError(err)
+	require.Equal(expectedHash, rawHash)
+}
+
+func TestCanonicalRawBlockDataHashHandlesSkippedBlock(t *testing.T) {
+	require := require.New(t)
+	rawHash, err := canonicalRawBlockDataHash(&api.BlockFile{Tag: 1, Height: 42, Skipped: true}, nil)
+	require.NoError(err)
+	expectedHash, err := canonicalBlockHash(&api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:     1,
+			Height:  42,
+			Skipped: true,
+		},
+	})
+	require.NoError(err)
+	require.Equal(expectedHash, rawHash)
+}
+
+func TestCompareCSCBDigestsDetectsMismatch(t *testing.T) {
+	require := require.New(t)
+	comparison := compareCSCBDigests(
+		[]cscbBlockDigest{{height: 42, hash: "legacy"}},
+		[]cscbBlockDigest{{height: 42, hash: "consolidated"}},
+	)
+
+	require.False(comparison.correct)
+	require.Equal([]uint64{42}, comparison.mismatchHeights)
+	require.Equal(1, comparison.hashesCompared)
+	require.Equal("legacy", comparison.firstLegacyHash)
+	require.Equal("consolidated", comparison.firstConsolidatedHash)
+}
+
+func TestCompareCSCBDigestsHandlesLengthMismatch(t *testing.T) {
+	require := require.New(t)
+	comparison := compareCSCBDigests(
+		[]cscbBlockDigest{{height: 42, hash: "hash"}},
+		[]cscbBlockDigest{{height: 42, hash: "hash"}, {height: 43, hash: "hash"}},
+	)
+
+	require.False(comparison.correct)
+	require.Equal([]uint64{42, 43}, comparison.mismatchHeights)
+	require.Zero(comparison.hashesCompared)
 }
 
 func TestSummarizeDurationsUsesNearestRankPercentile(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix INF-984: make `admin cscb validate` memory-bounded for large range validation.
- Replace full-range `DownloadMany` materialization with `OpenRawBlockPayloads` iteration and per-block canonical digest comparison.
- Preserve existing comparison semantics: legacy payload metadata is read from the block payload, CSCB payload metadata is overridden from `BlockFile` like the production CSCB downloader, and source-specific object placement fields are normalized before hashing.

## Context
- Linear: https://linear.app/cipherowl/issue/INF-984/cscb-make-admin-validation-memory-bounded
- Alert: https://cipherowl.slack.com/archives/C0744T9LDLL/p1782162531152279
- Root cause: the full-object Solana validation case materialized both the legacy block range and the consolidated block range in memory, which OOMKilled the `chainstorage-admin` console pod.

## Validation
- `go test ./cmd/admin`
- `git diff --check`