### PR TITLE
feat(INF-1004): automate CSCB promotion scheduling

### DIFF
--- a/cmd/admin/workflow.go
+++ b/cmd/admin/workflow.go
@@ -138,7 +138,7 @@ func startWorkflow() error {
 	}
 	defer app.Close()
 
-	ctx := context.WithValue(context.Background(), "workflowId", workflowId)
+	ctx := workflow.WithWorkflowID(context.Background(), workflowId)
 	workflowIdentityString, err := workflowIdentity.String()
 	if err != nil {
 		return xerrors.Errorf("error parsing workflowIdentity: %w", err)

--- a/cmd/admin/workflow.go
+++ b/cmd/admin/workflow.go
@@ -108,7 +108,7 @@ func listWorkflows() error {
 	}
 	defer app.Close()
 	ctx := context.Background()
-	workflows, err := executors.Runtime.ListOpenWorkflows(ctx, app.Config().Cadence.Domain, 0) //list all workflows
+	workflows, err := executors.Runtime.ListOpenWorkflows(ctx, app.Config().Cadence.Domain, 0, "") //list all workflows
 	if err != nil {
 		return xerrors.Errorf("failed to list workflows: %w", err)
 	} else {

--- a/internal/cadence/runtime.go
+++ b/internal/cadence/runtime.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"time"
 
+	filterpb "go.temporal.io/api/filter/v1"
 	"go.temporal.io/api/serviceerror"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
@@ -41,7 +43,7 @@ type (
 		TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string) error
 		OnStart(ctx context.Context) error
 		OnStop(ctx context.Context) error
-		ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
+		ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32, workflowType string) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
 	}
 
 	RuntimeParams struct {
@@ -57,6 +59,8 @@ type (
 		namespaceClient client.NamespaceClient
 		workers         []worker.Worker
 	}
+
+	listOpenWorkflowsFn func(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
 )
 
 func NewRuntime(params RuntimeParams) (Runtime, error) {
@@ -144,15 +148,43 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 
 }
 
-func (r *runtimeImpl) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
-	openWorkflows, err := r.workflowClient.ListOpenWorkflow(ctx, &workflowservice.ListOpenWorkflowExecutionsRequest{
-		Namespace:       namespace,
-		MaximumPageSize: maxPageSize,
-	})
-	if err != nil {
-		return nil, xerrors.Errorf("failed to get open workflows: %w", err)
+func (r *runtimeImpl) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32, workflowType string) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	return listOpenWorkflowExecutions(ctx, namespace, maxPageSize, workflowType, r.workflowClient.ListOpenWorkflow)
+}
+
+func listOpenWorkflowExecutions(
+	ctx context.Context,
+	namespace string,
+	maxPageSize int32,
+	workflowType string,
+	listFn listOpenWorkflowsFn,
+) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	var executions []*workflowpb.WorkflowExecutionInfo
+	var nextPageToken []byte
+	for {
+		request := &workflowservice.ListOpenWorkflowExecutionsRequest{
+			Namespace:       namespace,
+			MaximumPageSize: maxPageSize,
+			NextPageToken:   nextPageToken,
+		}
+		if workflowType != "" {
+			request.Filters = &workflowservice.ListOpenWorkflowExecutionsRequest_TypeFilter{
+				TypeFilter: &filterpb.WorkflowTypeFilter{Name: workflowType},
+			}
+		}
+
+		openWorkflows, err := listFn(ctx, request)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get open workflows: %w", err)
+		}
+		if openWorkflows != nil {
+			executions = append(executions, openWorkflows.Executions...)
+			nextPageToken = openWorkflows.GetNextPageToken()
+		}
+		if len(nextPageToken) == 0 {
+			return &workflowservice.ListOpenWorkflowExecutionsResponse{Executions: executions}, nil
+		}
 	}
