### PR TITLE
fix(INF-1035): improve CSCB stats observability

### DIFF
--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -746,9 +746,14 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
 		JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
 			AND shadow.legacy_object_key_main = bm.object_key_main
+			AND shadow.tag = cb.tag
+			AND shadow.height = cb.height
 		WHERE cb.tag = $1
 			AND cb.height >= $2
 			AND cb.height < $3
+			AND shadow.tag = $1
+			AND shadow.height >= $2
+			AND shadow.height < $3
 			AND bm.skipped = false
 			AND bm.object_key_main IS NOT NULL
 			AND bm.object_key_main <> ''

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -748,6 +748,7 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 			AND shadow.legacy_object_key_main = bm.object_key_main
 			AND shadow.tag = cb.tag
 			AND shadow.height = cb.height
+			AND shadow.hash = bm.hash
 		WHERE cb.tag = $1
 			AND cb.height >= $2
 			AND cb.height < $3

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -336,10 +336,36 @@ func (s *blockStorageTestSuite) insertConsolidationShadow(
 	validated bool,
 	legacyObjectKeyMain string,
 ) {
-	require := testutil.Require(s.T())
 	if legacyObjectKeyMain == "" {
 		legacyObjectKeyMain = block.GetObjectKeyMain()
 	}
+	s.insertConsolidationShadowWithIdentity(
+		ctx,
+		block,
+		consolidatedObjectKey,
+		byteOffset,
+		byteLength,
+		uncompressedLength,
+		validated,
+		legacyObjectKeyMain,
+		block.GetTag(),
+		block.GetHeight(),
+	)
+}
+
+func (s *blockStorageTestSuite) insertConsolidationShadowWithIdentity(
+	ctx context.Context,
+	block *api.BlockMetadata,
+	consolidatedObjectKey string,
+	byteOffset uint64,
+	byteLength uint64,
+	uncompressedLength uint64,
+	validated bool,
+	legacyObjectKeyMain string,
+	shadowTag uint32,
+	shadowHeight uint64,
+) {
+	require := testutil.Require(s.T())
 	var validatedAt any
 	if validated {
 		validatedAt = time.Now().UTC()
@@ -351,8 +377,8 @@ func (s *blockStorageTestSuite) insertConsolidationShadow(
 			object_format, byte_offset, byte_length, uncompressed_length, validated_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		s.getBlockMetadataID(ctx, block),
-		block.GetTag(),
-		block.GetHeight(),
+		shadowTag,
+		shadowHeight,
 		block.GetHash(),
 		legacyObjectKeyMain,
 		consolidatedObjectKey,
@@ -506,7 +532,7 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStats() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()
 	startHeight := s.config.Chain.BlockStartHeight
-	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 5, tag)
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 7, tag)
 
 	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
 	require.NoError(err)
@@ -516,8 +542,10 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStats() {
 	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/second.cscb.zstd", 50, 60, 60, true, "")
 	s.insertConsolidationShadow(ctx, blocks[3], "consolidated/unvalidated.cscb.zstd", 70, 80, 80, false, "")
 	s.insertConsolidationShadow(ctx, blocks[4], "consolidated/wrong-legacy-key.cscb.zstd", 90, 100, 100, true, "legacy/key/does/not/match")
+	s.insertConsolidationShadowWithIdentity(ctx, blocks[5], "consolidated/wrong-tag.cscb.zstd", 110, 120, 120, true, blocks[5].GetObjectKeyMain(), tag+1, blocks[5].GetHeight())
+	s.insertConsolidationShadowWithIdentity(ctx, blocks[6], "consolidated/wrong-height.cscb.zstd", 130, 140, 140, true, blocks[6].GetObjectKeyMain(), tag, blocks[6].GetHeight()+1000)
 
-	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+5)
+	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+7)
 	require.NoError(err)
 	require.Equal(uint64(2), stats.Objects)
 	require.Equal(uint64(3), stats.Blocks)

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -350,6 +350,7 @@ func (s *blockStorageTestSuite) insertConsolidationShadow(
 		legacyObjectKeyMain,
 		block.GetTag(),
 		block.GetHeight(),
+		block.GetHash(),
 	)
 }
 
@@ -364,6 +365,7 @@ func (s *blockStorageTestSuite) insertConsolidationShadowWithIdentity(
 	legacyObjectKeyMain string,
 	shadowTag uint32,
 	shadowHeight uint64,
+	shadowHash string,
 ) {
 	require := testutil.Require(s.T())
 	var validatedAt any
@@ -379,7 +381,7 @@ func (s *blockStorageTestSuite) insertConsolidationShadowWithIdentity(
 		s.getBlockMetadataID(ctx, block),
 		shadowTag,
 		shadowHeight,
-		block.GetHash(),
+		shadowHash,
 		legacyObjectKeyMain,
 		consolidatedObjectKey,
 		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
@@ -532,7 +534,7 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStats() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()
 	startHeight := s.config.Chain.BlockStartHeight
-	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 7, tag)
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 8, tag)
 
 	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
 	require.NoError(err)
