### PR TITLE
fix(INF-1046): restore parallel historical backfill

### DIFF
--- a/internal/cadence/runtime_test.go
+++ b/internal/cadence/runtime_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+
+	"github.com/coinbase/chainstorage/internal/config"
 )
 
 func TestNewWorkerOptionsPreservesDefaultActivityConcurrency(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -620,8 +620,8 @@ const (
 	ConsolidationModeLegacyOnly      ConsolidationMode = "legacy_only"
 	ConsolidationModeShadowDualWrite ConsolidationMode = "shadow_dual_write"
 	ConsolidationModeAutoConsolidate ConsolidationMode = "auto_consolidate"
-	// Deprecated: use ConsolidationModeAutoConsolidate. This remains accepted so
-	// existing Temporal histories and manually-started workflows can replay.
+	// Historical backfill is the manual catch-up mode. It remains separate from
+	// auto_consolidate, which is the normal serial cron mode.
 	ConsolidationModeHistoricalBackfill        ConsolidationMode = "historical_backfill"
 	ConsolidationModePromoteFinalized          ConsolidationMode = "promote_finalized"
 	ConsolidationModeSyncerConsolidatedPrimary ConsolidationMode = "syncer_consolidated_primary"

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -60,6 +60,8 @@ const (
 	batchConsolidatorShadowStatsVersion            = 1
 	batchConsolidatorHistoricalParallelismChangeID = "batch-consolidator-historical-parallelism"
 	batchConsolidatorHistoricalParallelismVersion  = 1
+	batchConsolidatorAutoSerialChangeID            = "batch-consolidator-auto-serial"
+	batchConsolidatorAutoSerialVersion             = 1
 	batchConsolidatorMaxParallelism                = 10
 	maxUint64                                      = ^uint64(0)
 )
@@ -171,6 +173,15 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				batchConsolidatorHistoricalParallelismVersion,
 			)
 		}
