### PR TITLE
fix(INF-1046): make auto consolidation cursor-driven

### DIFF
--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -171,6 +171,69 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		return nil
 	}
 
+	repairScanStart := searchStart
+	if cursorFound {
+		repairScanStart = cronConfig.StartHeight
+		if cursorHeight > consolidation.ShardSize && cursorHeight-consolidation.ShardSize > repairScanStart {
+			repairScanStart = cursorHeight - consolidation.ShardSize
+		}
+		if repairScanStart < searchStart {
+			repairStart, repairFound, err := t.firstAutoConsolidateWindowStart(
+				ctx,
+				tag,
+				repairScanStart,
+				searchStart,
+				cronConfig.StartHeight,
+				consolidation.MaxBlocks,
+				consolidation.ShardSize,
+			)
+			if err != nil {
+				return err
+			}
+			if repairFound {
+				searchStart = repairStart
+			}
+		}
+	} else {
+		bootstrapStart, bootstrapFound, err := t.firstAutoConsolidateWindowStart(
+			ctx,
+			tag,
+			cronConfig.StartHeight,
+			searchEnd,
+			cronConfig.StartHeight,
+			consolidation.MaxBlocks,
+			consolidation.ShardSize,
+		)
+		if err != nil {
+			return err
+		}
+		if !bootstrapFound {
+			t.logger.Info(
+				"batch_consolidator cron found no missing consolidation shadow to bootstrap cursor",
+				zap.Uint32("tag", tag),
+				zap.Uint64("configured_start_height", cronConfig.StartHeight),
+				zap.Uint64("safe_end_height", searchEnd),
+				zap.Uint64("latest_height", latest.GetHeight()),
+				zap.Uint64("safe_consolidation_height", safeHeight),
+			)
+			return nil
+		}
+		searchStart = bootstrapStart
+	}
+
+	normalizedStart := batchConsolidatorCronFullWindowStartAtOrAfter(searchStart, consolidation.MaxBlocks, consolidation.ShardSize)
+	if normalizedStart != searchStart {
+		t.logger.Info(
+			"batch_consolidator cron advanced start height to next full consolidation window",
+			zap.Uint32("tag", tag),
+			zap.Uint64("start_height", searchStart),
+			zap.Uint64("normalized_start_height", normalizedStart),
+			zap.Uint64("consolidation_max_blocks", consolidation.MaxBlocks),
+			zap.Uint64("shard_size", consolidation.ShardSize),
+		)
+		searchStart = normalizedStart
+	}
+
 	startHeight := searchStart
 	endHeight, found := batchConsolidatorCronRangeEnd(
 		searchStart,
@@ -231,6 +294,35 @@ func (t *batchConsolidatorTask) autoConsolidateWorkflowID() string {
 	return fmt.Sprintf("%s/%s", t.config.Workflows.BatchConsolidator.WorkflowIdentity, autoConsolidateSuffix)
 }
 
+func (t *batchConsolidatorTask) firstAutoConsolidateWindowStart(
+	ctx context.Context,
+	tag uint32,
+	searchStart uint64,
+	searchEnd uint64,
+	lowerBound uint64,
+	consolidationWindowBlocks uint64,
+	shardSize uint64,
+) (uint64, bool, error) {
+	if searchEnd <= searchStart {
+		return 0, false, nil
+	}
+	missingHeight, found, err := t.metaStorage.GetFirstBlockMissingConsolidationShadow(ctx, tag, searchStart, searchEnd)
+	if err != nil {
+		return 0, false, xerrors.Errorf("failed to get first block missing consolidation shadow: %w", err)
+	}
+	if !found {
+		return 0, false, nil
+	}
+	windowStart := batchConsolidatorCronObjectWindowStart(missingHeight, consolidationWindowBlocks, shardSize)
+	if windowStart < lowerBound {
+		windowStart = batchConsolidatorCronFullWindowStartAtOrAfter(lowerBound, consolidationWindowBlocks, shardSize)
+	}
+	if windowStart >= searchEnd {
+		return 0, false, nil
+	}
+	return windowStart, true, nil
+}
+
 func (t *batchConsolidatorTask) openBatchConsolidatorWorkflow(ctx context.Context) (string, bool, error) {
 	workflowIdentity := t.config.Workflows.BatchConsolidator.WorkflowIdentity
 	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, batchConsolidatorOpenPageSize, workflowIdentity)
@@ -280,6 +372,26 @@ func batchConsolidatorCronRangeEnd(startHeight uint64, safeEndHeight uint64, max
 		return 0, false
 	}
 	return endHeight, true
+}
+
+func batchConsolidatorCronObjectWindowStart(height uint64, consolidationWindowBlocks uint64, shardSize uint64) uint64 {
+	if consolidationWindowBlocks == 0 || shardSize == 0 {
+		return height
+	}
+	shardStart := (height / shardSize) * shardSize
+	offset := height - shardStart
+	return shardStart + (offset/consolidationWindowBlocks)*consolidationWindowBlocks
+}
+
+func batchConsolidatorCronFullWindowStartAtOrAfter(startHeight uint64, consolidationWindowBlocks uint64, shardSize uint64) uint64 {
+	if consolidationWindowBlocks == 0 || shardSize == 0 {
+		return startHeight
+	}
+	windowEnd := startHeight + consolidationWindowBlocks
+	if windowEnd >= startHeight && windowEnd <= batchConsolidatorCronShardEnd(startHeight, shardSize) {
+		return startHeight
+	}
+	return batchConsolidatorCronShardEnd(startHeight, shardSize)
 }
 
 func batchConsolidatorCronShardEnd(height uint64, shardSize uint64) uint64 {

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -207,10 +207,34 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 			return err
 		}
 		if !bootstrapFound {
+			cursorEnd, cursorEndFound := batchConsolidatorCronRangeEnd(
+				cronConfig.StartHeight,
+				searchEnd,
+				cronConfig.MaxRangeBlocks,
+				consolidation.MaxBlocks,
+				consolidation.ShardSize,
+			)
+			if !cursorEndFound {
+				t.logger.Info(
+					"batch_consolidator cron found no missing consolidation shadow and no full window to bootstrap cursor",
+					zap.Uint32("tag", tag),
+					zap.Uint64("configured_start_height", cronConfig.StartHeight),
+					zap.Uint64("safe_end_height", searchEnd),
+					zap.Uint64("latest_height", latest.GetHeight()),
+					zap.Uint64("safe_consolidation_height", safeHeight),
+					zap.Uint64("max_range_blocks", cronConfig.MaxRangeBlocks),
+					zap.Uint64("consolidation_max_blocks", consolidation.MaxBlocks),
+				)
+				return nil
+			}
+			if err := t.metaStorage.SetBlockConsolidationCursor(ctx, metastorage.BatchConsolidatorAutoConsolidateCursor, tag, cursorEnd); err != nil {
+				return xerrors.Errorf("failed to bootstrap auto_consolidate cursor to height %d: %w", cursorEnd, err)
+			}
 			t.logger.Info(
-				"batch_consolidator cron found no missing consolidation shadow to bootstrap cursor",
+				"batch_consolidator cron bootstrapped cursor from already consolidated range",
 				zap.Uint32("tag", tag),
 				zap.Uint64("configured_start_height", cronConfig.StartHeight),
+				zap.Uint64("cursor_height", cursorEnd),
 				zap.Uint64("safe_end_height", searchEnd),
 				zap.Uint64("latest_height", latest.GetHeight()),
 				zap.Uint64("safe_consolidation_height", safeHeight),

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -132,6 +132,13 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 
 	tag := t.config.GetEffectiveBlockTag(0)
 	searchStart := cronConfig.StartHeight
+	cursorHeight, cursorFound, err := t.metaStorage.GetBlockConsolidationCursor(ctx, metastorage.BatchConsolidatorAutoConsolidateCursor, tag)
+	if err != nil {
+		return xerrors.Errorf("failed to get auto_consolidate cursor: %w", err)
+	}
+	if cursorFound && cursorHeight > searchStart {
+		searchStart = cursorHeight
+	}
 	latest, err := t.metaStorage.GetLatestBlock(ctx, tag)
 	if err != nil {
 		return xerrors.Errorf("failed to get latest block for batch_consolidator cron: %w", err)
@@ -154,6 +161,9 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 			"batch_consolidator cron safe range is below configured start height",
 			zap.Uint32("tag", tag),
 			zap.Uint64("start_height", searchStart),
+			zap.Uint64("configured_start_height", cronConfig.StartHeight),
+			zap.Bool("cursor_found", cursorFound),
+			zap.Uint64("cursor_height", cursorHeight),
 			zap.Uint64("safe_end_height", searchEnd),
 			zap.Uint64("latest_height", latest.GetHeight()),
 			zap.Uint64("safe_consolidation_height", safeHeight),
@@ -161,26 +171,27 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		return nil
 	}
 
-	startHeight, endHeight, found, err := t.nextAutoConsolidateRange(
-		ctx,
-		tag,
+	startHeight := searchStart
+	endHeight, found := batchConsolidatorCronRangeEnd(
 		searchStart,
 		searchEnd,
 		cronConfig.MaxRangeBlocks,
 		consolidation.MaxBlocks,
 		consolidation.ShardSize,
 	)
-	if err != nil {
-		return err
-	}
 	if !found {
 		t.logger.Info(
 			"batch_consolidator cron found no full consolidation window",
 			zap.Uint32("tag", tag),
 			zap.Uint64("start_height", searchStart),
+			zap.Uint64("configured_start_height", cronConfig.StartHeight),
+			zap.Bool("cursor_found", cursorFound),
+			zap.Uint64("cursor_height", cursorHeight),
 			zap.Uint64("end_height", searchEnd),
 			zap.Uint64("latest_height", latest.GetHeight()),
 			zap.Uint64("safe_consolidation_height", safeHeight),
+			zap.Uint64("max_range_blocks", cronConfig.MaxRangeBlocks),
+			zap.Uint64("consolidation_max_blocks", consolidation.MaxBlocks),
 		)
 		return nil
 	}
@@ -207,62 +218,13 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		zap.Uint32("tag", tag),
 		zap.Uint64("start_height", startHeight),
 		zap.Uint64("end_height", endHeight),
+		zap.Uint64("configured_start_height", cronConfig.StartHeight),
+		zap.Bool("cursor_found", cursorFound),
+		zap.Uint64("cursor_height", cursorHeight),
 		zap.Uint64("latest_height", latest.GetHeight()),
 		zap.Uint64("safe_consolidation_height", safeHeight),
 	)
 	return nil
-}
-
-func (t *batchConsolidatorTask) nextAutoConsolidateRange(
-	ctx context.Context,
-	tag uint32,
-	searchStart uint64,
-	searchEnd uint64,
-	maxRangeBlocks uint64,
-	consolidationWindowBlocks uint64,
-	shardSize uint64,
-) (uint64, uint64, bool, error) {
-	for searchStart < searchEnd {
-		startHeight, found, err := t.metaStorage.GetFirstBlockMissingConsolidationShadow(ctx, tag, searchStart, searchEnd)
-		if err != nil {
-			return 0, 0, false, xerrors.Errorf("failed to get first block missing consolidation shadow: %w", err)
-		}
-		if !found {
-			return 0, 0, false, nil
-		}
-		windowStart := batchConsolidatorCronFullWindowStart(startHeight, consolidationWindowBlocks, shardSize)
-		if windowStart >= searchEnd {
-			return 0, 0, false, nil
-		}
-		if windowStart != startHeight {
-			t.logger.Info(
-				"batch_consolidator cron skipped shard tail without a full consolidation window",
-				zap.Uint32("tag", tag),
-				zap.Uint64("missing_height", startHeight),
-				zap.Uint64("next_window_start", windowStart),
-				zap.Uint64("safe_end_height", searchEnd),
-				zap.Uint64("consolidation_max_blocks", consolidationWindowBlocks),
-				zap.Uint64("shard_size", shardSize),
-			)
-			searchStart = windowStart
-			continue
-		}
-		endHeight, fullWindow := batchConsolidatorCronRangeEnd(windowStart, searchEnd, maxRangeBlocks, consolidationWindowBlocks, shardSize)
-		if !fullWindow {
-			t.logger.Info(
-				"batch_consolidator cron waiting for a full consolidation window",
-				zap.Uint32("tag", tag),
-				zap.Uint64("start_height", windowStart),
-				zap.Uint64("safe_end_height", searchEnd),
-				zap.Uint64("max_range_blocks", maxRangeBlocks),
-				zap.Uint64("consolidation_max_blocks", consolidationWindowBlocks),
-				zap.Uint64("shard_size", shardSize),
-			)
-			return 0, 0, false, nil
-		}
-		return windowStart, endHeight, true, nil
-	}
-	return 0, 0, false, nil
 }
 
 func (t *batchConsolidatorTask) autoConsolidateWorkflowID() string {
@@ -296,15 +258,6 @@ func batchConsolidatorCronSafeEndHeight(latestHeight uint64, irreversibleDistanc
 		return safeHeight, safeHeight, true
 	}
 	return safeHeight + 1, safeHeight, true
-}
-
-func batchConsolidatorCronFullWindowStart(startHeight uint64, consolidationWindowBlocks uint64, shardSize uint64) uint64 {
-	shardEnd := batchConsolidatorCronShardEnd(startHeight, shardSize)
-	windowEnd := startHeight + consolidationWindowBlocks
-	if windowEnd >= startHeight && windowEnd <= shardEnd {
-		return startHeight
-	}
-	return shardEnd
 }
 
 func batchConsolidatorCronRangeEnd(startHeight uint64, safeEndHeight uint64, maxRangeBlocks uint64, consolidationWindowBlocks uint64, shardSize uint64) (uint64, bool) {

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -171,9 +171,8 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		return nil
 	}
 
-	repairScanStart := searchStart
 	if cursorFound {
-		repairScanStart = cronConfig.StartHeight
+		repairScanStart := cronConfig.StartHeight
 		if cursorHeight > consolidation.ShardSize && cursorHeight-consolidation.ShardSize > repairScanStart {
 			repairScanStart = cursorHeight - consolidation.ShardSize
 		}

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -227,7 +227,7 @@ func TestBatchConsolidatorCronWaitsWhenCursorHasNoFullNewWindow(t *testing.T) {
 	require.Empty(t, runtime.executions)
 }
 
-func TestBatchConsolidatorCronWaitsWhenNoMissingShadowBootstrapsCursor(t *testing.T) {
+func TestBatchConsolidatorCronBootstrapsCursorWhenNoMissingShadow(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
@@ -242,6 +242,9 @@ func TestBatchConsolidatorCronWaitsWhenNoMissingShadowBootstrapsCursor(t *testin
 	metaStorage.EXPECT().
 		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(11_901)).
 		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		SetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag, uint64(11_000)).
+		Return(nil)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Empty(t, runtime.executions)

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/metastorage"
 	metastoragemocks "github.com/coinbase/chainstorage/internal/storage/metastorage/mocks"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/timesource"
@@ -54,11 +55,14 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 5_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(4_901)).
-		Return(uint64(1_500), true, nil)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Len(t, runtime.executions, 1)
@@ -67,8 +71,8 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
 		Tag:         tag,
-		StartHeight: 1_500,
-		EndHeight:   3_500,
+		StartHeight: 1_000,
+		EndHeight:   3_000,
 	}, runtime.executions[0].request)
 }
 
