### PR TITLE
perf(INF-1010): parallelize CSCB historical backfill

### DIFF
--- a/internal/storage/blobstorage/s3/blob_storage.go
+++ b/internal/storage/blobstorage/s3/blob_storage.go
@@ -280,19 +280,25 @@ func (s *blobStorageImpl) UploadConsolidated(ctx context.Context, blocks []inter
 		zap.Duration("duration", headExistingDuration),
 	)
 	var uploadDuration time.Duration
+	var uploadMD5Duration time.Duration
+	var uploadPutDuration time.Duration
 	var headUploadedDuration time.Duration
 	if !found {
 		uploadStart := time.Now()
-		uploaded, err := s.uploadConsolidatedObject(ctx, object, consolidation.Codec)
+		uploaded, md5Duration, putDuration, err := s.uploadConsolidatedObject(ctx, object, consolidation.Codec)
 		if err != nil {
 			return "", nil, err
 		}
 		uploadDuration = time.Since(uploadStart)
+		uploadMD5Duration = md5Duration
+		uploadPutDuration = putDuration
 		s.logger.Info(
 			"put CSCB object",
 			zap.String("object_key", object.Key),
 			zap.Bool("uploaded", uploaded),
 			zap.Uint64("bytes", object.Length),
+			zap.Duration("md5_duration", uploadMD5Duration),
+			zap.Duration("s3_put_duration", uploadPutDuration),
 			zap.Duration("duration", uploadDuration),
 		)
 		if uploaded {
@@ -319,27 +325,31 @@ func (s *blobStorageImpl) UploadConsolidated(ctx context.Context, blocks []inter
 		zap.Uint64("payload_uncompressed_bytes", object.PayloadUncompressedLength),
 		zap.Duration("encode_duration", encodeDuration),
 		zap.Duration("head_existing_duration", headExistingDuration),
-		zap.Duration("put_duration", uploadDuration),
+		zap.Duration("md5_duration", uploadMD5Duration),
+		zap.Duration("s3_put_duration", uploadPutDuration),
+		zap.Duration("upload_duration", uploadDuration),
 		zap.Duration("head_uploaded_duration", headUploadedDuration),
 		zap.Duration("total_duration", time.Since(totalStart)),
 	)
 	return object.Key, object.Placements, nil
 }
 
-func (s *blobStorageImpl) uploadConsolidatedObject(ctx context.Context, object *cscb.Object, compression api.Compression) (bool, error) {
+func (s *blobStorageImpl) uploadConsolidatedObject(ctx context.Context, object *cscb.Object, compression api.Compression) (bool, time.Duration, time.Duration, error) {
 	if object.Length > maxSinglePutObjectSize {
-		return false, xerrors.Errorf("CSCB object length %d exceeds v1 single-put limit %d", object.Length, maxSinglePutObjectSize)
+		return false, 0, 0, xerrors.Errorf("CSCB object length %d exceeds v1 single-put limit %d", object.Length, maxSinglePutObjectSize)
 	}
 	reader, err := object.Open()
 	if err != nil {
-		return false, err
+		return false, 0, 0, err
 	}
 	defer func() { _ = reader.Close() }()
 
 	internal.RecordConsolidatedUploadProgress(ctx, "s3_md5_started", object.Key, object.Length)
+	md5Start := time.Now()
 	contentMD5, err := computeContentMD5(ctx, object)
+	md5Duration := time.Since(md5Start)
 	if err != nil {
-		return false, err
+		return false, md5Duration, 0, err
 	}
 	internal.RecordConsolidatedUploadProgress(ctx, "s3_md5_finished", object.Key, object.Length)
 	metadata := map[string]string{
@@ -350,6 +360,7 @@ func (s *blobStorageImpl) uploadConsolidatedObject(ctx context.Context, object *
 		cscbMetadataUncompressedLength: fmt.Sprintf("%d", object.PayloadUncompressedLength),
 	}
 	internal.RecordConsolidatedUploadProgress(ctx, "s3_put_started", object.Key, object.Length)
+	putStart := time.Now()
 	if _, err := s.client.PutObject(ctx, &awss3.PutObjectInput{
 		Bucket:        aws.String(s.bucket),
 		Key:           aws.String(object.Key),
@@ -364,19 +375,21 @@ func (s *blobStorageImpl) uploadConsolidatedObject(ctx context.Context, object *
 		// that switch large uploads to aws-chunked request bodies.
 		options.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	}); err != nil {
+		putDuration := time.Since(putStart)
 		if isObjectPreconditionFailed(err) {
 			found, validateErr := s.validateExistingConsolidatedObject(ctx, object)
 			if validateErr != nil {
-				return false, validateErr
+				return false, md5Duration, putDuration, validateErr
 			}
 			if found {
-				return false, nil
+				return false, md5Duration, putDuration, nil
 			}
 		}
-		return false, xerrors.Errorf("failed to upload CSCB object to s3: %w", err)
+		return false, md5Duration, putDuration, xerrors.Errorf("failed to upload CSCB object to s3: %w", err)
 	}
+	putDuration := time.Since(putStart)
 	internal.RecordConsolidatedUploadProgress(ctx, "s3_put_finished", object.Key, object.Length)
-	return true, nil
+	return true, md5Duration, putDuration, nil
 }
 
 func computeContentMD5(ctx context.Context, object *cscb.Object) (string, error) {

--- a/internal/storage/blobstorage/s3/blob_storage.go
+++ b/internal/storage/blobstorage/s3/blob_storage.go
@@ -229,8 +229,10 @@ func (s *blobStorageImpl) Upload(ctx context.Context, block *api.Block, compress
 func (s *blobStorageImpl) UploadConsolidated(ctx context.Context, blocks []internal.ConsolidatedBlockPayload) (string, []internal.BlockPlacement, error) {
 	defer s.logDuration("upload_consolidated", time.Now())
 
+	totalStart := time.Now()
 	consolidation := s.config.AWS.Storage.Consolidation
 	internal.RecordConsolidatedUploadProgress(ctx, "s3_encode_config_loaded", len(blocks))
+	encodeStart := time.Now()
 	object, err := cscb.Encode(ctx, cscb.EncodeConfig{
 		Blockchain:                s.config.Chain.Blockchain,
 		Network:                   s.config.Chain.Network,
@@ -253,24 +255,74 @@ func (s *blobStorageImpl) UploadConsolidated(ctx context.Context, blocks []inter
 		return "", nil, err
 	}
 	defer func() { _ = object.Close() }()
+	encodeDuration := time.Since(encodeStart)
 	internal.RecordConsolidatedUploadProgress(ctx, "s3_object_encoded", object.Key, object.Length)
+	s.logger.Info(
+		"encoded CSCB object",
+		zap.String("object_key", object.Key),
+		zap.Int("blocks", len(blocks)),
+		zap.Uint64("compressed_bytes", object.Length),
+		zap.Uint64("payload_compressed_bytes", object.PayloadCompressedLength),
+		zap.Uint64("payload_uncompressed_bytes", object.PayloadUncompressedLength),
+		zap.Duration("duration", encodeDuration),
+	)
 
+	headExistingStart := time.Now()
 	found, err := s.validateExistingConsolidatedObject(ctx, object)
 	if err != nil {
 		return "", nil, err
 	}
+	headExistingDuration := time.Since(headExistingStart)
+	s.logger.Info(
+		"checked existing CSCB object",
+		zap.String("object_key", object.Key),
+		zap.Bool("found", found),
+		zap.Duration("duration", headExistingDuration),
+	)
+	var uploadDuration time.Duration
+	var headUploadedDuration time.Duration
 	if !found {
+		uploadStart := time.Now()
 		uploaded, err := s.uploadConsolidatedObject(ctx, object, consolidation.Codec)
 		if err != nil {
 			return "", nil, err
 		}
+		uploadDuration = time.Since(uploadStart)
+		s.logger.Info(
+			"put CSCB object",
+			zap.String("object_key", object.Key),
+			zap.Bool("uploaded", uploaded),
+			zap.Uint64("bytes", object.Length),
+			zap.Duration("duration", uploadDuration),
+		)
 		if uploaded {
+			headUploadedStart := time.Now()
 			if err := s.validateUploadedConsolidatedObject(ctx, object); err != nil {
 				return "", nil, err
 			}
+			headUploadedDuration = time.Since(headUploadedStart)
+			s.logger.Info(
+				"validated uploaded CSCB object",
+				zap.String("object_key", object.Key),
+				zap.Uint64("bytes", object.Length),
+				zap.Duration("duration", headUploadedDuration),
+			)
 			s.blobStorageMetrics.blobUploadedSize.Record(time.Duration(object.Length) * time.Millisecond)
 		}
 	}
+	s.logger.Info(
+		"finished consolidated upload",
+		zap.String("object_key", object.Key),
+		zap.Bool("existing_object", found),
+		zap.Int("blocks", len(blocks)),
+		zap.Uint64("compressed_bytes", object.Length),
+		zap.Uint64("payload_uncompressed_bytes", object.PayloadUncompressedLength),
+		zap.Duration("encode_duration", encodeDuration),
+		zap.Duration("head_existing_duration", headExistingDuration),
+		zap.Duration("put_duration", uploadDuration),
+		zap.Duration("head_uploaded_duration", headUploadedDuration),
+		zap.Duration("total_duration", time.Since(totalStart)),
+	)
 	return object.Key, object.Placements, nil
 }
 

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	sdkactivity "go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"
@@ -214,10 +215,14 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.started")
 
 	logger := a.getLogger(ctx).With(zap.Reflect("request", request))
+	totalStart := time.Now()
+	scanStart := time.Now()
 	records, err := a.metaStorage.GetBlocksMissingConsolidationShadow(ctx, request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to scan missing consolidation shadows: %w", err)
 	}
+	scanDuration := time.Since(scanStart)
+	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
 		return &BatchConsolidatorResponse{
 			StartHeight: request.StartHeight,
@@ -225,29 +230,39 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 		}, nil
 	}
 
+	buildStart := time.Now()
 	payloads, recordsByID, cleanup, err := a.buildPayloads(ctx, records)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup()
+	buildDuration := time.Since(buildStart)
+	rawBytes := consolidatedPayloadBytes(payloads)
+	logger.Info("built consolidated payloads", zap.Int("blocks", len(payloads)), zap.Uint64("raw_bytes", rawBytes), zap.Duration("duration", buildDuration))
 	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.payloads_built", len(records))
 
 	uploadCtx := blobstorage.WithConsolidatedUploadProgress(ctx, func(stage string, details ...any) {
 		heartbeatDetails := append([]any{"batch_consolidator." + stage}, details...)
 		sdkactivity.RecordHeartbeat(ctx, heartbeatDetails...)
 	})
+	uploadStart := time.Now()
 	objectKey, placements, err := a.blobStorage.UploadConsolidated(uploadCtx, payloads)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to upload consolidated block object: %w", err)
 	}
+	uploadDuration := time.Since(uploadStart)
+	logger.Info("uploaded consolidated block object", zap.String("object_key", objectKey), zap.Int("placements", len(placements)), zap.Duration("duration", uploadDuration))
 	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.object_uploaded", objectKey, len(placements))
 	shadowPlacements, err := makeShadowPlacements(recordsByID, objectKey, placements)
 	if err != nil {
 		return nil, err
 	}
+	persistStart := time.Now()
 	if err := a.metaStorage.PersistBlockConsolidationShadows(ctx, shadowPlacements); err != nil {
 		return nil, xerrors.Errorf("failed to persist consolidation shadow placements: %w", err)
 	}
+	persistDuration := time.Since(persistStart)
+	logger.Info("persisted consolidation shadow placements", zap.Int("placements", len(shadowPlacements)), zap.Duration("duration", persistDuration))
 	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.shadows_persisted", objectKey, len(shadowPlacements))
 
 	response := &BatchConsolidatorResponse{
@@ -262,6 +277,12 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 		zap.Int("scanned_blocks", len(records)),
 		zap.Int("consolidated_blocks", len(shadowPlacements)),
 		zap.String("object_key", objectKey),
+		zap.Uint64("raw_bytes", rawBytes),
+		zap.Duration("scan_duration", scanDuration),
+		zap.Duration("build_duration", buildDuration),
+		zap.Duration("upload_duration", uploadDuration),
+		zap.Duration("persist_duration", persistDuration),
+		zap.Duration("total_duration", time.Since(totalStart)),
 	)
 	return response, nil
 }
@@ -535,6 +556,14 @@ func writeRawBlockPayloadTempFile(raw []byte, dir string) (blobstorage.PayloadSo
 	success = true
 	length := uint64(len(raw))
 	return blobstorage.NewFilePayloadSource(path, length), path, length, nil
+}
+
+func consolidatedPayloadBytes(payloads []blobstorage.ConsolidatedBlockPayload) uint64 {
+	var total uint64
+	for _, payload := range payloads {
+		total += payload.UncompressedLength
+	}
+	return total
 }
 
 func validateDownloadedBlock(expected *api.BlockMetadata, block *api.Block) error {

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -58,6 +58,7 @@ const (
 	batchConsolidatorEmptyBatchCounter        = "workflow.batch_consolidator.empty_batch"
 	batchConsolidatorShadowStatsChangeID      = "batch-consolidator-shadow-stats"
 	batchConsolidatorShadowStatsVersion       = 1
+	batchConsolidatorMaxParallelism           = 10
 	maxUint64                                 = ^uint64(0)
 )
 
@@ -106,6 +107,9 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		parallelism := 1
 		if request.Parallelism > 0 {
 			parallelism = request.Parallelism
+		}
+		if parallelism > batchConsolidatorMaxParallelism {
+			return xerrors.Errorf("batch_consolidator parallelism(%d) exceeds max(%d)", parallelism, batchConsolidatorMaxParallelism)
 		}
 		mode, err := batchConsolidatorMode(request.Mode, cfg.Storage.Consolidation.Mode)
 		if err != nil {

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -408,6 +408,11 @@ func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
 		}
 
 		var firstErr error
+		type successResult struct {
+			request  *activity.BatchConsolidatorRequest
+			response activity.BatchConsolidatorResponse
+		}
+		successes := make([]successResult, 0, len(pending))
 		for _, item := range pending {
 			var response activity.BatchConsolidatorResponse
 			request := item.request
@@ -417,7 +422,15 @@ func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
 				}
 				continue
 			}
+			successes = append(successes, successResult{request: request, response: response})
+		}
+		if firstErr != nil {
+			return 0, 0, firstErr
+		}
 
+		for _, success := range successes {
+			request := success.request
+			response := success.response
 			if response.ScannedBlocks == 0 {
 				metrics.Counter(batchConsolidatorEmptyBatchCounter).Inc(1)
 				continue
@@ -454,9 +467,6 @@ func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
 				zap.Uint64("shadow_blocks", lastShadowBlocks),
 				zap.String("object_key", response.ObjectKey),
 			)
-		}
-		if firstErr != nil {
-			return 0, 0, firstErr
 		}
 	}
 

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -38,6 +38,12 @@ type (
 		BatchSize      uint64
 		CheckpointSize uint64
 		MaxBlocks      uint64
+		Parallelism    int `validate:"omitempty,gt=0"`
+	}
+
+	batchConsolidatorPendingActivity struct {
+		request *activity.BatchConsolidatorRequest
+		future  workflow.Future
 	}
 )
 
@@ -97,6 +103,10 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		if request.MaxBlocks > 0 {
 			maxBlocks = request.MaxBlocks
 		}
+		parallelism := 1
+		if request.Parallelism > 0 {
+			parallelism = request.Parallelism
+		}
 		mode, err := batchConsolidatorMode(request.Mode, cfg.Storage.Consolidation.Mode)
 		if err != nil {
 			return err
@@ -134,6 +144,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			zap.Uint64("max_blocks", maxBlocks),
 			zap.Uint64("storage_max_blocks", storageMaxBlocks),
 			zap.Uint64("shard_size", shardSize),
+			zap.Int("parallelism", parallelism),
 			zap.String("mode", string(mode)),
 		)
 		logger.Info("workflow started")
@@ -194,6 +205,35 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			batchEnd := batchConsolidatorWindowEnd(batchStart, workflowEndHeight, batchSize, shardSize)
 			if batchEnd <= batchStart {
 				return xerrors.Errorf("batch_consolidator made no height progress from %d to %d", batchStart, batchEnd)
+			}
+
+			if mode == config.ConsolidationModeHistoricalBackfill && parallelism > 1 {
+				objectsInBatch, blocksInBatch, err := w.processHistoricalBackfillBatchParallel(
+					ctx,
+					statsCtx,
+					logger,
+					metrics,
+					tag,
+					activityMode,
+					batchStart,
+					batchEnd,
+					maxBlocks,
+					parallelism,
+					usePersistedShadowStats,
+				)
+				if err != nil {
+					return err
+				}
+				metrics.Gauge(batchConsolidatorHeightGauge).Update(float64(batchEnd - 1))
+				logger.Info(
+					"processed shadow batch",
+					zap.Uint64("batch_start", batchStart),
+					zap.Uint64("batch_end", batchEnd),
+					zap.Uint64("objects", objectsInBatch),
+					zap.Uint64("consolidated_blocks", blocksInBatch),
+				)
+				batchStart = batchEnd
+				continue
 			}
 
 			objectsInBatch := uint64(0)
@@ -309,6 +349,145 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		logger.Info("workflow finished")
 		return nil
 	})