+		autoConsolidateVersion := workflow.DefaultVersion
+		if mode.IsAutoConsolidate() {
+			autoConsolidateVersion = workflow.GetVersion(
+				ctx,
+				batchConsolidatorAutoSerialChangeID,
+				workflow.DefaultVersion,
+				batchConsolidatorAutoSerialVersion,
+			)
+		}
 
 		if historicalBackfillVersion != workflow.DefaultVersion {
 			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
@@ -229,6 +240,35 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 
 			if historicalBackfillVersion != workflow.DefaultVersion && parallelism > 1 {
 				objectsInBatch, blocksInBatch, err := w.processHistoricalBackfillBatchParallel(
+					ctx,
+					statsCtx,
+					logger,
+					metrics,
+					tag,
+					activityMode,
+					batchStart,
+					batchEnd,
+					maxBlocks,
+					parallelism,
+					usePersistedShadowStats,
+				)
+				if err != nil {
+					return err
+				}
+				metrics.Gauge(batchConsolidatorHeightGauge).Update(float64(batchEnd - 1))
+				logger.Info(
+					"processed shadow batch",
+					zap.Uint64("batch_start", batchStart),
+					zap.Uint64("batch_end", batchEnd),
+					zap.Uint64("objects", objectsInBatch),
+					zap.Uint64("consolidated_blocks", blocksInBatch),
+				)
+				batchStart = batchEnd
+				continue
+			}
+
+			if mode.IsAutoConsolidate() && autoConsolidateVersion == workflow.DefaultVersion {
+				objectsInBatch, blocksInBatch, err := w.processAutoConsolidateBatchParallel(
 					ctx,
 					statsCtx,
 					logger,
@@ -369,6 +409,164 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		logger.Info("workflow finished")
 		return nil
 	})
+}
+
+func (w *BatchConsolidator) processAutoConsolidateBatchParallel(
+	ctx workflow.Context,
+	statsCtx workflow.Context,
+	logger *zap.Logger,
+	metrics client.MetricsHandler,
+	tag uint32,
+	activityMode config.ConsolidationMode,
+	batchStart uint64,
+	batchEnd uint64,
+	maxBlocks uint64,
+	parallelism int,
+	usePersistedShadowStats bool,
+) (uint64, uint64, error) {
+	lastShadowObjects := uint64(0)
+	lastShadowBlocks := uint64(0)
+	if usePersistedShadowStats {
+		baseline, err := w.batchConsolidator.GetShadowStats(statsCtx, &activity.BatchConsolidatorStatsRequest{
+			Mode:        activityMode,
+			Tag:         tag,
+			StartHeight: batchStart,
+			EndHeight:   batchEnd,
+		})
+		if err != nil {
+			return 0, 0, xerrors.Errorf("failed to get consolidation shadow stats for batch [%d, %d): %w", batchStart, batchEnd, err)
+		}
+		lastShadowObjects = baseline.ShadowObjects
+		lastShadowBlocks = baseline.ShadowBlocks
+	}
+
+	objectsInBatch := uint64(0)
+	blocksInBatch := uint64(0)
+	for windowStart := batchStart; windowStart < batchEnd; {
+		pending := make([]batchConsolidatorPendingActivity, 0, parallelism)
+		for len(pending) < parallelism && windowStart < batchEnd {
+			windowEnd, fullWindow := batchConsolidatorFullObjectWindowEnd(windowStart, batchEnd, maxBlocks)
+			if !fullWindow {
+				logger.Info(
+					"auto consolidate waiting for a full object window",
+					zap.Uint64("window_start", windowStart),
+					zap.Uint64("batch_end", batchEnd),
+					zap.Uint64("max_blocks", maxBlocks),
+				)
+				break
+			}
+			request := &activity.BatchConsolidatorRequest{
+				Mode:        activityMode,
+				Tag:         tag,
+				StartHeight: windowStart,
+				EndHeight:   windowEnd,
+				MaxBlocks:   maxBlocks,
+			}
+			pending = append(pending, batchConsolidatorPendingActivity{
+				request: request,
+				future:  workflow.ExecuteActivity(ctx, activity.ActivityBatchConsolidator, request),
+			})
+			windowStart = windowEnd
+		}
+		if len(pending) == 0 {
+			break
+		}
+
+		var firstErr error
+		type successResult struct {
+			request  *activity.BatchConsolidatorRequest
+			response activity.BatchConsolidatorResponse
+		}
+		successes := make([]successResult, 0, len(pending))
+		for _, item := range pending {
+			var response activity.BatchConsolidatorResponse
+			request := item.request
+			if err := item.future.Get(ctx, &response); err != nil {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf("failed to consolidate shadow batch [%d, %d): %w", request.StartHeight, request.EndHeight, err)
+				}
+				continue
+			}
+			successes = append(successes, successResult{request: request, response: response})
+		}
+		if firstErr != nil {
+			return 0, 0, firstErr
+		}
+
+		for _, success := range successes {
+			request := success.request
+			response := success.response
+			if response.ScannedBlocks == 0 {
+				metrics.Counter(batchConsolidatorEmptyBatchCounter).Inc(1)
+				continue
+			}
+			if response.ConsolidatedBlocks == 0 {
+				return 0, 0, xerrors.Errorf(
+					"batch_consolidator made no progress for non-empty shadow scan [%d, %d)",
+					request.StartHeight,
+					request.EndHeight,
+				)
+			}
+
+			newObjects := uint64(0)
+			newBlocks := uint64(0)
+			if !usePersistedShadowStats {
+				newObjects = 1
+				newBlocks = response.ConsolidatedBlocks
+				objectsInBatch += newObjects
+				blocksInBatch += newBlocks
+				metrics.Counter(batchConsolidatorObjectCounter).Inc(int64(newObjects))
+				metrics.Counter(batchConsolidatorConsolidatedBlockCounter).Inc(int64(newBlocks))
+			}
+			logger.Info(
+				"processed shadow object",
+				zap.Uint64("batch_start", batchStart),
+				zap.Uint64("batch_end", batchEnd),
+				zap.Uint64("window_start", request.StartHeight),
+				zap.Uint64("window_end", request.EndHeight),
+				zap.Uint64("scanned_blocks", response.ScannedBlocks),
+				zap.Uint64("consolidated_blocks", response.ConsolidatedBlocks),
+				zap.Uint64("new_objects", newObjects),
+				zap.Uint64("new_consolidated_blocks", newBlocks),
+				zap.Uint64("shadow_objects", lastShadowObjects),
+				zap.Uint64("shadow_blocks", lastShadowBlocks),
+				zap.String("object_key", response.ObjectKey),
+			)
+		}
+	}
+
+	if usePersistedShadowStats {
+		stats, err := w.batchConsolidator.GetShadowStats(statsCtx, &activity.BatchConsolidatorStatsRequest{
+			Mode:        activityMode,
+			Tag:         tag,
+			StartHeight: batchStart,
+			EndHeight:   batchEnd,
+		})
+		if err != nil {
+			return 0, 0, xerrors.Errorf("failed to get consolidation shadow stats for batch [%d, %d): %w", batchStart, batchEnd, err)
+		}
+		if stats.ShadowObjects < lastShadowObjects || stats.ShadowBlocks < lastShadowBlocks {
+			return 0, 0, xerrors.Errorf(
+				"batch_consolidator shadow stats regressed for batch [%d, %d): objects %d -> %d, blocks %d -> %d",
+				batchStart,
+				batchEnd,
+				lastShadowObjects,
+				stats.ShadowObjects,
+				lastShadowBlocks,
+				stats.ShadowBlocks,
+			)
+		}
+		objectsInBatch = stats.ShadowObjects - lastShadowObjects
+		blocksInBatch = stats.ShadowBlocks - lastShadowBlocks
+		if objectsInBatch > 0 {
+			metrics.Counter(batchConsolidatorObjectCounter).Inc(int64(objectsInBatch))
+		}
+		if blocksInBatch > 0 {
+			metrics.Counter(batchConsolidatorConsolidatedBlockCounter).Inc(int64(blocksInBatch))
+		}
+	}
+
+	return objectsInBatch, blocksInBatch, nil
 }
 
 func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