@@ -80,32 +84,35 @@ func TestBatchConsolidatorCronWaitsForFullConsolidationWindow(t *testing.T) {
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 2_098}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(1_999)).
-		Return(uint64(1_000), true, nil)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Empty(t, runtime.executions)
 }
 
-func TestBatchConsolidatorCronSkipsShardTailWithoutFullConsolidationWindow(t *testing.T) {
+func TestBatchConsolidatorCronUsesPersistedCursor(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
-	cfg.Cron.BatchConsolidator.StartHeight = 9_000
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
 	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(10_000), true, nil)
+	metaStorage.EXPECT().
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 12_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(9_000), uint64(11_901)).
-		Return(uint64(9_500), true, nil)
-	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(10_000), uint64(11_901)).
-		Return(uint64(10_000), true, nil)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Len(t, runtime.executions, 1)
@@ -127,11 +134,14 @@ func TestBatchConsolidatorCronDoesNotCapAutoConsolidateAtPromotionGate(t *testin
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 5_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(4_901)).
-		Return(uint64(1_000), true, nil)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Len(t, runtime.executions, 1)
@@ -143,18 +153,21 @@ func TestBatchConsolidatorCronDoesNotCapAutoConsolidateAtPromotionGate(t *testin
 	}, runtime.executions[0].request)
 }
 
