### PR TITLE
fix(INF-1004): wire cron batch dependencies

### DIFF
--- a/cmd/cron/main.go
+++ b/cmd/cron/main.go
@@ -17,10 +17,12 @@ import (
 	"github.com/coinbase/chainstorage/internal/gateway"
 	"github.com/coinbase/chainstorage/internal/s3"
 	"github.com/coinbase/chainstorage/internal/storage"
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader"
 	"github.com/coinbase/chainstorage/internal/tally"
 	"github.com/coinbase/chainstorage/internal/tracer"
 	"github.com/coinbase/chainstorage/internal/utils/consts"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
+	"github.com/coinbase/chainstorage/internal/workflow"
 	"github.com/coinbase/chainstorage/sdk"
 	"github.com/coinbase/chainstorage/sdk/services"
 )
@@ -32,8 +34,28 @@ func main() {
 
 func startManager(opts ...fx.Option) services.SystemManager {
 	manager := services.NewManager()
-	logger := manager.Logger()
 	ctx := manager.Context()
+
+	opts = cronAppOptions(manager, opts...)
+	app := fx.New(opts...)
+
+	logger := manager.Logger()
+	if err := app.Start(ctx); err != nil {
+		logger.Fatal("failed to start app", zap.Error(err))
+	}
+	manager.AddPreShutdownHook(func() {
+		logger.Info("shutting down cron")
+		if err := app.Stop(ctx); err != nil {
+			logger.Error("failed to stop app", zap.Error(err))
+		}
+	})
+
+	logger.Info("started cron")
+	return manager
+}
+
+func cronAppOptions(manager services.SystemManager, opts ...fx.Option) []fx.Option {
+	logger := manager.Logger()
 
 	opts = append(
 		opts,
@@ -54,24 +76,14 @@ func startManager(opts ...fx.Option) services.SystemManager {
 		parser.Module,
 		s3.Module,
 		storage.Module,
+		downloader.Module,
 		tally.Module,
 		fx.NopLogger,
+		workflow.Module,
 		fx.Provide(func() services.SystemManager { return manager }),
 		fx.Provide(func() *zap.Logger { return logger }),
 		fx.Invoke(cron.RegisterRunner),
 	)
-	app := fx.New(opts...)
 
-	if err := app.Start(ctx); err != nil {
-		logger.Fatal("failed to start app", zap.Error(err))
-	}
-	manager.AddPreShutdownHook(func() {
-		logger.Info("shutting down cron")
-		if err := app.Stop(ctx); err != nil {
-			logger.Error("failed to stop app", zap.Error(err))
-		}
-	})
-
-	logger.Info("started cron")
-	return manager
+	return opts
 }

--- a/cmd/cron/main_test.go
+++ b/cmd/cron/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/testsuite"
+	"go.uber.org/fx"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/testapp"
+	"github.com/coinbase/chainstorage/sdk/services"
 )
 
 type (
@@ -19,6 +22,13 @@ type (
 
 func (s CronTestSuite) T() *testing.T {
 	return s.t
+}
+
+func TestCronAppDependencyGraph(t *testing.T) {
+	manager := services.NewManager()
+	defer manager.Shutdown()
+
+	require.NoError(t, fx.ValidateApp(cronAppOptions(manager)...))
 }
 
 func TestIntegrationCron(t *testing.T) {


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1004/cscb-23-automate-promote-finalized-scheduling

## Summary
- add the missing downloader and workflow modules to the cron binary Fx graph
- share the cron app option builder between runtime startup and tests
- add an Fx graph validation test so missing cron task dependencies fail before deployment

## Root cause
The Solana prod cron deployment crashed during startup because `/app/cron` constructed all cron task providers, including disabled canaries and the batch consolidator. The cron binary included `sdk.Module` but not `downloader.Module`, so `NewStreamingCanary` could not build `sdk.Client`. After that was fixed locally, graph validation also exposed the missing `workflow.Module` needed by `NewBatchConsolidator`.

## Verification
- `PATH="$PATH:$(go env GOPATH)/bin" make test TARGET=./cmd/cron`
- `go test ./internal/cron ./internal/workflow ./internal/workflow/activity`
- `go build -o /tmp/chainstorage-cron-fix-build ./cmd/cron`