+}
+
+func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
+	ctx workflow.Context,
+	statsCtx workflow.Context,
+	logger *zap.Logger,
+	metrics client.MetricsHandler,
+	tag uint32,
+	activityMode config.ConsolidationMode,
+	batchStart uint64,
+	batchEnd uint64,
+	maxBlocks uint64,
+	parallelism int,
+	usePersistedShadowStats bool,
+) (uint64, uint64, error) {
+	lastShadowObjects := uint64(0)
+	lastShadowBlocks := uint64(0)
+	if usePersistedShadowStats {
+		baseline, err := w.batchConsolidator.GetShadowStats(statsCtx, &activity.BatchConsolidatorStatsRequest{
+			Mode:        activityMode,
+			Tag:         tag,
+			StartHeight: batchStart,
+			EndHeight:   batchEnd,
+		})
+		if err != nil {
+			return 0, 0, xerrors.Errorf("failed to get consolidation shadow stats for batch [%d, %d): %w", batchStart, batchEnd, err)
+		}
+		lastShadowObjects = baseline.ShadowObjects
+		lastShadowBlocks = baseline.ShadowBlocks
+	}
+
+	objectsInBatch := uint64(0)
+	blocksInBatch := uint64(0)
+	for windowStart := batchStart; windowStart < batchEnd; {
+		pending := make([]batchConsolidatorPendingActivity, 0, parallelism)
+		for len(pending) < parallelism && windowStart < batchEnd {
+			windowEnd := batchConsolidatorObjectWindowEnd(windowStart, batchEnd, maxBlocks)
+			if windowEnd <= windowStart {
+				return 0, 0, xerrors.Errorf("batch_consolidator made no parallel window progress from %d to %d", windowStart, windowEnd)
+			}
+			request := &activity.BatchConsolidatorRequest{
+				Mode:        activityMode,
+				Tag:         tag,
+				StartHeight: windowStart,
+				EndHeight:   windowEnd,
+				MaxBlocks:   maxBlocks,
+			}
+			pending = append(pending, batchConsolidatorPendingActivity{
+				request: request,
+				future:  workflow.ExecuteActivity(ctx, activity.ActivityBatchConsolidator, request),
+			})
+			windowStart = windowEnd
+		}
+
+		var firstErr error
+		for _, item := range pending {
+			var response activity.BatchConsolidatorResponse
+			request := item.request
+			if err := item.future.Get(ctx, &response); err != nil {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf("failed to consolidate shadow batch [%d, %d): %w", request.StartHeight, request.EndHeight, err)
+				}
+				continue
+			}
+
+			if response.ScannedBlocks == 0 {
+				metrics.Counter(batchConsolidatorEmptyBatchCounter).Inc(1)
+				continue
+			}
+			if response.ConsolidatedBlocks == 0 {
+				return 0, 0, xerrors.Errorf(
+					"batch_consolidator made no progress for non-empty shadow scan [%d, %d)",
+					request.StartHeight,
+					request.EndHeight,
+				)
+			}
+
+			newObjects := uint64(0)
+			newBlocks := uint64(0)
+			if !usePersistedShadowStats {
+				newObjects = 1
+				newBlocks = response.ConsolidatedBlocks
+				objectsInBatch += newObjects
+				blocksInBatch += newBlocks
+				metrics.Counter(batchConsolidatorObjectCounter).Inc(int64(newObjects))
+				metrics.Counter(batchConsolidatorConsolidatedBlockCounter).Inc(int64(newBlocks))
+			}
+			logger.Info(
+				"processed shadow object",
+				zap.Uint64("batch_start", batchStart),
+				zap.Uint64("batch_end", batchEnd),
+				zap.Uint64("window_start", request.StartHeight),
+				zap.Uint64("window_end", request.EndHeight),
+				zap.Uint64("scanned_blocks", response.ScannedBlocks),
+				zap.Uint64("consolidated_blocks", response.ConsolidatedBlocks),
+				zap.Uint64("new_objects", newObjects),
+				zap.Uint64("new_consolidated_blocks", newBlocks),
+				zap.Uint64("shadow_objects", lastShadowObjects),
+				zap.Uint64("shadow_blocks", lastShadowBlocks),
+				zap.String("object_key", response.ObjectKey),
+			)
+		}
+		if firstErr != nil {
+			return 0, 0, firstErr
+		}
+	}
+
+	if usePersistedShadowStats {
+		stats, err := w.batchConsolidator.GetShadowStats(statsCtx, &activity.BatchConsolidatorStatsRequest{
+			Mode:        activityMode,
+			Tag:         tag,
+			StartHeight: batchStart,
+			EndHeight:   batchEnd,
+		})
+		if err != nil {
+			return 0, 0, xerrors.Errorf("failed to get consolidation shadow stats for batch [%d, %d): %w", batchStart, batchEnd, err)
+		}
+		if stats.ShadowObjects < lastShadowObjects || stats.ShadowBlocks < lastShadowBlocks {
+			return 0, 0, xerrors.Errorf(
+				"batch_consolidator shadow stats regressed for batch [%d, %d): objects %d -> %d, blocks %d -> %d",
+				batchStart,
+				batchEnd,
+				lastShadowObjects,
+				stats.ShadowObjects,
+				lastShadowBlocks,
+				stats.ShadowBlocks,
+			)
+		}
+		objectsInBatch = stats.ShadowObjects - lastShadowObjects
+		blocksInBatch = stats.ShadowBlocks - lastShadowBlocks
+		if objectsInBatch > 0 {
+			metrics.Counter(batchConsolidatorObjectCounter).Inc(int64(objectsInBatch))
+		}
+		if blocksInBatch > 0 {
+			metrics.Counter(batchConsolidatorConsolidatedBlockCounter).Inc(int64(blocksInBatch))
+		}
+	}
+
+	return objectsInBatch, blocksInBatch, nil
 }
 
 func batchConsolidatorMode(
@@ -437,6 +616,14 @@ func batchConsolidatorWindowEnd(startHeight uint64, requestedEndHeight uint64, b
 		return shardEnd
 	}
 	return batchEnd
+}
+
+func batchConsolidatorObjectWindowEnd(startHeight uint64, batchEnd uint64, maxBlocks uint64) uint64 {
+	windowEnd := startHeight + maxBlocks
+	if windowEnd < startHeight || windowEnd > batchEnd {
+		return batchEnd
+	}
+	return windowEnd
 }
 
 func batchConsolidatorShardEnd(height uint64, shardSize uint64) uint64 {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -2,7 +2,10 @@ package workflow
 
 import (
 	"context"
+	"sort"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -244,6 +247,45 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRepeatsHeightBatchUnti
 	}
 }
 