-func TestBatchConsolidatorCronNoOpsWhenNoMissingConsolidationShadowExists(t *testing.T) {
+func TestBatchConsolidatorCronWaitsWhenCursorHasNoFullNewWindow(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(1_000), true, nil)
+	metaStorage.EXPECT().
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 2_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(1_901)).
-		Return(uint64(0), false, nil)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Empty(t, runtime.executions)
@@ -166,6 +179,7 @@ func TestBatchConsolidatorCronSkipsWhenBatchConsolidatorWorkflowIsAlreadyOpen(t 
 	runtime.openWorkflowID = []string{"custom-manual-promote-workflow-id"}
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
 
+	metaStorage.EXPECT().GetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
 	metaStorage.EXPECT().GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
@@ -179,6 +193,7 @@ func TestBatchConsolidatorCronRequiresAutoConsolidateMode(t *testing.T) {
 	defer ctrl.Finish()
 	cfg.AWS.Storage.Consolidation.Mode = config.ConsolidationModePromoteFinalized
 
+	metaStorage.EXPECT().GetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
 	metaStorage.EXPECT().GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -61,8 +61,8 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 5_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Times(0)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(4_901)).
+		Return(uint64(3_500), true, nil)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Len(t, runtime.executions, 1)
@@ -71,8 +71,8 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
 		Tag:         tag,
-		StartHeight: 1_000,
-		EndHeight:   3_000,
+		StartHeight: 3_000,
+		EndHeight:   4_000,
 	}, runtime.executions[0].request)
 }
 
@@ -90,8 +90,8 @@ func TestBatchConsolidatorCronWaitsForFullConsolidationWindow(t *testing.T) {
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 2_098}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Times(0)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(1_999)).
+		Return(uint64(1_000), true, nil)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Empty(t, runtime.executions)
@@ -111,8 +111,8 @@ func TestBatchConsolidatorCronUsesPersistedCursor(t *testing.T) {
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 12_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Times(0)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(10_000)).
+		Return(uint64(0), false, nil)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Len(t, runtime.executions, 1)
@@ -121,6 +121,60 @@ func TestBatchConsolidatorCronUsesPersistedCursor(t *testing.T) {
 		Tag:         tag,
 		StartHeight: 10_000,
 		EndHeight:   11_000,
+	}, runtime.executions[0].request)
+}
+
+func TestBatchConsolidatorCronNormalizesCursorShardTail(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(9_500), true, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 12_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(9_500)).
+		Return(uint64(0), false, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         tag,
+		StartHeight: 10_000,
+		EndHeight:   11_000,
+	}, runtime.executions[0].request)
+}
+
+func TestBatchConsolidatorCronRepairsWithinCursorLookback(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(20_000), true, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 25_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(10_000), uint64(20_000)).
+		Return(uint64(18_500), true, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         tag,
+		StartHeight: 18_000,
+		EndHeight:   24_000,
 	}, runtime.executions[0].request)
 }
 
@@ -140,8 +194,8 @@ func TestBatchConsolidatorCronDoesNotCapAutoConsolidateAtPromotionGate(t *testin
 		GetLatestBlock(gomock.Any(), tag).
 		Return(&api.BlockMetadata{Tag: tag, Height: 5_000}, nil)
 	metaStorage.EXPECT().
-		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Times(0)
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(4_901)).
+		Return(uint64(1_000), true, nil)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Len(t, runtime.executions, 1)
@@ -168,6 +222,26 @@ func TestBatchConsolidatorCronWaitsWhenCursorHasNoFullNewWindow(t *testing.T) {
 	metaStorage.EXPECT().
 		GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestBatchConsolidatorCronWaitsWhenNoMissingShadowBootstrapsCursor(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 12_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(11_901)).
+		Return(uint64(0), false, nil)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Empty(t, runtime.executions)

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -301,6 +301,14 @@ func (a *blockStorageImpl) GetFirstPromotableBlockConsolidationShadow(ctx contex
 	return 0, false, xerrors.New("GetFirstPromotableBlockConsolidationShadow not implemented for DynamoDB")
 }
 
+func (a *blockStorageImpl) GetBlockConsolidationCursor(ctx context.Context, name string, tag uint32) (uint64, bool, error) {
+	return 0, false, xerrors.New("GetBlockConsolidationCursor not implemented for DynamoDB")
+}
+
+func (a *blockStorageImpl) SetBlockConsolidationCursor(ctx context.Context, name string, tag uint32, height uint64) error {
+	return xerrors.New("SetBlockConsolidationCursor not implemented for DynamoDB")
+}
+
 func (a *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context, placements []*internal.ConsolidationShadowPlacement) error {
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for DynamoDB")
 }

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -274,6 +274,14 @@ func (b *blockStorageImpl) GetFirstPromotableBlockConsolidationShadow(ctx contex
 	return 0, false, xerrors.New("GetFirstPromotableBlockConsolidationShadow not implemented for Firestore")
 }
 
+func (b *blockStorageImpl) GetBlockConsolidationCursor(ctx context.Context, name string, tag uint32) (uint64, bool, error) {
+	return 0, false, xerrors.New("GetBlockConsolidationCursor not implemented for Firestore")
+}
+
+func (b *blockStorageImpl) SetBlockConsolidationCursor(ctx context.Context, name string, tag uint32, height uint64) error {
+	return xerrors.New("SetBlockConsolidationCursor not implemented for Firestore")
+}
+
 func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context, placements []*internal.ConsolidationShadowPlacement) error {
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for Firestore")
 }

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -30,6 +30,8 @@ type (
 		GetBlockConsolidationShadowStats(ctx context.Context, tag uint32, startHeight, endHeight uint64) (*ConsolidationShadowStats, error)
 		GetFirstBlockMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error)
 		GetFirstPromotableBlockConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error)