@@ -718,6 +916,14 @@ func batchConsolidatorObjectWindowEnd(startHeight uint64, batchEnd uint64, maxBl
 		return batchEnd
 	}
 	return windowEnd
+}
+
+func batchConsolidatorFullObjectWindowEnd(startHeight uint64, batchEnd uint64, maxBlocks uint64) (uint64, bool) {
+	windowEnd := startHeight + maxBlocks
+	if windowEnd < startHeight || windowEnd > batchEnd {
+		return batchEnd, false
+	}
+	return windowEnd, true
 }
 
 func batchConsolidatorShardEnd(height uint64, shardSize uint64) uint64 {

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -162,17 +162,17 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			workflow.DefaultVersion,
 			batchConsolidatorShadowStatsVersion,
 		) != workflow.DefaultVersion && mode != config.ConsolidationModePromoteFinalized
-		useHistoricalBackfillParallelism := false
-		if mode == config.ConsolidationModeHistoricalBackfill && parallelism > 1 {
-			useHistoricalBackfillParallelism = workflow.GetVersion(
+		historicalBackfillVersion := workflow.DefaultVersion
+		if mode == config.ConsolidationModeHistoricalBackfill {
+			historicalBackfillVersion = workflow.GetVersion(
 				ctx,
 				batchConsolidatorHistoricalParallelismChangeID,
 				workflow.DefaultVersion,
 				batchConsolidatorHistoricalParallelismVersion,
-			) != workflow.DefaultVersion
+			)
 		}
 
-		if mode == config.ConsolidationModeHistoricalBackfill {
+		if historicalBackfillVersion != workflow.DefaultVersion {
 			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
 				return err
 			}
@@ -227,7 +227,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				return xerrors.Errorf("batch_consolidator made no height progress from %d to %d", batchStart, batchEnd)
 			}
 
-			if useHistoricalBackfillParallelism {
+			if historicalBackfillVersion != workflow.DefaultVersion && parallelism > 1 {
 				objectsInBatch, blocksInBatch, err := w.processHistoricalBackfillBatchParallel(
 					ctx,
 					statsCtx,

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -52,14 +52,16 @@ var (
 )
 
 const (
-	batchConsolidatorHeightGauge              = "workflow.batch_consolidator.height"
-	batchConsolidatorObjectCounter            = "workflow.batch_consolidator.object"
-	batchConsolidatorConsolidatedBlockCounter = "workflow.batch_consolidator.consolidated_block"
-	batchConsolidatorEmptyBatchCounter        = "workflow.batch_consolidator.empty_batch"
-	batchConsolidatorShadowStatsChangeID      = "batch-consolidator-shadow-stats"
-	batchConsolidatorShadowStatsVersion       = 1
-	batchConsolidatorMaxParallelism           = 10
-	maxUint64                                 = ^uint64(0)
+	batchConsolidatorHeightGauge                   = "workflow.batch_consolidator.height"
+	batchConsolidatorObjectCounter                 = "workflow.batch_consolidator.object"
+	batchConsolidatorConsolidatedBlockCounter      = "workflow.batch_consolidator.consolidated_block"
+	batchConsolidatorEmptyBatchCounter             = "workflow.batch_consolidator.empty_batch"
+	batchConsolidatorShadowStatsChangeID           = "batch-consolidator-shadow-stats"
+	batchConsolidatorShadowStatsVersion            = 1
+	batchConsolidatorHistoricalParallelismChangeID = "batch-consolidator-historical-parallelism"
+	batchConsolidatorHistoricalParallelismVersion  = 1
+	batchConsolidatorMaxParallelism                = 10
+	maxUint64                                      = ^uint64(0)
 )
 
 func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
@@ -160,7 +162,21 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			workflow.DefaultVersion,
 			batchConsolidatorShadowStatsVersion,
 		) != workflow.DefaultVersion && mode != config.ConsolidationModePromoteFinalized
+		useHistoricalBackfillParallelism := false
+		if mode == config.ConsolidationModeHistoricalBackfill && parallelism > 1 {
+			useHistoricalBackfillParallelism = workflow.GetVersion(
+				ctx,
+				batchConsolidatorHistoricalParallelismChangeID,
+				workflow.DefaultVersion,
+				batchConsolidatorHistoricalParallelismVersion,
+			) != workflow.DefaultVersion
+		}
 
+		if mode == config.ConsolidationModeHistoricalBackfill {
+			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
+				return err
+			}
+		}
 		if mode.IsAutoConsolidate() {
 			if err := w.validateAutoConsolidateRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
 				return err
@@ -211,8 +227,8 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				return xerrors.Errorf("batch_consolidator made no height progress from %d to %d", batchStart, batchEnd)
 			}
 
-			if mode.IsAutoConsolidate() {
-				objectsInBatch, blocksInBatch, err := w.processAutoConsolidateBatchParallel(
+			if useHistoricalBackfillParallelism {
+				objectsInBatch, blocksInBatch, err := w.processHistoricalBackfillBatchParallel(
 					ctx,
 					statsCtx,
 					logger,
@@ -355,7 +371,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 	})
 }
 
-func (w *BatchConsolidator) processAutoConsolidateBatchParallel(
+func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
 	ctx workflow.Context,
 	statsCtx workflow.Context,
 	logger *zap.Logger,
@@ -389,15 +405,9 @@ func (w *BatchConsolidator) processAutoConsolidateBatchParallel(
 	for windowStart := batchStart; windowStart < batchEnd; {
 		pending := make([]batchConsolidatorPendingActivity, 0, parallelism)
 		for len(pending) < parallelism && windowStart < batchEnd {
-			windowEnd, fullWindow := batchConsolidatorFullObjectWindowEnd(windowStart, batchEnd, maxBlocks)
-			if !fullWindow {
-				logger.Info(
-					"auto consolidate waiting for a full object window",
-					zap.Uint64("window_start", windowStart),
-					zap.Uint64("batch_end", batchEnd),
-					zap.Uint64("max_blocks", maxBlocks),
-				)
-				break
+			windowEnd := batchConsolidatorObjectWindowEnd(windowStart, batchEnd, maxBlocks)
+			if windowEnd <= windowStart {
+				return 0, 0, xerrors.Errorf("batch_consolidator made no parallel window progress from %d to %d", windowStart, windowEnd)
 			}
 			request := &activity.BatchConsolidatorRequest{
 				Mode:        activityMode,
@@ -539,6 +549,59 @@ func batchConsolidatorMode(
 	}
 }
 
+func (w *BatchConsolidator) validateHistoricalBackfillRange(
+	ctx workflow.Context,
+	logger *zap.Logger,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	irreversibleDistance uint64,
+) error {
+	latest, err := w.batchConsolidator.GetLatestBlock(ctx, &activity.BatchConsolidatorLatestBlockRequest{
+		Tag: tag,
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to get latest block for historical backfill range validation: %w", err)
+	}
+	if latest == nil {
+		return xerrors.New("latest block response is nil for historical backfill range validation")
+	}
+	safeEndHeight, ok := batchConsolidatorHistoricalSafeEndHeight(latest.Height, irreversibleDistance)
+	if !ok {
+		return xerrors.Errorf(
+			"historical_backfill range [%d, %d) is unsafe: latest height %d is below irreversible_distance %d",
+			startHeight,
+			endHeight,
+			latest.Height,
+			irreversibleDistance,
+		)
+	}
+	if endHeight > safeEndHeight {
+		return xerrors.Errorf(
+			"historical_backfill range [%d, %d) is unsafe: end_height must be <= %d for latest_height=%d irreversible_distance=%d",
+			startHeight,
+			endHeight,
+			safeEndHeight,
+			latest.Height,
+			irreversibleDistance,
+		)
+	}
+	logger.Info(
+		"validated historical backfill range",
+		zap.Uint32("tag", tag),
+		zap.Uint64("start_height", startHeight),
+		zap.Uint64("end_height", endHeight),
+		zap.Uint64("latest_height", latest.Height),
+		zap.Uint64("irreversible_distance", irreversibleDistance),
+		zap.Uint64("safe_end_height", safeEndHeight),
+	)
+	return nil
+}
+
+func batchConsolidatorHistoricalSafeEndHeight(latestHeight uint64, irreversibleDistance uint64) (uint64, bool) {
+	return batchConsolidatorSafeEndHeight(latestHeight, irreversibleDistance)
+}
+
 func (w *BatchConsolidator) validateAutoConsolidateRange(
 	ctx workflow.Context,
 	logger *zap.Logger,
@@ -589,6 +652,10 @@ func (w *BatchConsolidator) validateAutoConsolidateRange(
 }
 
 func batchConsolidatorAutoConsolidateSafeEndHeight(latestHeight uint64, irreversibleDistance uint64) (uint64, bool) {
+	return batchConsolidatorSafeEndHeight(latestHeight, irreversibleDistance)
+}
+
+func batchConsolidatorSafeEndHeight(latestHeight uint64, irreversibleDistance uint64) (uint64, bool) {
 	if irreversibleDistance == 0 {
 		if latestHeight == maxUint64 {
 			return maxUint64, true
@@ -651,17 +718,6 @@ func batchConsolidatorObjectWindowEnd(startHeight uint64, batchEnd uint64, maxBl
 		return batchEnd
 	}
 	return windowEnd
-}
-
-func batchConsolidatorFullObjectWindowEnd(startHeight uint64, batchEnd uint64, maxBlocks uint64) (uint64, bool) {
-	if maxBlocks == 0 || batchEnd <= startHeight {
-		return 0, false
-	}
-	windowEnd := startHeight + maxBlocks
-	if windowEnd < startHeight || windowEnd > batchEnd {
-		return 0, false
-	}
-	return windowEnd, true
 }
 
 func batchConsolidatorShardEnd(height uint64, shardSize uint64) uint64 {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 
@@ -619,6 +620,75 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 			MaxBlocks:   25,
 		}, request)
 	}
+}
+
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesParallelObjectWindows() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
+	var requests []*activity.BatchConsolidatorRequest
+	s.mockAutoConsolidateLatestHeight(220)
+	s.mockEmptyShadowStats()
+	s.env.OnGetVersion(
+		batchConsolidatorAutoSerialChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoSerialVersion,
+	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: 4,
+	})
+	require.NoError(err)
+	require.Len(requests, 4)
+	sort.Slice(requests, func(i, j int) bool {
+		return requests[i].StartHeight < requests[j].StartHeight
+	})
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   125,
+		MaxBlocks:   25,
+	}, requests[0])
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 125,
+		EndHeight:   150,
+		MaxBlocks:   25,
+	}, requests[1])
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 150,
+		EndHeight:   175,
+		MaxBlocks:   25,
+	}, requests[2])
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 175,
+		EndHeight:   200,
+		MaxBlocks:   25,
+	}, requests[3])
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateResumeAfterLostActivityCompletion() {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -247,7 +247,7 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRepeatsHeightBatchUnti
 	}
 }
 