+func (s *batchConsolidatorTestSuite) TestBatchConsolidatorIgnoresParallelismOutsideHistoricalBackfill() {
+	require := testutil.Require(s.T())
+
+	var requests []*activity.BatchConsolidatorRequest
+	normalCalls := 0
+	s.mockEmptyShadowStats()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			normalCalls++
+			if normalCalls == 1 {
+				return &activity.BatchConsolidatorResponse{
+					StartHeight:        request.StartHeight,
+					EndHeight:          request.EndHeight,
+					ScannedBlocks:      request.MaxBlocks,
+					ConsolidatedBlocks: request.MaxBlocks,
+					ObjectKey:          "consolidated/object.zstd",
+				}, nil
+			}
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1100,
+		MaxBlocks:   25,
+		Parallelism: 4,
+	})
+	require.NoError(err)
+	require.Len(requests, 2)
+	for _, request := range requests {
+		require.Equal(&activity.BatchConsolidatorRequest{Tag: 2, StartHeight: 1000, EndHeight: 1100, MaxBlocks: 25}, request)
+	}
+}
+
 func (s *batchConsolidatorTestSuite) TestHistoricalBackfillValidatesFinalizedRange() {
 	require := testutil.Require(s.T())
 
@@ -318,6 +360,114 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillDuplicateRunNoOpsWhen
 	require.NoError(err)
 	require.Len(requests, 1)
 	require.Equal(config.ConsolidationModeHistoricalBackfill, requests[0].Mode)
+}
+
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillProcessesObjectWindowsInParallel() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
+	var requests []*activity.BatchConsolidatorRequest
+	s.mockHistoricalBackfillLatestHeight(220)
+	s.mockEmptyShadowStats()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: 4,
+	})
+	require.NoError(err)
+	require.Len(requests, 4)
+	sort.Slice(requests, func(i, j int) bool {
+		return requests[i].StartHeight < requests[j].StartHeight
+	})
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   125,
+		MaxBlocks:   25,
+	}, requests[0])
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 125,
+		EndHeight:   150,
+		MaxBlocks:   25,
+	}, requests[1])
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 150,
+		EndHeight:   175,
+		MaxBlocks:   25,
+	}, requests[2])
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 175,
+		EndHeight:   200,
+		MaxBlocks:   25,
+	}, requests[3])
+}
+
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillRunsObjectWindowsConcurrently() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
+	var inFlight int64
+	var maxInFlight int64
+	s.mockHistoricalBackfillLatestHeight(220)
+	s.mockEmptyShadowStats()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			current := atomic.AddInt64(&inFlight, 1)
+			for {
+				maxSeen := atomic.LoadInt64(&maxInFlight)
+				if current <= maxSeen || atomic.CompareAndSwapInt64(&maxInFlight, maxSeen, current) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&inFlight, -1)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: 4,
+	})
+	require.NoError(err)
+	observedMaxInFlight := atomic.LoadInt64(&maxInFlight)
+	s.T().Logf("max in-flight batch_consolidator activities: %d", observedMaxInFlight)
+	require.Greater(observedMaxInFlight, int64(1))
 }
 
 func (s *batchConsolidatorTestSuite) TestHistoricalBackfillResumeAfterLostActivityCompletion() {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -286,6 +286,21 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorIgnoresParallelismOuts
 	}
 }
 