-	return openWorkflows, nil
 }
 
 func (r *runtimeImpl) RegisterWorkflow(w any, options workflow.RegisterOptions) {

--- a/internal/cadence/runtime_test.go
+++ b/internal/cadence/runtime_test.go
@@ -1,0 +1,60 @@
+package cadence
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func TestListOpenWorkflowExecutionsPaginatesAndAppliesTypeFilter(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	calls := make([]*workflowservice.ListOpenWorkflowExecutionsRequest, 0, 2)
+	responses := []*workflowservice.ListOpenWorkflowExecutionsResponse{
+		{
+			Executions: []*workflowpb.WorkflowExecutionInfo{
+				{
+					Execution: &commonpb.WorkflowExecution{WorkflowId: "custom-manual-workflow-id-1"},
+					Type:      &commonpb.WorkflowType{Name: "workflow.batch_consolidator"},
+				},
+			},
+			NextPageToken: []byte("page-2"),
+		},
+		{
+			Executions: []*workflowpb.WorkflowExecutionInfo{
+				{
+					Execution: &commonpb.WorkflowExecution{WorkflowId: "custom-manual-workflow-id-2"},
+					Type:      &commonpb.WorkflowType{Name: "workflow.batch_consolidator"},
+				},
+			},
+		},
+	}
+
+	response, err := listOpenWorkflowExecutions(
+		ctx,
+		"chainstorage-prod",
+		100,
+		"workflow.batch_consolidator",
+		func(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+			calls = append(calls, request)
+			return responses[len(calls)-1], nil
+		},
+	)
+
+	require.NoError(err)
+	require.Len(calls, 2)
+	require.Equal("chainstorage-prod", calls[0].GetNamespace())
+	require.Equal(int32(100), calls[0].GetMaximumPageSize())
+	require.Empty(calls[0].GetNextPageToken())
+	require.Equal("workflow.batch_consolidator", calls[0].GetTypeFilter().GetName())
+	require.Equal([]byte("page-2"), calls[1].GetNextPageToken())
+	require.Equal("workflow.batch_consolidator", calls[1].GetTypeFilter().GetName())
+	require.Len(response.GetExecutions(), 2)
+	require.Equal("custom-manual-workflow-id-1", response.GetExecutions()[0].GetExecution().GetWorkflowId())
+	require.Equal("custom-manual-workflow-id-2", response.GetExecutions()[1].GetExecution().GetWorkflowId())
+	require.Empty(response.GetNextPageToken())
+}

--- a/internal/cadence/test_runtime.go
+++ b/internal/cadence/test_runtime.go
@@ -102,7 +102,7 @@ func (r *testRuntime) TerminateWorkflow(ctx context.Context, workflowID string, 
 	return nil
 }
 
-func (t *testRuntime) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+func (t *testRuntime) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32, workflowType string) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
 	return nil, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -406,12 +406,22 @@ type (
 	}
 
 	CronConfig struct {
-		BlockRangeSize         uint64 `mapstructure:"block_range_size" validate:"required"`
-		DisableDLQProcessor    bool   `mapstructure:"disable_dlq_processor"`
-		DisablePollingCanary   bool   `mapstructure:"disable_polling_canary"`
-		DisableStreamingCanary bool   `mapstructure:"disable_streaming_canary"`
-		DisableNodeCanary      bool   `mapstructure:"disable_node_canary"`
-		DisableWorkflowStatus  bool   `mapstructure:"disable_workflow_status"`
+		BlockRangeSize         uint64                      `mapstructure:"block_range_size" validate:"required"`
+		BatchConsolidator      BatchConsolidatorCronConfig `mapstructure:"batch_consolidator"`
+		DisableDLQProcessor    bool                        `mapstructure:"disable_dlq_processor"`
+		DisablePollingCanary   bool                        `mapstructure:"disable_polling_canary"`
+		DisableStreamingCanary bool                        `mapstructure:"disable_streaming_canary"`
+		DisableNodeCanary      bool                        `mapstructure:"disable_node_canary"`
+		DisableWorkflowStatus  bool                        `mapstructure:"disable_workflow_status"`
+	}
+
+	BatchConsolidatorCronConfig struct {
+		Enabled            bool          `mapstructure:"enabled"`
+		Spec               string        `mapstructure:"spec"`
+		Parallelism        int64         `mapstructure:"parallelism"`
+		DelayStartDuration time.Duration `mapstructure:"delay_start_duration"`
+		StartHeight        uint64        `mapstructure:"start_height"`
+		MaxRangeBlocks     uint64        `mapstructure:"max_range_blocks"`
 	}
 
 	StorageConfig struct {
@@ -672,6 +682,11 @@ func New(opts ...ConfigOption) (*Config, error) {
 		v.SetDefault("aws.reset_local", true)
 	}
 	v.SetDefault("chain.client.tx_batch_size", 100)
+	v.SetDefault("cron.batch_consolidator.enabled", false)
+	v.SetDefault("cron.batch_consolidator.spec", "@every 30m")
+	v.SetDefault("cron.batch_consolidator.parallelism", 1)
+	v.SetDefault("cron.batch_consolidator.delay_start_duration", "1m")
+	v.SetDefault("cron.batch_consolidator.max_range_blocks", 10000)
 	v.SetDefault("aws.storage.consolidation.enabled", false)
 	v.SetDefault("aws.storage.consolidation.mode", string(ConsolidationModeLegacyOnly))
 	v.SetDefault("aws.storage.consolidation.codec", "ZSTD")
@@ -819,9 +834,6 @@ func (c *Config) validateConsolidationConfig() error {
 	}
 	if consolidation.ShadowTimeout <= 0 {
 		return xerrors.New("consolidation shadow_timeout must be positive")
-	}
-	if consolidation.Mode == ConsolidationModePromoteFinalized && consolidation.PromotionGateHeight == nil {
-		return xerrors.New("consolidation promote_finalized requires promotion_gate_height")
 	}
 	if consolidation.Mode == ConsolidationModePromoteFinalized && consolidation.SafePromotionLag == nil {
 		return xerrors.New("consolidation promote_finalized requires safe_promotion_lag")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -885,19 +885,12 @@ func TestConsolidationHistoricalBackfillModeAccepted(t *testing.T) {
 	require.Equal(config.ConsolidationModeHistoricalBackfill, cfg.AWS.Storage.Consolidation.Mode)
 }
 
-func TestConsolidationPromoteFinalizedRequiresOperatorGates(t *testing.T) {
+func TestConsolidationPromoteFinalizedRequiresSafePromotionLag(t *testing.T) {
 	tests := []struct {
 		name        string
 		env         map[string]string
 		expectedErr string
 	}{
-		{
-			name: "missing promotion gate",
-			env: map[string]string{
-				"CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_SAFE_PROMOTION_LAG": "100000",
-			},
-			expectedErr: "requires promotion_gate_height",
-		},
 		{
 			name: "missing safe promotion lag",
 			env: map[string]string{
@@ -930,6 +923,20 @@ func TestConsolidationPromoteFinalizedRequiresOperatorGates(t *testing.T) {
 			require.Contains(err.Error(), test.expectedErr)
 		})
 	}
+}
+
+func TestConsolidationPromoteFinalizedAllowsMissingPromotionGate(t *testing.T) {
+	require := testutil.Require(t)
+
+	t.Setenv("CHAINSTORAGE_STORAGE_TYPE_META", "POSTGRES")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_ENABLED", "true")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_MODE", string(config.ConsolidationModePromoteFinalized))
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_SAFE_PROMOTION_LAG", "100000")
+
+	cfg, err := config.New()
+	require.NoError(err)
+	require.Nil(cfg.AWS.Storage.Consolidation.PromotionGateHeight)
+	require.NotNil(cfg.AWS.Storage.Consolidation.SafePromotionLag)
 }
 
 func TestConsolidationPromoteFinalizedRejectsDynamoDB(t *testing.T) {

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -1,0 +1,256 @@
+package cron
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/cadence"
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	"github.com/coinbase/chainstorage/internal/utils/fxparams"
+	"github.com/coinbase/chainstorage/internal/utils/log"
+	"github.com/coinbase/chainstorage/internal/workflow"
+)
+
+type (
+	BatchConsolidatorTaskParams struct {
+		fx.In
+		fxparams.Params
+		Config            *config.Config
+		Runtime           cadence.Runtime
+		MetaStorage       metastorage.MetaStorage
+		BatchConsolidator *workflow.BatchConsolidator
+	}
+
+	batchConsolidatorTask struct {
+		config            *config.Config
+		logger            *zap.Logger
+		runtime           cadence.Runtime
+		metaStorage       metastorage.MetaStorage
+		batchConsolidator *workflow.BatchConsolidator
+	}
+)
+
+const (
+	autoPromoteFinalizedSuffix       = "auto_promote_finalized"
+	batchConsolidatorOpenPageSize    = 1000
+	defaultBatchConsolidatorCronSpec = "@every 30m"
+)
+
+func NewBatchConsolidator(params BatchConsolidatorTaskParams) (Task, error) {
+	return &batchConsolidatorTask{
+		config:            params.Config,
+		logger:            log.WithPackage(params.Logger),
+		runtime:           params.Runtime,
+		metaStorage:       params.MetaStorage,
+		batchConsolidator: params.BatchConsolidator,
+	}, nil
+}
+
+func (t *batchConsolidatorTask) Name() string {
+	return "batch_consolidator"
+}
+
+func (t *batchConsolidatorTask) Spec() string {
+	spec := t.config.Cron.BatchConsolidator.Spec
+	if spec == "" {
+		return defaultBatchConsolidatorCronSpec
+	}
+	return spec
+}
+
+func (t *batchConsolidatorTask) Parallelism() int64 {
+	parallelism := t.config.Cron.BatchConsolidator.Parallelism
+	if parallelism <= 0 {
+		return 1
+	}
+	return parallelism
+}
+
+func (t *batchConsolidatorTask) Enabled() bool {
+	return t.config.Cron.BatchConsolidator.Enabled
+}
+
+func (t *batchConsolidatorTask) DelayStartDuration() time.Duration {
+	return t.config.Cron.BatchConsolidator.DelayStartDuration
+}
+
+func (t *batchConsolidatorTask) Run(ctx context.Context) error {
+	consolidation := t.config.AWS.Storage.Consolidation
+	if !consolidation.Enabled {
+		return xerrors.New("batch_consolidator cron requires aws.storage.consolidation.enabled=true")
+	}
+	if consolidation.Mode != config.ConsolidationModePromoteFinalized {
+		return xerrors.Errorf("batch_consolidator cron requires consolidation mode %q, got %q", config.ConsolidationModePromoteFinalized, consolidation.Mode)
+	}
+	if consolidation.SafePromotionLag == nil {
+		return xerrors.New("batch_consolidator cron requires safe_promotion_lag")
+	}
+
+	cronConfig := t.config.Cron.BatchConsolidator
+	if cronConfig.MaxRangeBlocks == 0 {
+		return xerrors.New("batch_consolidator cron max_range_blocks must be positive")
+	}
+
+	workflowID := t.autoPromoteWorkflowID()
+	openWorkflowID, open, err := t.openBatchConsolidatorWorkflow(ctx)
+	if err != nil {
+		return err
+	}
+	if open {
+		t.logger.Info(
+			"batch_consolidator cron skipped because a batch_consolidator workflow is already open",
+			zap.String("open_workflow_id", openWorkflowID),
+			zap.String("auto_workflow_id", workflowID),
+		)
+		return nil
+	}
+
+	tag := t.config.GetEffectiveBlockTag(0)
+	searchStart := cronConfig.StartHeight
+	latest, err := t.metaStorage.GetLatestBlock(ctx, tag)
+	if err != nil {
+		return xerrors.Errorf("failed to get latest block for batch_consolidator cron: %w", err)
+	}
+	if latest == nil {
+		return xerrors.New("latest block not found for batch_consolidator cron")
+	}
+	searchEnd, safeHeight, ok := batchConsolidatorCronSafeEndHeight(latest.GetHeight(), *consolidation.SafePromotionLag)
+	if !ok {
+		t.logger.Info(
+			"batch_consolidator cron has no safe promotion range",
+			zap.Uint32("tag", tag),
+			zap.Uint64("latest_height", latest.GetHeight()),
+			zap.Uint64("safe_promotion_lag", *consolidation.SafePromotionLag),
+		)
+		return nil
+	}
+	if consolidation.PromotionGateHeight != nil && *consolidation.PromotionGateHeight < searchEnd {
+		searchEnd = *consolidation.PromotionGateHeight
+	}
+	if searchEnd <= searchStart {
+		t.logger.Info(
+			"batch_consolidator cron safe range is below configured start height",
+			zap.Uint32("tag", tag),
+			zap.Uint64("start_height", searchStart),
+			zap.Uint64("safe_end_height", searchEnd),
+			zap.Uint64("latest_height", latest.GetHeight()),
+			zap.Uint64("safe_promotion_height", safeHeight),
+		)
+		return nil
+	}
+
+	startHeight, found, err := t.metaStorage.GetFirstPromotableBlockConsolidationShadow(ctx, tag, searchStart, searchEnd)
+	if err != nil {
+		return xerrors.Errorf("failed to get first promotable consolidation shadow: %w", err)
+	}
+	if !found {
+		t.logger.Info(
+			"batch_consolidator cron found no promotable consolidation shadows",
+			zap.Uint32("tag", tag),
+			zap.Uint64("start_height", searchStart),
+			zap.Uint64("end_height", searchEnd),
+			zap.Uint64("latest_height", latest.GetHeight()),
+			zap.Uint64("safe_promotion_height", safeHeight),
+		)
+		return nil
+	}
+
+	endHeight := batchConsolidatorCronRangeEnd(startHeight, cronConfig.MaxRangeBlocks)
+	if endHeight > searchEnd {
+		endHeight = searchEnd
+	}
+	if endHeight <= startHeight {
+		t.logger.Info(
+			"batch_consolidator cron planned an empty promotion range",
+			zap.Uint32("tag", tag),
+			zap.Uint64("start_height", startHeight),
+			zap.Uint64("end_height", endHeight),
+		)
+		return nil
+	}
+
+	request := &workflow.BatchConsolidatorRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	}
+	workflowCtx := context.WithValue(ctx, "workflowId", workflowID)
+	run, err := t.batchConsolidator.Execute(workflowCtx, request)
+	if err != nil {
+		if isWorkflowAlreadyStarted(err) {
+			t.logger.Info("batch_consolidator cron skipped because auto promotion workflow was already started", zap.String("workflow_id", workflowID))
+			return nil
+		}
+		return xerrors.Errorf("failed to start batch_consolidator cron workflow: %w", err)
+	}
+	t.logger.Info(
+		"started batch_consolidator cron workflow",
+		zap.String("workflow_id", workflowID),
+		zap.String("run_id", run.GetRunID()),
+		zap.Uint32("tag", tag),
+		zap.Uint64("start_height", startHeight),
+		zap.Uint64("end_height", endHeight),
+		zap.Uint64("latest_height", latest.GetHeight()),
+		zap.Uint64("safe_promotion_height", safeHeight),
+	)
+	return nil
+}
+
+func (t *batchConsolidatorTask) autoPromoteWorkflowID() string {
+	return fmt.Sprintf("%s/%s", t.config.Workflows.BatchConsolidator.WorkflowIdentity, autoPromoteFinalizedSuffix)
+}
+
+func (t *batchConsolidatorTask) openBatchConsolidatorWorkflow(ctx context.Context) (string, bool, error) {
+	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, batchConsolidatorOpenPageSize)
+	if err != nil {
+		return "", false, xerrors.Errorf("failed to list open workflows for batch_consolidator cron: %w", err)
+	}
+	if openWorkflows == nil {
+		return "", false, nil
+	}
+	workflowIdentity := t.config.Workflows.BatchConsolidator.WorkflowIdentity
+	for _, wf := range openWorkflows.Executions {
+		workflowID := wf.GetExecution().GetWorkflowId()
+		if workflowID == workflowIdentity ||
+			strings.HasPrefix(workflowID, workflowIdentity+"/") ||
+			strings.HasPrefix(workflowID, workflowIdentity+".") {
+			return workflowID, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func batchConsolidatorCronSafeEndHeight(latestHeight uint64, safePromotionLag uint64) (uint64, uint64, bool) {
+	if latestHeight < safePromotionLag {
+		return 0, 0, false
+	}
+	safeHeight := latestHeight - safePromotionLag
+	if safeHeight == ^uint64(0) {
+		return safeHeight, safeHeight, true
+	}
+	return safeHeight + 1, safeHeight, true
+}
+
+func batchConsolidatorCronRangeEnd(startHeight uint64, maxRangeBlocks uint64) uint64 {
+	endHeight := startHeight + maxRangeBlocks
+	if endHeight < startHeight {
+		return ^uint64(0)
+	}
+	return endHeight
+}
+
+func isWorkflowAlreadyStarted(err error) bool {
+	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+	if xerrors.As(err, &alreadyStarted) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already started")
+}

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -209,19 +209,17 @@ func (t *batchConsolidatorTask) autoPromoteWorkflowID() string {
 }
 
 func (t *batchConsolidatorTask) openBatchConsolidatorWorkflow(ctx context.Context) (string, bool, error) {
-	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, batchConsolidatorOpenPageSize)
+	workflowIdentity := t.config.Workflows.BatchConsolidator.WorkflowIdentity
+	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, batchConsolidatorOpenPageSize, workflowIdentity)
 	if err != nil {
 		return "", false, xerrors.Errorf("failed to list open workflows for batch_consolidator cron: %w", err)
 	}
 	if openWorkflows == nil {
 		return "", false, nil
 	}
-	workflowIdentity := t.config.Workflows.BatchConsolidator.WorkflowIdentity
 	for _, wf := range openWorkflows.Executions {
-		workflowID := wf.GetExecution().GetWorkflowId()
-		if workflowID == workflowIdentity ||
-			strings.HasPrefix(workflowID, workflowIdentity+"/") ||
-			strings.HasPrefix(workflowID, workflowIdentity+".") {
+		if wf.GetType().GetName() == workflowIdentity {
+			workflowID := wf.GetExecution().GetWorkflowId()
 			return workflowID, true, nil
 		}
 	}

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -182,7 +182,7 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		StartHeight: startHeight,
 		EndHeight:   endHeight,
 	}
-	workflowCtx := context.WithValue(ctx, "workflowId", workflowID)
+	workflowCtx := workflow.WithWorkflowID(ctx, workflowID)
 	run, err := t.batchConsolidator.Execute(workflowCtx, request)
 	if err != nil {
 		if isWorkflowAlreadyStarted(err) {

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -27,9 +27,10 @@ import (
 
 type (
 	batchConsolidatorCronRuntime struct {
-		logger         *zap.Logger
-		openWorkflowID []string
-		executions     []batchConsolidatorCronExecution
+		logger                *zap.Logger
+		openWorkflowID        []string
+		requestedWorkflowType string
+		executions            []batchConsolidatorCronExecution
 	}
 
 	batchConsolidatorCronExecution struct {
@@ -115,13 +116,14 @@ func TestBatchConsolidatorCronNoOpsWhenNoPromotableShadowExists(t *testing.T) {
 func TestBatchConsolidatorCronSkipsWhenBatchConsolidatorWorkflowIsAlreadyOpen(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
-	runtime.openWorkflowID = []string{"workflow.batch_consolidator.solana-mainnet.1-2.promote"}
+	runtime.openWorkflowID = []string{"custom-manual-promote-workflow-id"}
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
 
 	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
 	metaStorage.EXPECT().GetFirstPromotableBlockConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
+	require.Equal(t, "workflow.batch_consolidator", runtime.requestedWorkflowType)
 	require.Empty(t, runtime.executions)
 }
 
@@ -209,11 +211,13 @@ func (r *batchConsolidatorCronRuntime) OnStop(ctx context.Context) error {
 	return nil
 }
 
-func (r *batchConsolidatorCronRuntime) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+func (r *batchConsolidatorCronRuntime) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32, workflowType string) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	r.requestedWorkflowType = workflowType
 	executions := make([]*workflowpb.WorkflowExecutionInfo, 0, len(r.openWorkflowID))
 	for _, workflowID := range r.openWorkflowID {
 		executions = append(executions, &workflowpb.WorkflowExecutionInfo{
 			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+			Type:      &commonpb.WorkflowType{Name: workflowType},
 		})
 	}
 	return &workflowservice.ListOpenWorkflowExecutionsResponse{Executions: executions}, nil

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -1,0 +1,236 @@
+package cron
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally/v4"
+	commonpb "go.temporal.io/api/common/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/coinbase/chainstorage/internal/cadence"
+	"github.com/coinbase/chainstorage/internal/config"
+	metastoragemocks "github.com/coinbase/chainstorage/internal/storage/metastorage/mocks"
+	"github.com/coinbase/chainstorage/internal/utils/fxparams"
+	"github.com/coinbase/chainstorage/internal/utils/timesource"
+	workflowpkg "github.com/coinbase/chainstorage/internal/workflow"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+type (
+	batchConsolidatorCronRuntime struct {
+		logger         *zap.Logger
+		openWorkflowID []string
+		executions     []batchConsolidatorCronExecution
+	}
+
+	batchConsolidatorCronExecution struct {
+		options client.StartWorkflowOptions
+		request any
+	}
+
+	batchConsolidatorCronRun struct {
+		id    string
+		runID string
+	}
+)
+
+var _ cadence.Runtime = (*batchConsolidatorCronRuntime)(nil)
+
+func TestBatchConsolidatorCronStartsBoundedPromotionWorkflow(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 200
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 2_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstPromotableBlockConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(1_901)).
+		Return(uint64(1_500), true, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, "workflow.batch_consolidator/auto_promote_finalized", runtime.executions[0].options.ID)
+	require.Equal(t, "default", runtime.executions[0].options.TaskQueue)
+	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
+		Tag:         tag,
+		StartHeight: 1_500,
+		EndHeight:   1_700,
+	}, runtime.executions[0].request)
+}
+
+func TestBatchConsolidatorCronCapsSearchAndWorkflowRangeAtPromotionGate(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	gateHeight := uint64(1_600)
+	cfg.AWS.Storage.Consolidation.PromotionGateHeight = &gateHeight
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 2_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstPromotableBlockConsolidationShadow(gomock.Any(), tag, uint64(1_000), gateHeight).
+		Return(uint64(1_500), true, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
+		Tag:         tag,
+		StartHeight: 1_500,
+		EndHeight:   gateHeight,
+	}, runtime.executions[0].request)
+}
+
+func TestBatchConsolidatorCronNoOpsWhenNoPromotableShadowExists(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 2_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstPromotableBlockConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(1_901)).
+		Return(uint64(0), false, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestBatchConsolidatorCronSkipsWhenBatchConsolidatorWorkflowIsAlreadyOpen(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	runtime.openWorkflowID = []string{"workflow.batch_consolidator.solana-mainnet.1-2.promote"}
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+
+	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetFirstPromotableBlockConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func newBatchConsolidatorCronTask(t *testing.T) (*batchConsolidatorTask, *batchConsolidatorCronRuntime, *metastoragemocks.MockMetaStorage, *config.Config, *gomock.Controller) {
+	t.Helper()
+	cfg, err := config.New()
+	require.NoError(t, err)
+	cfg.Chain.BlockTag.Stable = 2
+	cfg.Chain.BlockTag.Latest = 2
+	cfg.Cron.BatchConsolidator.Enabled = true
+	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
+	cfg.AWS.Storage.Consolidation.Enabled = true
+	cfg.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	safeLag := uint64(100)
+	cfg.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+
+	logger := zaptest.NewLogger(t)
+	runtime := &batchConsolidatorCronRuntime{logger: logger}
+	batchConsolidator := workflowpkg.NewBatchConsolidator(workflowpkg.BatchConsolidatorParams{
+		Params: fxparams.Params{
+			Config:  cfg,
+			Logger:  logger,
+			Metrics: tally.NoopScope,
+		},
+		Runtime: runtime,
+	})
+	ctrl := gomock.NewController(t)
+	metaStorage := metastoragemocks.NewMockMetaStorage(ctrl)
+	task, err := NewBatchConsolidator(BatchConsolidatorTaskParams{
+		Params: fxparams.Params{
+			Config:  cfg,
+			Logger:  logger,
+			Metrics: tally.NoopScope,
+		},
+		Config:            cfg,
+		Runtime:           runtime,
+		MetaStorage:       metaStorage,
+		BatchConsolidator: batchConsolidator,
+	})
+	require.NoError(t, err)
+	return task.(*batchConsolidatorTask), runtime, metaStorage, cfg, ctrl
+}
+
+func (r *batchConsolidatorCronRuntime) RegisterWorkflow(w any, options workflow.RegisterOptions) {}
+
+func (r *batchConsolidatorCronRuntime) RegisterActivity(a any, options activity.RegisterOptions) {}
+
+func (r *batchConsolidatorCronRuntime) ExecuteWorkflow(ctx context.Context, options client.StartWorkflowOptions, workflow any, request any) (client.WorkflowRun, error) {
+	r.executions = append(r.executions, batchConsolidatorCronExecution{
+		options: options,
+		request: request,
+	})
+	return batchConsolidatorCronRun{id: options.ID, runID: "test-run-id"}, nil
+}
+
+func (r *batchConsolidatorCronRuntime) ExecuteActivity(ctx workflow.Context, activity any, request any, response any) error {
+	panic("ExecuteActivity is not used by batch_consolidator cron tests")
+}
+
+func (r *batchConsolidatorCronRuntime) GetLogger(ctx workflow.Context) *zap.Logger {
+	return r.logger
+}
+
+func (r *batchConsolidatorCronRuntime) GetMetricsHandler(ctx workflow.Context) client.MetricsHandler {
+	return client.MetricsNopHandler
+}
+
+func (r *batchConsolidatorCronRuntime) GetActivityLogger(ctx context.Context) *zap.Logger {
+	return r.logger
+}
+
+func (r *batchConsolidatorCronRuntime) GetTimeSource(ctx workflow.Context) timesource.TimeSource {
+	return timesource.NewRealTimeSource()
+}
+
+func (r *batchConsolidatorCronRuntime) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string) error {
+	return nil
+}
+
+func (r *batchConsolidatorCronRuntime) OnStart(ctx context.Context) error {
+	return nil
+}
+
+func (r *batchConsolidatorCronRuntime) OnStop(ctx context.Context) error {
+	return nil
+}
+
+func (r *batchConsolidatorCronRuntime) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	executions := make([]*workflowpb.WorkflowExecutionInfo, 0, len(r.openWorkflowID))
+	for _, workflowID := range r.openWorkflowID {
+		executions = append(executions, &workflowpb.WorkflowExecutionInfo{
+			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+		})
+	}
+	return &workflowservice.ListOpenWorkflowExecutionsResponse{Executions: executions}, nil
+}
+
+func (r batchConsolidatorCronRun) GetID() string {
+	return r.id
+}
+
+func (r batchConsolidatorCronRun) GetRunID() string {
+	return r.runID
+}
+
+func (r batchConsolidatorCronRun) Get(ctx context.Context, valuePtr any) error {
+	return nil
+}
+
+func (r batchConsolidatorCronRun) GetWithOptions(ctx context.Context, valuePtr any, options client.WorkflowRunGetOptions) error {
+	return nil
+}

--- a/internal/cron/module.go
+++ b/internal/cron/module.go
@@ -25,4 +25,8 @@ var Module = fx.Options(
 		Group:  "task",
 		Target: NewWorkflowStatus,
 	}),
+	fx.Provide(fx.Annotated{
+		Group:  "task",
+		Target: NewBatchConsolidator,
+	}),
 )

--- a/internal/cron/workflow_status.go
+++ b/internal/cron/workflow_status.go
@@ -155,7 +155,7 @@ func (t *workflowStatusTask) Run(ctx context.Context) error {
 }
 
 func (t *workflowStatusTask) markOpenWorkflows(ctx context.Context, expectedWorkflowMap map[string]bool) error {
-	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, maxPageSize)
+	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, maxPageSize, "")
 	if err != nil {
 		return xerrors.Errorf("failed to get open workflows: %w", err)
 	}

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -293,6 +293,10 @@ func (a *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 	return nil, xerrors.New("GetBlockConsolidationShadowStats not implemented for DynamoDB")
 }
 
+func (a *blockStorageImpl) GetFirstPromotableBlockConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error) {
+	return 0, false, xerrors.New("GetFirstPromotableBlockConsolidationShadow not implemented for DynamoDB")
+}
+
 func (a *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context, placements []*internal.ConsolidationShadowPlacement) error {
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for DynamoDB")
 }

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -266,6 +266,10 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 	return nil, xerrors.New("GetBlockConsolidationShadowStats not implemented for Firestore")
 }
 