-func (s *batchConsolidatorTestSuite) TestBatchConsolidatorIgnoresParallelismOutsideAutoConsolidate() {
+func (s *batchConsolidatorTestSuite) TestBatchConsolidatorIgnoresParallelismOutsideHistoricalBackfill() {
 	require := testutil.Require(s.T())
 
 	var requests []*activity.BatchConsolidatorRequest
@@ -290,7 +290,7 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRejectsExcessiveParall
 	require := testutil.Require(s.T())
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 100,
 		EndHeight:   200,
@@ -335,10 +335,12 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateValidatesFinalizedRange(
 	}, requests[0])
 }
 
-func (s *batchConsolidatorTestSuite) TestDeprecatedHistoricalBackfillAliasRemainsAccepted() {
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillValidatesFinalizedRange() {
 	require := testutil.Require(s.T())
 
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
 	var requests []*activity.BatchConsolidatorRequest
+	s.mockAutoConsolidateLatestHeight(120)
 	s.mockEmptyShadowStats()
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
@@ -365,6 +367,22 @@ func (s *batchConsolidatorTestSuite) TestDeprecatedHistoricalBackfillAliasRemain
 		EndHeight:   111,
 		MaxBlocks:   25,
 	}, requests[0])
+}
+
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillRejectsReorgUnsafeRange() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.mockAutoConsolidateLatestHeight(120)
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   113,
+	})
+	require.Error(err)
+	require.Contains(err.Error(), "historical_backfill range [100, 113) is unsafe")
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateRejectsReorgUnsafeRange() {
@@ -411,12 +429,21 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDuplicateRunNoOpsWhenSca
 	require.Equal(config.ConsolidationModeAutoConsolidate, requests[0].Mode)
 }
 
