### PR TITLE
fix(INF-1002): ignore skipped blocks in cscb fallback validation

### DIFF
--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -939,7 +939,6 @@ func summarizeCSCBFiles(files []*api.BlockFile) cscbFileSummary {
 		summary.LastHeight = file.GetHeight()
 		if file.GetSkipped() {
 			summary.SkippedCount++
-			formats["SKIPPED"] = struct{}{}
 		} else if isCSCBFile(file) {
 			summary.ConsolidatedObjectCount++
 			formats[file.GetObjectFormat().String()] = struct{}{}
@@ -1111,14 +1110,20 @@ func writeCSCBMarkdownReport(path string, report *cscbValidationReport) error {
 			continue
 		}
 		fmt.Fprintf(&b, "### %s\n\n", c.Name)
-		fmt.Fprintf(&b, "- legacy files: `%d`, formats: `%s`, HTTP requests: `%d`, bytes: `%d`\n",
+		fmt.Fprintf(&b, "- legacy files: `%d`, skipped: `%d`, legacy_objects: `%d`, consolidated_objects: `%d`, formats: `%s`, HTTP requests: `%d`, bytes: `%d`\n",
 			c.Legacy.Files.Count,
+			c.Legacy.Files.SkippedCount,
+			c.Legacy.Files.LegacyObjectCount,
+			c.Legacy.Files.ConsolidatedObjectCount,
 			strings.Join(c.Legacy.Files.Formats, ","),
 			c.Legacy.HTTP.Requests,
 			c.Legacy.HTTP.Bytes,
 		)
-		fmt.Fprintf(&b, "- consolidated files: `%d`, formats: `%s`, HTTP requests: `%d`, bytes: `%d`\n",
+		fmt.Fprintf(&b, "- consolidated files: `%d`, skipped: `%d`, legacy_objects: `%d`, consolidated_objects: `%d`, formats: `%s`, HTTP requests: `%d`, bytes: `%d`\n",
 			c.Consolidated.Files.Count,
+			c.Consolidated.Files.SkippedCount,
+			c.Consolidated.Files.LegacyObjectCount,
+			c.Consolidated.Files.ConsolidatedObjectCount,
 			strings.Join(c.Consolidated.Files.Formats, ","),
 			c.Consolidated.HTTP.Requests,
 			c.Consolidated.HTTP.Bytes,

--- a/cmd/admin/cscb_validate.go
+++ b/cmd/admin/cscb_validate.go
@@ -939,15 +939,16 @@ func summarizeCSCBFiles(files []*api.BlockFile) cscbFileSummary {
 		summary.LastHeight = file.GetHeight()
 		if file.GetSkipped() {
 			summary.SkippedCount++
-		}
-		if isCSCBFile(file) {
+			formats["SKIPPED"] = struct{}{}
+		} else if isCSCBFile(file) {
 			summary.ConsolidatedObjectCount++
+			formats[file.GetObjectFormat().String()] = struct{}{}
 		} else {
 			summary.LegacyObjectCount++
+			formats[file.GetObjectFormat().String()] = struct{}{}
 		}
 		summary.MetadataByteLength += file.GetByteLength()
 		summary.MetadataUncompressedBytes += file.GetUncompressedLength()
-		formats[file.GetObjectFormat().String()] = struct{}{}
 	}
 	for format := range formats {
 		summary.Formats = append(summary.Formats, format)

--- a/cmd/admin/cscb_validate_test.go
+++ b/cmd/admin/cscb_validate_test.go
@@ -265,7 +265,7 @@ func TestSummarizeCSCBFilesDoesNotCountSkippedBlocksAsLegacyFallback(t *testing.
 	require.Equal(1, summary.LegacyObjectCount)
 	require.Equal(uint64(100), summary.FirstHeight)
 	require.Equal(uint64(102), summary.LastHeight)
-	require.Equal([]string{"BLOCK_OBJECT_FORMAT_CSCB_BATCH", "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK", "SKIPPED"}, summary.Formats)
+	require.Equal([]string{"BLOCK_OBJECT_FORMAT_CSCB_BATCH", "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK"}, summary.Formats)
 }
 
 func TestSanitizeCSCBStringRedactsEmbeddedURLs(t *testing.T) {

--- a/cmd/admin/cscb_validate_test.go
+++ b/cmd/admin/cscb_validate_test.go
@@ -240,6 +240,34 @@ func TestSummarizeDurationsUsesNearestRankPercentile(t *testing.T) {
 	require.Equal(float64(50), summary.MaxMs)
 }
 
+func TestSummarizeCSCBFilesDoesNotCountSkippedBlocksAsLegacyFallback(t *testing.T) {
+	require := require.New(t)
+
+	summary := summarizeCSCBFiles([]*api.BlockFile{
+		{
+			Height:       100,
+			ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteLength:   1024,
+		},
+		{
+			Height:  101,
+			Skipped: true,
+		},
+		{
+			Height:     102,
+			ByteLength: 512,
+		},
+	})
+
+	require.Equal(3, summary.Count)
+	require.Equal(1, summary.ConsolidatedObjectCount)
+	require.Equal(1, summary.SkippedCount)
+	require.Equal(1, summary.LegacyObjectCount)
+	require.Equal(uint64(100), summary.FirstHeight)
+	require.Equal(uint64(102), summary.LastHeight)
+	require.Equal([]string{"BLOCK_OBJECT_FORMAT_CSCB_BATCH", "BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK", "SKIPPED"}, summary.Formats)
+}
+
 func TestSanitizeCSCBStringRedactsEmbeddedURLs(t *testing.T) {
 	require := require.New(t)
 	errText := `Download failed: blockFile={FileUrl:"https://bucket.s3.amazonaws.com/key?X-Amz-Signature=secret", Height:42}`


### PR DESCRIPTION
## Summary

- Fix `admin cscb validate` so skipped block placeholders do not count as legacy fallback.
- Render skipped placeholders explicitly as `SKIPPED` in validator file-format summaries.
- Add focused unit coverage for skipped-block fallback accounting.

## Root Cause

Prod Solana validation for `[428659025, 428660000)` false-failed `range_full_object` with `unexpected consolidated fallback to legacy metadata` even though direct `GetBlockFilesByRange` showed `971` CSCB entries, `4` skipped entries, and `0` non-skipped legacy fallback entries. The validator counted every non-CSCB `BlockFile` as legacy fallback, including `skipped=true` placeholders.

Linear: https://linear.app/cipherowl/issue/INF-1002/cscb-fix-skipped-block-false-fallback-in-validation-harness

## Validation

- `go test ./cmd/admin`
- Reran prod Solana partial-object validation locally through a prod port-forward after the fix:
  - range: `[428659025, 428660000)`
  - result: `15 passed / 15 total`
  - mismatches: `0`
  - observed fallback: only the deliberate uncovered fallback height `428660000`