+func (b *blockStorageImpl) GetFirstPromotableBlockConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error) {
+	return 0, false, xerrors.New("GetFirstPromotableBlockConsolidationShadow not implemented for Firestore")
+}
+
 func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context, placements []*internal.ConsolidationShadowPlacement) error {
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for Firestore")
 }

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -28,6 +28,7 @@ type (
 		GetBlocksConsolidationShadow(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error)
 		GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*BlockMetadataRecord, error)
 		GetBlockConsolidationShadowStats(ctx context.Context, tag uint32, startHeight, endHeight uint64) (*ConsolidationShadowStats, error)
+		GetFirstPromotableBlockConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error)
 		PersistBlockConsolidationShadows(ctx context.Context, placements []*ConsolidationShadowPlacement) error
 		PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*ConsolidationPromotionResult, error)
 	}

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -294,6 +294,22 @@ func (mr *MockMetaStorageMockRecorder) GetFirstEventIdByBlockHeight(arg0, arg1, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstEventIdByBlockHeight", reflect.TypeOf((*MockMetaStorage)(nil).GetFirstEventIdByBlockHeight), arg0, arg1, arg2)
 }
 
+// GetFirstPromotableBlockConsolidationShadow mocks base method.
+func (m *MockMetaStorage) GetFirstPromotableBlockConsolidationShadow(arg0 context.Context, arg1 uint32, arg2, arg3 uint64) (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFirstPromotableBlockConsolidationShadow", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetFirstPromotableBlockConsolidationShadow indicates an expected call of GetFirstPromotableBlockConsolidationShadow.
+func (mr *MockMetaStorageMockRecorder) GetFirstPromotableBlockConsolidationShadow(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstPromotableBlockConsolidationShadow", reflect.TypeOf((*MockMetaStorage)(nil).GetFirstPromotableBlockConsolidationShadow), arg0, arg1, arg2, arg3)
+}
+
 // GetLatestBlock mocks base method.
 func (m *MockMetaStorage) GetLatestBlock(arg0 context.Context, arg1 uint32) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -707,6 +723,22 @@ func (m *MockBlockStorage) GetBlocksMissingConsolidationShadow(arg0 context.Cont
 func (mr *MockBlockStorageMockRecorder) GetBlocksMissingConsolidationShadow(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksMissingConsolidationShadow", reflect.TypeOf((*MockBlockStorage)(nil).GetBlocksMissingConsolidationShadow), arg0, arg1, arg2, arg3, arg4)
+}
+
+// GetFirstPromotableBlockConsolidationShadow mocks base method.
+func (m *MockBlockStorage) GetFirstPromotableBlockConsolidationShadow(arg0 context.Context, arg1 uint32, arg2, arg3 uint64) (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFirstPromotableBlockConsolidationShadow", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetFirstPromotableBlockConsolidationShadow indicates an expected call of GetFirstPromotableBlockConsolidationShadow.
+func (mr *MockBlockStorageMockRecorder) GetFirstPromotableBlockConsolidationShadow(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstPromotableBlockConsolidationShadow", reflect.TypeOf((*MockBlockStorage)(nil).GetFirstPromotableBlockConsolidationShadow), arg0, arg1, arg2, arg3)
 }
 
 // GetLatestBlock mocks base method.

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -766,6 +766,53 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 	}, nil
 }
 
+func (b *blockStorageImpl) GetFirstPromotableBlockConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error) {
+	if endHeight <= startHeight {
+		return 0, false, nil
+	}
+	const query = `
+		SELECT cb.height
+		FROM canonical_blocks cb
+		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+		JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+			AND shadow.tag = bm.tag
+			AND shadow.height = bm.height
+			AND shadow.hash = bm.hash
+			AND shadow.legacy_object_key_main = bm.object_key_main
+		WHERE cb.tag = $1
+			AND cb.height >= $2
+			AND cb.height < $3
+			AND bm.skipped = false
+			AND bm.byte_length IS NULL
+			AND bm.object_key_main IS NOT NULL
+			AND bm.object_key_main <> ''
+			AND shadow.validated_at IS NOT NULL
+			AND shadow.consolidated_object_key_main IS NOT NULL
+			AND shadow.consolidated_object_key_main <> ''
+			AND shadow.object_format = $4
+			AND shadow.byte_offset >= 0
+			AND shadow.byte_length > 0
+			AND shadow.uncompressed_length IS NOT NULL
+			AND shadow.uncompressed_length > 0
+		ORDER BY cb.height ASC
+		LIMIT 1`
+	var height uint64
+	if err := b.db.QueryRowContext(
+		ctx,
+		query,
+		tag,
+		startHeight,
+		endHeight,
+		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
+	).Scan(&height); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, false, nil
+		}
+		return 0, false, xerrors.Errorf("failed to get first promotable consolidation shadow: %w", err)
+	}
+	return height, true, nil
+}
+
 func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context, placements []*internal.ConsolidationShadowPlacement) error {
 	if len(placements) == 0 {
 		return nil

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -611,6 +611,56 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsPromotesVali
 	s.equalProto(blocks[2], primary)
 }
 
+func (s *blockStorageTestSuite) TestGetFirstPromotableBlockConsolidationShadowFiltersCandidates() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 6, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	s.insertInvalidConsolidationShadow(
+		ctx,
+		blocks[0],
+		"consolidated/invalid.cscb.zstd",
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		10,
+		0,
+		20,
+	)
+	s.insertConsolidationShadow(ctx, blocks[1], "consolidated/skipped.cscb.zstd", 10, 20, 20, true, "")
+	_, err = s.db.ExecContext(
+		ctx,
+		`UPDATE block_metadata SET skipped = true WHERE tag = $1 AND height = $2 AND hash = $3`,
+		blocks[1].GetTag(),
+		blocks[1].GetHeight(),
+		blocks[1].GetHash(),
+	)
+	require.NoError(err)
+	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/unvalidated.cscb.zstd", 10, 20, 20, false, "")
+	s.insertConsolidationShadow(ctx, blocks[3], "consolidated/promoted.cscb.zstd", 10, 20, 20, true, "")
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, blocks[3].GetHeight(), blocks[3].GetHeight()+1, 10)
+	require.NoError(err)
+	require.Equal(uint64(1), result.Blocks)
+	s.insertConsolidationShadow(ctx, blocks[4], "consolidated/first-promotable.cscb.zstd", 10, 20, 20, true, "")
+
+	height, found, err := s.accessor.GetFirstPromotableBlockConsolidationShadow(ctx, tag, startHeight, startHeight+uint64(len(blocks)))
+	require.NoError(err)
+	require.True(found)
+	require.Equal(blocks[4].GetHeight(), height)
+
+	height, found, err = s.accessor.GetFirstPromotableBlockConsolidationShadow(ctx, tag, startHeight, blocks[4].GetHeight())
+	require.NoError(err)
+	require.False(found)
+	require.Zero(height)
+
+	height, found, err = s.accessor.GetFirstPromotableBlockConsolidationShadow(ctx, tag, blocks[4].GetHeight()+1, startHeight+uint64(len(blocks)))
+	require.NoError(err)
+	require.False(found)
+	require.Zero(height)
+}
+
 func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsMissingShadowNoOps() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -321,7 +321,10 @@ func (a *BatchConsolidator) planPromoteFinalized(ctx context.Context, tag uint32
 
 	consolidation := a.config.AWS.Storage.Consolidation
 	safeLag := *consolidation.SafePromotionLag
-	gateHeight := *consolidation.PromotionGateHeight
+	gateHeight := endHeight
+	if consolidation.PromotionGateHeight != nil {
+		gateHeight = *consolidation.PromotionGateHeight
+	}
 	safeEnd, safeHeight, ok := promotionSafeEndHeight(latest.GetHeight(), safeLag)
 	if !ok {
 		return &BatchConsolidatorPlanResponse{
@@ -408,9 +411,6 @@ func (a *BatchConsolidator) validatePromoteFinalizedMode() error {
 	consolidation := a.config.AWS.Storage.Consolidation
 	if consolidation.Mode != config.ConsolidationModePromoteFinalized {
 		return xerrors.Errorf("batch consolidator requires consolidation mode %q, got %q", config.ConsolidationModePromoteFinalized, consolidation.Mode)
-	}
-	if consolidation.PromotionGateHeight == nil {
-		return xerrors.New("batch consolidator promote_finalized requires promotion_gate_height")
 	}
 	if consolidation.SafePromotionLag == nil {
 		return xerrors.New("batch consolidator promote_finalized requires safe_promotion_lag")

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -440,6 +440,35 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteCapsAtGateAndSaf
 	}, response)
 }
 
+func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteAllowsMissingPromotionGate() {
+	require := testutil.Require(s.T())
+	safeLag := uint64(10)
+	s.batchConsolidator.config.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.batchConsolidator.config.AWS.Storage.Consolidation.PromotionGateHeight = nil
+	s.batchConsolidator.config.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+	request := &BatchConsolidatorRequest{
+		Tag:         2,
+		StartHeight: 1_000,
+		EndHeight:   1_200,
+		MaxBlocks:   25,
+	}
+	s.metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), request.Tag).
+		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_080}, nil)
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, uint64(1_071), request.MaxBlocks).
+		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:        request.StartHeight,
+		EndHeight:          1_071,
+		ScannedBlocks:      12,
+		ConsolidatedBlocks: 12,
+	}, response)
+}
+
 func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPlanCapsAtGateAndSafeHeight() {
 	require := testutil.Require(s.T())
 	gateHeight := uint64(1_050)
@@ -464,6 +493,32 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPlanCapsAtGateAndSafeHe
 		LatestHeight:        1_080,
 		SafePromotionHeight: 1_070,
 		PromotionGateHeight: gateHeight,
+	}, response)
+}
+
+func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPlanAllowsMissingPromotionGate() {
+	require := testutil.Require(s.T())
+	safeLag := uint64(10)
+	s.batchConsolidator.config.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
+	s.batchConsolidator.config.AWS.Storage.Consolidation.PromotionGateHeight = nil
+	s.batchConsolidator.config.AWS.Storage.Consolidation.SafePromotionLag = &safeLag
+	request := &BatchConsolidatorPlanRequest{
+		Tag:         2,
+		StartHeight: 1_000,
+		EndHeight:   1_200,
+	}
+	s.metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), request.Tag).
+		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_080}, nil)
+
+	response, err := s.batchConsolidator.GetPromotionPlan(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorPlanResponse{
+		StartHeight:         request.StartHeight,
+		EndHeight:           1_071,
+		LatestHeight:        1_080,
+		SafePromotionHeight: 1_070,
+		PromotionGateHeight: request.EndHeight,
 	}, response)
 }
 