-func (s *batchConsolidatorTestSuite) TestAutoConsolidateWaitsForFullObjectWindow() {
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateLeavesWindowSelectionToSerialActivity() {
 	require := testutil.Require(s.T())
 
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	var requests []*activity.BatchConsolidatorRequest
 	s.mockAutoConsolidateLatestHeight(120)
 	s.mockEmptyShadowStats()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		})
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
@@ -426,9 +453,17 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateWaitsForFullObjectWindow
 		MaxBlocks:   25,
 	})
 	require.NoError(err)
+	require.Len(requests, 1)
+	require.Equal(&activity.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   111,
+		MaxBlocks:   25,
+	}, requests[0])
 }
 
-func (s *batchConsolidatorTestSuite) TestAutoConsolidateProcessesObjectWindowsInParallel() {
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillProcessesObjectWindowsInParallel() {
 	require := testutil.Require(s.T())
 
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
@@ -450,7 +485,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateProcessesObjectWindowsIn
 		})
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 100,
 		EndHeight:   200,
@@ -463,28 +498,28 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateProcessesObjectWindowsIn
 		return requests[i].StartHeight < requests[j].StartHeight
 	})
 	require.Equal(&activity.BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 100,
 		EndHeight:   125,
 		MaxBlocks:   25,
 	}, requests[0])
 	require.Equal(&activity.BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 125,
 		EndHeight:   150,
 		MaxBlocks:   25,
 	}, requests[1])
 	require.Equal(&activity.BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 150,
 		EndHeight:   175,
 		MaxBlocks:   25,
 	}, requests[2])
 	require.Equal(&activity.BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 175,
 		EndHeight:   200,
@@ -492,7 +527,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateProcessesObjectWindowsIn
 	}, requests[3])
 }
 
