### PR TITLE
fix(INF-1010): cap worker activity concurrency

### DIFF
--- a/internal/cadence/runtime.go
+++ b/internal/cadence/runtime.go
@@ -127,12 +127,7 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 		workers[i] = worker.New(
 			workflowClient,
 			workerConfig.TaskList,
-			worker.Options{
-				// Enable this option to allow worker to process sessions. Defaults to false.
-				EnableSessionWorker: true,
-				// If set defines maximum amount of time that workflow task will be allowed to run. Defaults to 1 sec.
-				DeadlockDetectionTimeout: 2 * time.Second,
-			},
+			newWorkerOptions(workerConfig),
 		)
 	}
 
@@ -146,6 +141,20 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 
 	return runtime, nil
 
+}
+
+func newWorkerOptions(workerConfig config.WorkerConfig) worker.Options {
+	options := worker.Options{
+		// Enable this option to allow worker to process sessions. Defaults to false.
+		EnableSessionWorker: true,
+		// If set defines maximum amount of time that workflow task will be allowed to run. Defaults to 1 sec.
+		DeadlockDetectionTimeout: 2 * time.Second,
+	}
+	if workerConfig.MaxConcurrentActivityExecutionSize > 0 {
+		options.MaxConcurrentActivityExecutionSize = workerConfig.MaxConcurrentActivityExecutionSize
+	}
+
+	return options
 }
 
 func (r *runtimeImpl) ListOpenWorkflows(ctx context.Context, namespace string, maxPageSize int32, workflowType string) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {

--- a/internal/cadence/runtime_test.go
+++ b/internal/cadence/runtime_test.go
@@ -3,12 +3,37 @@ package cadence
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 )
+
+func TestNewWorkerOptionsPreservesDefaultActivityConcurrency(t *testing.T) {
+	require := require.New(t)
+
+	options := newWorkerOptions(config.WorkerConfig{TaskList: "default"})
+
+	require.True(options.EnableSessionWorker)
+	require.Equal(2*time.Second, options.DeadlockDetectionTimeout)
+	require.Zero(options.MaxConcurrentActivityExecutionSize)
+}
+
+func TestNewWorkerOptionsAppliesActivityConcurrencyLimit(t *testing.T) {
+	require := require.New(t)
+
+	options := newWorkerOptions(config.WorkerConfig{
+		TaskList:                           "batch_consolidator",
+		MaxConcurrentActivityExecutionSize: 1,
+	})
+
+	require.True(options.EnableSessionWorker)
+	require.Equal(2*time.Second, options.DeadlockDetectionTimeout)
+	require.Equal(1, options.MaxConcurrentActivityExecutionSize)
+}
 
 func TestListOpenWorkflowExecutionsPaginatesAndAppliesTypeFilter(t *testing.T) {
 	require := require.New(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,7 +206,8 @@ type (
 	}
 
 	WorkerConfig struct {
-		TaskList string `mapstructure:"task_list"`
+		TaskList                           string `mapstructure:"task_list"`
+		MaxConcurrentActivityExecutionSize int    `mapstructure:"max_concurrent_activity_execution_size"`
 	}
 
 	WorkflowConfig struct {

--- a/internal/config/worker_config_test.go
+++ b/internal/config/worker_config_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerConfigDecodesActivityConcurrencyLimit(t *testing.T) {
+	require := require.New(t)
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(strings.NewReader(`
+workflows:
+  workers:
+    - task_list: batch_consolidator
+      max_concurrent_activity_execution_size: 1
+`))
+	require.NoError(err)
+
+	var cfg Config
+	err = v.Unmarshal(&cfg)
+	require.NoError(err)
+	require.Len(cfg.Workflows.Workers, 1)
+	require.Equal("batch_consolidator", cfg.Workflows.Workers[0].TaskList)
+	require.Equal(1, cfg.Workflows.Workers[0].MaxConcurrentActivityExecutionSize)
+}


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1010/cscb-backfill-safety

## Summary
- add optional per-worker `max_concurrent_activity_execution_size` config
- apply the limit to Temporal worker options while preserving session worker and deadlock timeout defaults
- cover default and configured worker option behavior in unit tests

## Why
During Solana CSCB backfill, two active workflows could land multiple large consolidation activities on one 3Gi batch-worker pod and trigger OOMKilled. This config lets us cap heavy batch-worker activity concurrency per pod so horizontal pod/workflow parallelism is bounded and predictable.

## Validation
- `go test ./internal/cadence`
- `git diff --check`

## Follow-up
After this is merged and deployed, monorepo should set `max_concurrent_activity_execution_size: 1` for the Solana batch-worker task list before increasing concurrent CSCB backfill workflows.