@@ -542,10 +544,11 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStats() {
 	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/second.cscb.zstd", 50, 60, 60, true, "")
 	s.insertConsolidationShadow(ctx, blocks[3], "consolidated/unvalidated.cscb.zstd", 70, 80, 80, false, "")
 	s.insertConsolidationShadow(ctx, blocks[4], "consolidated/wrong-legacy-key.cscb.zstd", 90, 100, 100, true, "legacy/key/does/not/match")
-	s.insertConsolidationShadowWithIdentity(ctx, blocks[5], "consolidated/wrong-tag.cscb.zstd", 110, 120, 120, true, blocks[5].GetObjectKeyMain(), tag+1, blocks[5].GetHeight())
-	s.insertConsolidationShadowWithIdentity(ctx, blocks[6], "consolidated/wrong-height.cscb.zstd", 130, 140, 140, true, blocks[6].GetObjectKeyMain(), tag, blocks[6].GetHeight()+1000)
+	s.insertConsolidationShadowWithIdentity(ctx, blocks[5], "consolidated/wrong-tag.cscb.zstd", 110, 120, 120, true, blocks[5].GetObjectKeyMain(), tag+1, blocks[5].GetHeight(), blocks[5].GetHash())
+	s.insertConsolidationShadowWithIdentity(ctx, blocks[6], "consolidated/wrong-height.cscb.zstd", 130, 140, 140, true, blocks[6].GetObjectKeyMain(), tag, blocks[6].GetHeight()+1000, blocks[6].GetHash())
+	s.insertConsolidationShadowWithIdentity(ctx, blocks[7], "consolidated/wrong-hash.cscb.zstd", 150, 160, 160, true, blocks[7].GetObjectKeyMain(), tag, blocks[7].GetHeight(), "wrong-hash")
 
-	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+7)
+	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+8)
 	require.NoError(err)
 	require.Equal(uint64(2), stats.Objects)
 	require.Equal(uint64(3), stats.Blocks)

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -146,10 +146,23 @@ func (a *BatchConsolidator) executeStats(ctx context.Context, request *BatchCons
 	if err := a.validateShadowStatsMode(request.Mode); err != nil {
 		return nil, err
 	}
+	logger := a.statsActivity.getLogger(ctx).With(zap.Reflect("request", request))
+	statsStart := time.Now()
+	logger.Info("started consolidation shadow stats")
+	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.stats.started", request.Tag, request.StartHeight, request.EndHeight)
 	stats, err := a.getConsolidationShadowStats(ctx, request.Tag, request.StartHeight, request.EndHeight)
 	if err != nil {
+		logger.Error("failed consolidation shadow stats", zap.Duration("duration", time.Since(statsStart)), zap.Error(err))
 		return nil, err
 	}
+	statsDuration := time.Since(statsStart)
+	logger.Info(
+		"finished consolidation shadow stats",
+		zap.Uint64("shadow_objects", stats.Objects),
+		zap.Uint64("shadow_blocks", stats.Blocks),
+		zap.Duration("duration", statsDuration),
+	)
+	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.stats.completed", request.Tag, request.StartHeight, request.EndHeight, stats.Objects, stats.Blocks)
 	return &BatchConsolidatorStatsResponse{
 		StartHeight:   request.StartHeight,
 		EndHeight:     request.EndHeight,


### PR DESCRIPTION
## Summary
- add start/finish/error logs and Temporal heartbeats around batch_consolidator stats collection
- constrain CSCB shadow stats to matching shadow tag/height so stale shadow identity cannot inflate counts and the tag/height index is usable
- extend postgres stats coverage with mismatched shadow tag/height rows

## Context
The active Solana CSCB backfill showed retry noise on worker-to-Temporal RPCs, while the current stall was in the stats activity with no heartbeat details. This adds enough activity-level observability to distinguish DB stats time from post-query failure/retry behavior.

Linear: https://linear.app/cipherowl/issue/INF-1035/fixchainstorage-improve-cscb-backfill-stats-observability

## Verification
- `TEST_TYPE=unit go test ./internal/workflow/activity -run 'TestBatchConsolidatorTestSuite/TestGetShadowStatsReturnsPersistedShadowStats'`\n- `TEST_TYPE=unit go test ./internal/workflow/activity -run 'TestBatchConsolidatorTestSuite'`\n- `CHAINSTORAGE_AWS_POSTGRES_PASSWORD=worker_password make integration TARGET=internal/storage/metastorage/postgres TEST_FILTER='TestIntegration/TestGetBlockConsolidationShadowStats'`\n