+func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRejectsExcessiveParallelism() {
+	require := testutil.Require(s.T())
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: batchConsolidatorMaxParallelism + 1,
+	})
+	require.Error(err)
+	require.Contains(err.Error(), "parallelism(11) exceeds max(10)")
+}
+
 func (s *batchConsolidatorTestSuite) TestHistoricalBackfillValidatesFinalizedRange() {
 	require := testutil.Require(s.T())
 


### PR DESCRIPTION
## Summary

- Add phase timing logs around CSCB historical backfill scan/build/upload/encode paths so slow stages are visible in production logs.
- Split CSCB upload timing into total upload, MD5 hashing, and actual S3 `PutObject` duration so S3 latency is not conflated with local hashing.
- Add request-only `Parallelism` for `workflow.batch_consolidator` historical backfill.
- When `Parallelism > 1`, split each historical backfill batch into non-overlapping `max_blocks` object windows and schedule up to N `activity.batch_consolidator` activities concurrently.
- Cap requested fanout at 10 and reject larger values before scheduling activity futures.
- Keep shadow dual-write and promote-finalized behavior serial, even if `Parallelism` is present.

## Why

The active Solana CSCB catch-up is bottlenecked by serial object processing. Zstd tuning would change the long-term storage/compression behavior, which is not the desired fix. This keeps the object format/config stable and gives manual historical backfills a bounded fanout path that can use multiple workers/hosts.

## Validation

- `go test ./internal/workflow`
- `go test ./internal/workflow ./internal/workflow/activity ./internal/storage/blobstorage/s3`
- Focused local Temporal harness verification observed `max in-flight batch_consolidator activities: 4` for `Parallelism: 4`.
- `git diff --check`

## Operational note

Existing running workflows will not change behavior. After deploy, start the next manual historical backfill with `"Parallelism":4` in the workflow input to activate bounded object-window fanout.