-func (s *batchConsolidatorTestSuite) TestAutoConsolidateRunsObjectWindowsConcurrently() {
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillRunsObjectWindowsConcurrently() {
 	require := testutil.Require(s.T())
 
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
@@ -523,7 +558,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateRunsObjectWindowsConcurr
 		})
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
+		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 100,
 		EndHeight:   200,
@@ -534,6 +569,56 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateRunsObjectWindowsConcurr
 	observedMaxInFlight := atomic.LoadInt64(&maxInFlight)
 	s.T().Logf("max in-flight batch_consolidator activities: %d", observedMaxInFlight)
 	require.Greater(observedMaxInFlight, int64(1))
+}
+
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
+	var requests []*activity.BatchConsolidatorRequest
+	normalCalls := 0
+	s.mockAutoConsolidateLatestHeight(220)
+	s.mockEmptyShadowStats()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			normalCalls++
+			if normalCalls == 1 {
+				return &activity.BatchConsolidatorResponse{
+					StartHeight:        request.StartHeight,
+					EndHeight:          request.EndHeight,
+					ScannedBlocks:      request.MaxBlocks,
+					ConsolidatedBlocks: request.MaxBlocks,
+					ObjectKey:          "consolidated/object.zstd",
+				}, nil
+			}
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: 4,
+	})
+	require.NoError(err)
+	require.Len(requests, 2)
+	for _, request := range requests {
+		require.Equal(&activity.BatchConsolidatorRequest{
+			Mode:        config.ConsolidationModeAutoConsolidate,
+			Tag:         2,
+			StartHeight: 100,
+			EndHeight:   200,
+			MaxBlocks:   25,
+		}, request)
+	}
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateResumeAfterLostActivityCompletion() {
@@ -599,6 +684,21 @@ func TestBatchConsolidatorAutoConsolidateSafeEndHeight(t *testing.T) {
 	require.Equal(uint64(121), safeEnd)
 
 	_, ok = batchConsolidatorAutoConsolidateSafeEndHeight(8, 10)
+	require.False(ok)
+}
+
+func TestBatchConsolidatorHistoricalSafeEndHeight(t *testing.T) {
+	require := testutil.Require(t)
+
+	safeEnd, ok := batchConsolidatorHistoricalSafeEndHeight(120, 10)
+	require.True(ok)
+	require.Equal(uint64(112), safeEnd)
+
+	safeEnd, ok = batchConsolidatorHistoricalSafeEndHeight(120, 0)
+	require.True(ok)
+	require.Equal(uint64(121), safeEnd)
+
+	_, ok = batchConsolidatorHistoricalSafeEndHeight(8, 10)
 	require.False(ok)
 }
 


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046

## Summary
- restore `historical_backfill` as the only batch_consolidator mode that honors `Parallelism > 1`
- keep `auto_consolidate` on the serial workflow path for normal cron execution
- restore historical backfill range safety validation and update the misleading mode comment
- add regression coverage for historical backfill p10 fan-out and auto-consolidate ignoring `Parallelism`

## Why
PR #149 accidentally moved the parallel full-object fan-out from manual `historical_backfill` to normal `auto_consolidate`. That made manual catch-up ignore p10 while normal auto-consolidation attempted parallel object windows. This PR restores the intended split:

- manual catch-up/backfill: `historical_backfill` + `Parallelism` can fan out
- normal production cron: `auto_consolidate` remains serial and waits on full eligible windows upstream

The new parallel branch is guarded with Temporal `GetVersion`, so already-open historical workflows that started on the old deployed code continue replaying the old serial history. New historical backfill workflows started after this deploy will use p10 fan-out.

## Verification
- `go test ./internal/workflow/...`
- `PATH="$(go env GOPATH)/bin:$PATH" make test TARGET=internal/workflow/...`