+		GetBlockConsolidationCursor(ctx context.Context, name string, tag uint32) (uint64, bool, error)
+		SetBlockConsolidationCursor(ctx context.Context, name string, tag uint32, height uint64) error
 		PersistBlockConsolidationShadows(ctx context.Context, placements []*ConsolidationShadowPlacement) error
 		PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*ConsolidationPromotionResult, error)
 	}
@@ -111,6 +113,10 @@ type (
 		Firestore MetaStorageFactory `name:"metastorage/firestore"`
 		Postgres  MetaStorageFactory `name:"metastorage/postgres"`
 	}
+)
+
+const (
+	BatchConsolidatorAutoConsolidateCursor = "batch_consolidator_auto_consolidate_processed_exclusive"
 )
 
 func WithMetaStorageFactory(params MetaStorageFactoryParams) (Result, error) {

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -129,6 +129,22 @@ func (mr *MockMetaStorageMockRecorder) GetBlockByTimestamp(arg0, arg1, arg2 any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByTimestamp", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockByTimestamp), arg0, arg1, arg2)
 }
 
+// GetBlockConsolidationCursor mocks base method.
+func (m *MockMetaStorage) GetBlockConsolidationCursor(arg0 context.Context, arg1 string, arg2 uint32) (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockConsolidationCursor", arg0, arg1, arg2)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBlockConsolidationCursor indicates an expected call of GetBlockConsolidationCursor.
+func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationCursor(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationCursor", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationCursor), arg0, arg1, arg2)
+}
+
 // GetBlockConsolidationShadow mocks base method.
 func (m *MockMetaStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -414,6 +430,20 @@ func (mr *MockMetaStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockMetaStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4)
 }
 
+// SetBlockConsolidationCursor mocks base method.
+func (m *MockMetaStorage) SetBlockConsolidationCursor(arg0 context.Context, arg1 string, arg2 uint32, arg3 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetBlockConsolidationCursor", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetBlockConsolidationCursor indicates an expected call of SetBlockConsolidationCursor.
+func (mr *MockMetaStorageMockRecorder) SetBlockConsolidationCursor(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBlockConsolidationCursor", reflect.TypeOf((*MockMetaStorage)(nil).SetBlockConsolidationCursor), arg0, arg1, arg2, arg3)
+}
+
 // SetMaxEventId mocks base method.
 func (m *MockMetaStorage) SetMaxEventId(arg0 context.Context, arg1 uint32, arg2 int64) error {
 	m.ctrl.T.Helper()
@@ -651,6 +681,22 @@ func (mr *MockBlockStorageMockRecorder) GetBlockByTimestamp(arg0, arg1, arg2 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByTimestamp", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockByTimestamp), arg0, arg1, arg2)
 }
 
+// GetBlockConsolidationCursor mocks base method.
+func (m *MockBlockStorage) GetBlockConsolidationCursor(arg0 context.Context, arg1 string, arg2 uint32) (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockConsolidationCursor", arg0, arg1, arg2)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBlockConsolidationCursor indicates an expected call of GetBlockConsolidationCursor.
+func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationCursor(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationCursor", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationCursor), arg0, arg1, arg2)
+}
+
 // GetBlockConsolidationShadow mocks base method.
 func (m *MockBlockStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -829,6 +875,20 @@ func (m *MockBlockStorage) PromoteBlockConsolidationShadows(arg0 context.Context
 func (mr *MockBlockStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockBlockStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4)
+}
+
+// SetBlockConsolidationCursor mocks base method.
+func (m *MockBlockStorage) SetBlockConsolidationCursor(arg0 context.Context, arg1 string, arg2 uint32, arg3 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetBlockConsolidationCursor", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetBlockConsolidationCursor indicates an expected call of SetBlockConsolidationCursor.
+func (mr *MockBlockStorageMockRecorder) SetBlockConsolidationCursor(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBlockConsolidationCursor", reflect.TypeOf((*MockBlockStorage)(nil).SetBlockConsolidationCursor), arg0, arg1, arg2, arg3)
 }
 
 // MockTransactionStorage is a mock of TransactionStorage interface.

--- a/internal/storage/metastorage/module.go
+++ b/internal/storage/metastorage/module.go
@@ -25,6 +25,8 @@ type (
 const (
 	EventIdStartValue = model.EventIdStartValue
 	EventIdDeleted    = model.EventIdDeleted
+
+	BatchConsolidatorAutoConsolidateCursor = internal.BatchConsolidatorAutoConsolidateCursor
 )
 
 func NewEventsToChainAdaptor() *EventsToChainAdaptor {

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -859,6 +859,40 @@ func (b *blockStorageImpl) GetFirstPromotableBlockConsolidationShadow(ctx contex
 	return height, true, nil
 }
 
+func (b *blockStorageImpl) GetBlockConsolidationCursor(ctx context.Context, name string, tag uint32) (uint64, bool, error) {
+	if name == "" {
+		return 0, false, xerrors.New("block consolidation cursor name must be non-empty")
+	}
+	const query = `
+		SELECT height
+		FROM block_consolidation_cursor
+		WHERE name = $1 AND tag = $2`
+	var height uint64
+	if err := b.db.QueryRowContext(ctx, query, name, tag).Scan(&height); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, false, nil
+		}
+		return 0, false, xerrors.Errorf("failed to get block consolidation cursor %q for tag %d: %w", name, tag, err)
+	}
+	return height, true, nil
+}
+
+func (b *blockStorageImpl) SetBlockConsolidationCursor(ctx context.Context, name string, tag uint32, height uint64) error {
+	if name == "" {
+		return xerrors.New("block consolidation cursor name must be non-empty")
+	}
+	const query = `
+		INSERT INTO block_consolidation_cursor (name, tag, height, updated_at)
+		VALUES ($1, $2, $3, NOW())
+		ON CONFLICT (name, tag) DO UPDATE SET
+			height = GREATEST(block_consolidation_cursor.height, EXCLUDED.height),
+			updated_at = NOW()`
+	if _, err := b.db.ExecContext(ctx, query, name, tag, height); err != nil {
+		return xerrors.Errorf("failed to set block consolidation cursor %q for tag %d to height %d: %w", name, tag, height, err)
+	}
+	return nil
+}
+
 func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context, placements []*internal.ConsolidationShadowPlacement) error {
 	if len(placements) == 0 {
 		return nil

--- a/internal/storage/metastorage/postgres/db/migrations/20260702000001_add_block_consolidation_cursor.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260702000001_add_block_consolidation_cursor.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS block_consolidation_cursor (
+    name TEXT NOT NULL,
+    tag INTEGER NOT NULL,
+    height BIGINT NOT NULL CHECK (height >= 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (name, tag)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS block_consolidation_cursor;

--- a/internal/workflow/activity/activity.go
+++ b/internal/workflow/activity/activity.go
@@ -33,6 +33,7 @@ const (
 	ActivityBatchConsolidatorStats       = "activity.batch_consolidator.stats"
 	ActivityBatchConsolidatorLatestBlock = "activity.batch_consolidator.latest_block"
 	ActivityBatchConsolidatorPlan        = "activity.batch_consolidator.plan"
+	ActivityBatchConsolidatorCursor      = "activity.batch_consolidator.cursor"
 
 	loggerMsg = "activity.request"
 

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -28,6 +28,7 @@ type (
 		statsActivity       baseActivity
 		latestBlockActivity baseActivity
 		planActivity        baseActivity
+		cursorActivity      baseActivity
 		config              *config.Config
 		metaStorage         metastorage.MetaStorage
 		blobStorage         blobstorage.BlobStorage
@@ -93,6 +94,16 @@ type (
 		SafePromotionHeight uint64
 		PromotionGateHeight uint64
 	}
+
+	BatchConsolidatorCursorRequest struct {
+		Tag    uint32
+		Height uint64
+	}
+
+	BatchConsolidatorCursorResponse struct {
+		Tag    uint32
+		Height uint64
+	}
 )
 
 func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
@@ -101,6 +112,7 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 		statsActivity:       newBaseActivity(ActivityBatchConsolidatorStats, params.Runtime),
 		latestBlockActivity: newBaseActivity(ActivityBatchConsolidatorLatestBlock, params.Runtime),
 		planActivity:        newBaseActivity(ActivityBatchConsolidatorPlan, params.Runtime),
+		cursorActivity:      newBaseActivity(ActivityBatchConsolidatorCursor, params.Runtime),
 		config:              params.Config,
 		metaStorage:         params.MetaStorage,
 		blobStorage:         params.BlobStorage,
@@ -109,6 +121,7 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 	a.statsActivity.register(a.executeStats)
 	a.latestBlockActivity.register(a.executeLatestBlock)
 	a.planActivity.register(a.executePlan)
+	a.cursorActivity.register(a.executeCursor)
 	return a
 }
 
@@ -136,6 +149,12 @@ func (a *BatchConsolidator) GetLatestBlock(ctx workflow.Context, request *BatchC
 func (a *BatchConsolidator) GetPromotionPlan(ctx workflow.Context, request *BatchConsolidatorPlanRequest) (*BatchConsolidatorPlanResponse, error) {
 	var response BatchConsolidatorPlanResponse
 	err := a.planActivity.executeActivity(ctx, request, &response)
+	return &response, err
+}
+
+func (a *BatchConsolidator) UpdateAutoConsolidateCursor(ctx workflow.Context, request *BatchConsolidatorCursorRequest) (*BatchConsolidatorCursorResponse, error) {
+	var response BatchConsolidatorCursorResponse
+	err := a.cursorActivity.executeActivity(ctx, request, &response)
 	return &response, err
 }
 
@@ -195,6 +214,19 @@ func (a *BatchConsolidator) executePlan(ctx context.Context, request *BatchConso
 	return a.planPromoteFinalized(ctx, request.Tag, request.StartHeight, request.EndHeight)
 }
 
+func (a *BatchConsolidator) executeCursor(ctx context.Context, request *BatchConsolidatorCursorRequest) (*BatchConsolidatorCursorResponse, error) {
+	if err := a.cursorActivity.validateRequest(request); err != nil {
+		return nil, err
+	}
+	if err := a.metaStorage.SetBlockConsolidationCursor(ctx, metastorage.BatchConsolidatorAutoConsolidateCursor, request.Tag, request.Height); err != nil {
+		return nil, xerrors.Errorf("failed to update auto_consolidate cursor: %w", err)
+	}
+	return &BatchConsolidatorCursorResponse{
+		Tag:    request.Tag,
+		Height: request.Height,
+	}, nil
+}
+
 func (a *BatchConsolidator) execute(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {
 	if err := a.validateRequest(request); err != nil {
 		return nil, err
@@ -239,23 +271,6 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	scanDuration := time.Since(scanStart)
 	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
-		return &BatchConsolidatorResponse{
-			StartHeight: request.StartHeight,
-			EndHeight:   request.EndHeight,
-		}, nil
-	}
-	mode := request.Mode
-	if mode == "" {
-		mode = a.config.AWS.Storage.Consolidation.Mode
-	}
-	if mode.IsAutoConsolidate() && !isFullContiguousConsolidationWindow(records, request.StartHeight, request.MaxBlocks) {
-		logger.Info(
-			"auto consolidate waiting for a full contiguous consolidation window",
-			zap.Uint64("start_height", request.StartHeight),
-			zap.Uint64("end_height", request.EndHeight),
-			zap.Uint64("max_blocks", request.MaxBlocks),
-			zap.Int("records", len(records)),
-		)
 		return &BatchConsolidatorResponse{
 			StartHeight: request.StartHeight,
 			EndHeight:   request.EndHeight,
@@ -454,22 +469,6 @@ func (a *BatchConsolidator) validateShadowWriteMode(mode config.ConsolidationMod
 
 func (a *BatchConsolidator) validateShadowStatsMode(mode config.ConsolidationMode) error {
 	return a.validateShadowWriteMode(mode)
-}
-
-func isFullContiguousConsolidationWindow(records []*metastorage.BlockMetadataRecord, startHeight uint64, maxBlocks uint64) bool {
-	if maxBlocks == 0 || uint64(len(records)) != maxBlocks {
-		return false
-	}
-	for i, record := range records {
-		if record == nil || record.Metadata == nil {
-			return false
-		}
-		expectedHeight := startHeight + uint64(i)
-		if expectedHeight < startHeight || record.Metadata.GetHeight() != expectedHeight {
-			return false
-		}
-	}
-	return true
 }
 
 func (a *BatchConsolidator) validatePromoteFinalizedMode() error {

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -225,10 +225,11 @@ func (s *BatchConsolidatorTestSuite) TestConsolidatesAndPersistsShadowPlacements
 	}
 }
 
-func (s *BatchConsolidatorTestSuite) TestAutoConsolidateWaitsForFullContiguousWindow() {
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateConsolidatesNonContiguousWindowRecords() {
 	require := testutil.Require(s.T())
-	records, _ := makeConsolidatorFixture(3, 1000)
+	records, blocks := makeConsolidatorFixture(3, 1000)
 	records = []*metastorage.BlockMetadataRecord{records[0], records[2]}
+	blocks = []*api.Block{blocks[0], blocks[2]}
 	request := &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
 		Tag:         records[0].Metadata.GetTag(),
@@ -236,16 +237,76 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateWaitsForFullContiguousWi
 		EndHeight:   1003,
 		MaxBlocks:   3,
 	}
+	objectKey := "consolidated/v=000000000001/shard=000000001000-000000001999/000000001000-000000001003-sha.zstd"
+	placements := []blobstorage.BlockPlacement{
+		{
+			MetadataID:         records[0].ID,
+			Height:             records[0].Metadata.GetHeight(),
+			Hash:               records[0].Metadata.GetHash(),
+			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:         0,
+			ByteLength:         100,
+			UncompressedLength: 100,
+		},
+		{
+			MetadataID:         records[1].ID,
+			Height:             records[1].Metadata.GetHeight(),
+			Hash:               records[1].Metadata.GetHash(),
+			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:         100,
+			ByteLength:         110,
+			UncompressedLength: 110,
+		},
+	}
+	expectedShadows := []*metastorage.ConsolidationShadowPlacement{
+		{
+			BlockMetadataID:           records[0].ID,
+			Tag:                       records[0].Metadata.GetTag(),
+			Height:                    records[0].Metadata.GetHeight(),
+			Hash:                      records[0].Metadata.GetHash(),
+			LegacyObjectKeyMain:       records[0].Metadata.GetObjectKeyMain(),
+			ConsolidatedObjectKeyMain: objectKey,
+			ObjectFormat:              api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:                0,
+			ByteLength:                100,
+			UncompressedLength:        100,
+		},
+		{
+			BlockMetadataID:           records[1].ID,
+			Tag:                       records[1].Metadata.GetTag(),
+			Height:                    records[1].Metadata.GetHeight(),
+			Hash:                      records[1].Metadata.GetHash(),
+			LegacyObjectKeyMain:       records[1].Metadata.GetObjectKeyMain(),
+			ConsolidatedObjectKeyMain: objectKey,
+			ObjectFormat:              api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:                100,
+			ByteLength:                110,
+			UncompressedLength:        110,
+		},
+	}
+	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
 
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
+	for i, record := range records {
+		s.blobStorage.EXPECT().Download(gomock.Any(), record.Metadata).Return(blocks[i], nil)
+	}
+	s.blobStorage.EXPECT().
+		UploadConsolidated(gomock.Any(), consolidatedPayloadsMatch(blocks, []int64{records[0].ID, records[1].ID})).
+		Return(objectKey, placements, nil)
+	s.metaStorage.EXPECT().
+		PersistBlockConsolidationShadows(gomock.Any(), expectedShadows).
+		Return(nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
 	require.Equal(&BatchConsolidatorResponse{
-		StartHeight: request.StartHeight,
-		EndHeight:   request.EndHeight,
+		StartHeight:        request.StartHeight,
+		EndHeight:          request.EndHeight,
+		ScannedBlocks:      2,
+		ConsolidatedBlocks: 2,
+		ObjectKey:          objectKey,
 	}, response)
 }
 
@@ -340,6 +401,24 @@ func (s *BatchConsolidatorTestSuite) TestGetLatestBlockRejectsNilMetastoreLatest
 	require.Error(err)
 	require.Nil(response)
 	require.Contains(err.Error(), "latest block not found")
+}
+
+func (s *BatchConsolidatorTestSuite) TestUpdateAutoConsolidateCursorPersistsExclusiveHeight() {
+	require := testutil.Require(s.T())
+	request := &BatchConsolidatorCursorRequest{
+		Tag:    2,
+		Height: 11_000,
+	}
+	s.metaStorage.EXPECT().
+		SetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, request.Tag, request.Height).
+		Return(nil)
+
+	response, err := s.batchConsolidator.UpdateAutoConsolidateCursor(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorCursorResponse{
+		Tag:    request.Tag,
+		Height: request.Height,
+	}, response)
 }
 
 func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPromotesShadows() {

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -158,6 +158,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		logger.Info("workflow started")
 		ctx = w.withActivityOptions(ctx)
 		statsCtx := w.withShadowStatsActivityOptions(ctx, cfg)
+		cursorCtx := w.withCursorActivityOptions(ctx, cfg)
 		usePersistedShadowStats := workflow.GetVersion(
 			ctx,
 			batchConsolidatorShadowStatsChangeID,
@@ -420,7 +421,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		}
 
 		if mode.IsAutoConsolidate() && autoConsolidateVersion != workflow.DefaultVersion {
-			if _, err := w.batchConsolidator.UpdateAutoConsolidateCursor(ctx, &activity.BatchConsolidatorCursorRequest{
+			if _, err := w.batchConsolidator.UpdateAutoConsolidateCursor(cursorCtx, &activity.BatchConsolidatorCursorRequest{
 				Tag:    tag,
 				Height: workflowEndHeight,
 			}); err != nil {
@@ -915,6 +916,34 @@ func (w *BatchConsolidator) getShadowStatsActivityRetryPolicy(cfg *config.RetryP
 		// Stats reads are side-effect-free and cheap. Unlimited attempts prevent
 		// old workers on the shared task queue from exhausting retries during a
 		// rolling deploy before a new worker polls the new stats activity name.
+		retryPolicyCopy.MaximumAttempts = 0
+		retryPolicy = &retryPolicyCopy
+	}
+	return retryPolicy
+}
+
+func (w *BatchConsolidator) withCursorActivityOptions(
+	ctx workflow.Context,
+	cfg config.BatchConsolidatorWorkflowConfig,
+) workflow.Context {
+	base := cfg.Base()
+	retryPolicy := w.getCursorActivityRetryPolicy(base.ActivityRetry)
+	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		TaskQueue:              base.TaskList,
+		StartToCloseTimeout:    base.ActivityStartToCloseTimeout,
+		ScheduleToCloseTimeout: base.ActivityScheduleToCloseTimeout,
+		HeartbeatTimeout:       base.ActivityHeartbeatTimeout,
+		RetryPolicy:            retryPolicy,
+	})
+}
+
+func (w *BatchConsolidator) getCursorActivityRetryPolicy(cfg *config.RetryPolicy) *temporal.RetryPolicy {
+	retryPolicy := w.getRetryPolicy(cfg)
+	if retryPolicy != nil {
+		retryPolicyCopy := *retryPolicy
+		// Cursor writes are monotonic and idempotent. Unlimited attempts prevent
+		// old workers on the shared task queue from exhausting retries during a
+		// rolling deploy before a new worker polls the new cursor activity name.
 		retryPolicyCopy.MaximumAttempts = 0
 		retryPolicy = &retryPolicyCopy
 	}

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -62,6 +62,8 @@ const (
 	batchConsolidatorHistoricalParallelismVersion  = 1
 	batchConsolidatorAutoSerialChangeID            = "batch-consolidator-auto-serial"
 	batchConsolidatorAutoSerialVersion             = 1
+	batchConsolidatorAutoCursorChangeID            = "batch-consolidator-auto-cursor"
+	batchConsolidatorAutoCursorVersion             = 1
 	batchConsolidatorMaxParallelism                = 10
 	maxUint64                                      = ^uint64(0)
 )
@@ -183,6 +185,15 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				batchConsolidatorAutoSerialVersion,
 			)
 		}
+		autoConsolidateCursorVersion := workflow.DefaultVersion
+		if mode.IsAutoConsolidate() {
+			autoConsolidateCursorVersion = workflow.GetVersion(
+				ctx,
+				batchConsolidatorAutoCursorChangeID,
+				workflow.DefaultVersion,
+				batchConsolidatorAutoCursorVersion,
+			)
+		}
 
 		if historicalBackfillVersion != workflow.DefaultVersion {
 			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
@@ -193,7 +204,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			if err := w.validateAutoConsolidateRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
 				return err
 			}
-			if autoConsolidateVersion != workflow.DefaultVersion &&
+			if autoConsolidateCursorVersion != workflow.DefaultVersion &&
 				!batchConsolidatorAutoRangeHasOnlyFullObjectWindows(request.StartHeight, request.EndHeight, batchSize, maxBlocks, shardSize) {
 				return xerrors.Errorf(
 					"auto_consolidate range [%d, %d) must contain only full object windows of max_blocks=%d",
@@ -277,10 +288,11 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				continue
 			}
 
-			if mode.IsAutoConsolidate() {
-				autoConsolidateParallelism := parallelism
-				if autoConsolidateVersion != workflow.DefaultVersion {
-					autoConsolidateParallelism = 1
+			if mode.IsAutoConsolidate() &&
+				(autoConsolidateCursorVersion != workflow.DefaultVersion || autoConsolidateVersion == workflow.DefaultVersion) {
+				autoConsolidateParallelism := 1
+				if autoConsolidateCursorVersion == workflow.DefaultVersion {
+					autoConsolidateParallelism = parallelism
 				}
 				objectsInBatch, blocksInBatch, err := w.processAutoConsolidateBatchParallel(
 					ctx,
@@ -420,7 +432,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			batchStart = batchEnd
 		}
 
-		if mode.IsAutoConsolidate() && autoConsolidateVersion != workflow.DefaultVersion {
+		if mode.IsAutoConsolidate() && autoConsolidateCursorVersion != workflow.DefaultVersion {
 			if _, err := w.batchConsolidator.UpdateAutoConsolidateCursor(cursorCtx, &activity.BatchConsolidatorCursorRequest{
 				Tag:    tag,
 				Height: workflowEndHeight,

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -192,6 +192,15 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			if err := w.validateAutoConsolidateRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
 				return err
 			}
+			if autoConsolidateVersion != workflow.DefaultVersion &&
+				!batchConsolidatorAutoRangeHasOnlyFullObjectWindows(request.StartHeight, request.EndHeight, batchSize, maxBlocks, shardSize) {
+				return xerrors.Errorf(
+					"auto_consolidate range [%d, %d) must contain only full object windows of max_blocks=%d",
+					request.StartHeight,
+					request.EndHeight,
+					maxBlocks,
+				)
+			}
 		}
 
 		workflowEndHeight := request.EndHeight
@@ -267,7 +276,11 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				continue
 			}
 
-			if mode.IsAutoConsolidate() && autoConsolidateVersion == workflow.DefaultVersion {
+			if mode.IsAutoConsolidate() {
+				autoConsolidateParallelism := parallelism
+				if autoConsolidateVersion != workflow.DefaultVersion {
+					autoConsolidateParallelism = 1
+				}
 				objectsInBatch, blocksInBatch, err := w.processAutoConsolidateBatchParallel(
 					ctx,
 					statsCtx,
@@ -278,7 +291,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 					batchStart,
 					batchEnd,
 					maxBlocks,
-					parallelism,
+					autoConsolidateParallelism,
 					usePersistedShadowStats,
 				)
 				if err != nil {
@@ -404,6 +417,16 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				zap.Uint64("consolidated_blocks", blocksInBatch),
 			)
 			batchStart = batchEnd
+		}
+
+		if mode.IsAutoConsolidate() && autoConsolidateVersion != workflow.DefaultVersion {
+			if _, err := w.batchConsolidator.UpdateAutoConsolidateCursor(ctx, &activity.BatchConsolidatorCursorRequest{
+				Tag:    tag,
+				Height: workflowEndHeight,
+			}); err != nil {
+				return xerrors.Errorf("failed to update auto_consolidate cursor to height %d: %w", workflowEndHeight, err)
+			}
+			logger.Info("updated auto_consolidate cursor", zap.Uint32("tag", tag), zap.Uint64("height", workflowEndHeight))
 		}
 
 		logger.Info("workflow finished")
@@ -924,6 +947,27 @@ func batchConsolidatorFullObjectWindowEnd(startHeight uint64, batchEnd uint64, m
 		return batchEnd, false
 	}
 	return windowEnd, true
+}
+
+func batchConsolidatorAutoRangeHasOnlyFullObjectWindows(startHeight uint64, endHeight uint64, batchSize uint64, maxBlocks uint64, shardSize uint64) bool {
+	if endHeight <= startHeight || batchSize == 0 || maxBlocks == 0 || shardSize == 0 {
+		return false
+	}
+	for batchStart := startHeight; batchStart < endHeight; {
+		batchEnd := batchConsolidatorWindowEnd(batchStart, endHeight, batchSize, shardSize)
+		if batchEnd <= batchStart {
+			return false
+		}
+		for windowStart := batchStart; windowStart < batchEnd; {
+			windowEnd, fullWindow := batchConsolidatorFullObjectWindowEnd(windowStart, batchEnd, maxBlocks)
+			if !fullWindow || windowEnd <= windowStart {
+				return false
+			}
+			windowStart = windowEnd
+		}
+		batchStart = batchEnd
+	}
+	return true
 }
 
 func batchConsolidatorShardEnd(height uint64, shardSize uint64) uint64 {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -309,6 +309,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateValidatesFinalizedRange(
 	var requests []*activity.BatchConsolidatorRequest
 	s.mockAutoConsolidateLatestHeight(120)
 	s.mockEmptyShadowStats()
+	s.mockAutoConsolidateCursorUpdate(111)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
@@ -409,6 +410,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDuplicateRunNoOpsWhenSca
 	var requests []*activity.BatchConsolidatorRequest
 	s.mockAutoConsolidateLatestHeight(120)
 	s.mockEmptyShadowStats()
+	s.mockAutoConsolidateCursorUpdate(111)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
@@ -430,21 +432,47 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDuplicateRunNoOpsWhenSca
 	require.Equal(config.ConsolidationModeAutoConsolidate, requests[0].Mode)
 }
 
-func (s *batchConsolidatorTestSuite) TestAutoConsolidateLeavesWindowSelectionToSerialActivity() {
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateProcessesFullObjectWindowsSerially() {
 	require := testutil.Require(s.T())
 
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
 	var requests []*activity.BatchConsolidatorRequest
-	s.mockAutoConsolidateLatestHeight(120)
+	s.mockAutoConsolidateLatestHeight(220)
 	s.mockEmptyShadowStats()
+	s.mockAutoConsolidateCursorUpdate(200)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
 			return &activity.BatchConsolidatorResponse{
-				StartHeight: request.StartHeight,
-				EndHeight:   request.EndHeight,
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
 			}, nil
 		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+	})
+	require.NoError(err)
+	require.Equal([]*activity.BatchConsolidatorRequest{
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 125, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 125, EndHeight: 150, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 150, EndHeight: 175, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 175, EndHeight: 200, MaxBlocks: 25},
+	}, requests)
+}
+
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateRejectsPartialObjectWindowRange() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.mockAutoConsolidateLatestHeight(120)
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
@@ -453,15 +481,8 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateLeavesWindowSelectionToS
 		EndHeight:   111,
 		MaxBlocks:   25,
 	})
-	require.NoError(err)
-	require.Len(requests, 1)
-	require.Equal(&activity.BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeAutoConsolidate,
-		Tag:         2,
-		StartHeight: 100,
-		EndHeight:   111,
-		MaxBlocks:   25,
-	}, requests[0])
+	require.Error(err)
+	require.Contains(err.Error(), "must contain only full object windows")
 }
 
 func (s *batchConsolidatorTestSuite) TestHistoricalBackfillProcessesObjectWindowsInParallel() {
@@ -582,22 +603,17 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 	normalCalls := 0
 	s.mockAutoConsolidateLatestHeight(220)
 	s.mockEmptyShadowStats()
+	s.mockAutoConsolidateCursorUpdate(200)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
 			normalCalls++
-			if normalCalls == 1 {
-				return &activity.BatchConsolidatorResponse{
-					StartHeight:        request.StartHeight,
-					EndHeight:          request.EndHeight,
-					ScannedBlocks:      request.MaxBlocks,
-					ConsolidatedBlocks: request.MaxBlocks,
-					ObjectKey:          "consolidated/object.zstd",
-				}, nil
-			}
 			return &activity.BatchConsolidatorResponse{
-				StartHeight: request.StartHeight,
-				EndHeight:   request.EndHeight,
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
 			}, nil
 		})
 
@@ -610,16 +626,13 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 		Parallelism: 4,
 	})
 	require.NoError(err)
-	require.Len(requests, 2)
-	for _, request := range requests {
-		require.Equal(&activity.BatchConsolidatorRequest{
-			Mode:        config.ConsolidationModeAutoConsolidate,
-			Tag:         2,
-			StartHeight: 100,
-			EndHeight:   200,
-			MaxBlocks:   25,
-		}, request)
-	}
+	require.Equal(4, normalCalls)
+	require.Equal([]*activity.BatchConsolidatorRequest{
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 125, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 125, EndHeight: 150, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 150, EndHeight: 175, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 175, EndHeight: 200, MaxBlocks: 25},
+	}, requests)
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesParallelObjectWindows() {
@@ -697,6 +710,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateResumeAfterLostActivityC
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
 	var requests []*activity.BatchConsolidatorRequest
 	s.mockAutoConsolidateLatestHeight(120)
+	s.mockAutoConsolidateCursorUpdate(111)
 	statsCalls := 0
 	s.env.OnActivity(activity.ActivityBatchConsolidatorStats, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorStatsRequest) (*activity.BatchConsolidatorStatsResponse, error) {
@@ -980,6 +994,19 @@ func (s *batchConsolidatorTestSuite) mockAutoConsolidateLatestHeight(height uint
 			return &activity.BatchConsolidatorLatestBlockResponse{
 				Tag:    request.Tag,
 				Height: height,
+			}, nil
+		})
+}
+
+func (s *batchConsolidatorTestSuite) mockAutoConsolidateCursorUpdate(height uint64) {
+	s.env.OnActivity(activity.ActivityBatchConsolidatorCursor, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorCursorRequest) (*activity.BatchConsolidatorCursorResponse, error) {
+			require := testutil.Require(s.T())
+			require.Equal(uint64(2), uint64(request.Tag))
+			require.Equal(height, request.Height)
+			return &activity.BatchConsolidatorCursorResponse{
+				Tag:    request.Tag,
+				Height: request.Height,
 			}, nil
 		})
 }

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -649,6 +649,11 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesP
 		temporalworkflow.DefaultVersion,
 		batchConsolidatorAutoSerialVersion,
 	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnGetVersion(
+		batchConsolidatorAutoCursorChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoCursorVersion,
+	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
@@ -702,6 +707,58 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesP
 		EndHeight:   200,
 		MaxBlocks:   25,
 	}, requests[3])
+}
+
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateSerialVersionWithoutCursorPreservesOldScanner() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
+	var requests []*activity.BatchConsolidatorRequest
+	s.mockAutoConsolidateLatestHeight(220)
+	s.mockEmptyShadowStats()
+	s.env.OnGetVersion(
+		batchConsolidatorAutoSerialChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoSerialVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorAutoSerialVersion))
+	s.env.OnGetVersion(
+		batchConsolidatorAutoCursorChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoCursorVersion,
+	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			if len(requests) == 1 {
+				return &activity.BatchConsolidatorResponse{
+					StartHeight:        request.StartHeight,
+					EndHeight:          request.EndHeight,
+					ScannedBlocks:      request.EndHeight - request.StartHeight,
+					ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+					ObjectKey:          "consolidated/object.zstd",
+				}, nil
+			}
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: 4,
+	})
+	require.NoError(err)
+	require.Equal([]*activity.BatchConsolidatorRequest{
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 200, MaxBlocks: 25},
+		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 200, MaxBlocks: 25},
+	}, requests)
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateResumeAfterLostActivityCompletion() {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -978,6 +978,21 @@ func (s *batchConsolidatorTestSuite) TestShadowStatsActivityRetryPolicyUsesUnlim
 	require.Equal(int32(3), activityRetry.MaximumAttempts)
 }
 
+func (s *batchConsolidatorTestSuite) TestCursorActivityRetryPolicyUsesUnlimitedAttempts() {
+	require := testutil.Require(s.T())
+
+	activityRetry := s.cfg.Workflows.BatchConsolidator.ActivityRetry
+	activityRetry.MaximumAttempts = 3
+	policy := s.batchConsolidator.getCursorActivityRetryPolicy(activityRetry)
+
+	require.NotNil(policy)
+	require.Equal(int32(0), policy.MaximumAttempts)
+	require.Equal(activityRetry.BackoffCoefficient, policy.BackoffCoefficient)
+	require.Equal(activityRetry.InitialInterval, policy.InitialInterval)
+	require.Equal(activityRetry.MaximumInterval, policy.MaximumInterval)
+	require.Equal(int32(3), activityRetry.MaximumAttempts)
+}
+
 func (s *batchConsolidatorTestSuite) mockEmptyShadowStats() {
 	s.env.OnActivity(activity.ActivityBatchConsolidatorStats, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorStatsRequest) (*activity.BatchConsolidatorStatsResponse, error) {


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046

## Summary

Fix normal CSCB auto consolidation so the scheduled workflow is cursor-driven instead of searching for the first missing consolidation shadow.

- Add a Postgres-backed `block_consolidation_cursor` table for the auto-consolidate processed exclusive height.
- Make the cron scheduler read the cursor, fall back to configured `start_height`, and start exactly one full-window range capped by safe tip and `max_range_blocks`.
- Remove the old first-missing-shadow scheduler path so skipped-block holes cannot hold the normal cursor or create confusing partial repairs.
- Make new `auto_consolidate` workflow histories process fixed object windows serially, ignore requested parallelism, reject partial auto ranges, and update the cursor only after successful workflow completion.
- Allow auto consolidation activity to consolidate non-contiguous missing records in a full height window, so skipped blocks do not block the rest of the file.

## Root Cause

The normal cron path was still using first-missing-shadow lookup plus an activity-side contiguous-record gate. On Solana, skipped blocks make the missing-record set non-contiguous, so scheduled `auto_consolidate` could complete a narrow object and leave holes across the rest of the selected range.

## Deploy Notes

The migration is additive and backward compatible: it creates a new cursor table only. Run the migration before re-enabling `CHAINSTORAGE_CRON_BATCH_CONSOLIDATOR_ENABLED` in prod so the scheduler has a durable cursor. Prod Solana auto-consolidate cron is currently paused by env override until this fix is deployed.

## Validation

- `TEST_TYPE=unit go test ./internal/cron ./internal/workflow ./internal/workflow/activity ./internal/storage/metastorage/postgres ./internal/storage/metastorage/dynamodb ./internal/storage/metastorage/firestore`
- `go vet -printfuncs=wrapf,statusf,warnf,infof,debugf,failf,equalf,containsf,fprintf,sprintf ./internal/cron ./internal/workflow ./internal/workflow/activity ./internal/storage/metastorage/postgres ./internal/storage/metastorage/dynamodb ./internal/storage/metastorage/firestore`
- `git diff --check`