--- a/internal/workflow/backfiller.go
+++ b/internal/workflow/backfiller.go
@@ -79,8 +79,8 @@ func NewBackfiller(params BackfillerParams) *Backfiller {
 
 func (w *Backfiller) Execute(ctx context.Context, request *BackfillerRequest) (client.WorkflowRun, error) {
 	workflowId := w.name
-	if v, ok := ctx.Value("workflowId").(string); ok && v != "" {
-		workflowId = v
+	if override, ok := workflowIDFromContext(ctx); ok {
+		workflowId = override
 	}
 	return w.startWorkflow(ctx, workflowId, request)
 }

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -66,8 +66,8 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 
 func (w *BatchConsolidator) Execute(ctx context.Context, request *BatchConsolidatorRequest) (client.WorkflowRun, error) {
 	workflowID := w.name
-	if v, ok := ctx.Value("workflowId").(string); ok && v != "" {
-		workflowID = v
+	if override, ok := workflowIDFromContext(ctx); ok {
+		workflowID = override
 	}
 	return w.startWorkflow(ctx, workflowID, request)
 }

--- a/internal/workflow/context.go
+++ b/internal/workflow/context.go
@@ -1,0 +1,18 @@
+package workflow
+
+import "context"
+
+type workflowIDContextKey struct{}
+
+// WithWorkflowID overrides the default Temporal workflow ID for manual/admin starts.
+func WithWorkflowID(ctx context.Context, workflowID string) context.Context {
+	if workflowID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, workflowIDContextKey{}, workflowID)
+}
+
+func workflowIDFromContext(ctx context.Context) (string, bool) {
+	workflowID, ok := ctx.Value(workflowIDContextKey{}).(string)
+	return workflowID, ok && workflowID != ""
+}


### PR DESCRIPTION
## Summary
- add an opt-in cron.batch_consolidator task that starts bounded promote_finalized batch-consolidator workflows
- select the next promotion start from Postgres metadata using only canonical legacy-primary rows with validated CSCB shadow placement
- keep safe_promotion_lag required, make promotion_gate_height an optional extra cap, and skip scheduling when any batch-consolidator workflow is already open

## Validation
- TEST_TYPE=unit go test ./internal/config ./internal/cadence ./internal/cron ./internal/workflow ./internal/workflow/activity ./internal/storage/metastorage/postgres ./cmd/cron ./cmd/admin
- TEST_TYPE=unit go test ./...
- PATH="/Users/boyangxu/go/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/boyangxu/.local/bin:/Users/boyangxu/.codex/tmp/arg0/codex-arg0n1QBYS:/Users/boyangxu/.duckdb/cli/latest:/Users/boyangxu/.pyenv/plugins/pyenv-virtualenv/shims:/Users/boyangxu/.pyenv/shims:/Users/boyangxu/.pyenv/bin:/opt/anaconda3/condabin:/Users/boyangxu/.temporalio/bin:/opt/homebrew/opt/fzf/bin:/Applications/Codex.app/Contents/Resources" make lint
- CHAINSTORAGE_AWS_POSTGRES_PASSWORD=worker_password TEST_TYPE=integration go test ./internal/storage/metastorage/postgres -run 'TestIntegrationBlockStorageTestSuite/TestGetFirstPromotableBlockConsolidationShadowFiltersCandidates' -count=1 -v

Linear: https://linear.app/cipherowl/issue/INF-1004/cscb-23-automate-promote-finalized-scheduling

Recreated from #142 to retrigger the approval workflow.