### PR TITLE
fix(INF-1037): tune Temporal client keepalive

### DIFF
--- a/config/chainstorage/solana/mainnet/production.yml
+++ b/config/chainstorage/solana/mainnet/production.yml
@@ -4,6 +4,8 @@ aws:
   bucket: example-chainstorage-solana-mainnet-prod
 cadence:
   address: temporal.example.com:7233
+  keep_alive_time: 10s
+  keep_alive_timeout: 30s
 server:
   bind_address: 0.0.0.0:9090
 workflows:

--- a/config_templates/config/chainstorage/solana/mainnet/production.template.yml
+++ b/config_templates/config/chainstorage/solana/mainnet/production.template.yml
@@ -1,5 +1,8 @@
 aws:
   aws_account: production
+cadence:
+  keep_alive_time: 10s
+  keep_alive_timeout: 30s
 workflows:
   backfiller:
     num_concurrent_extractors: 150

--- a/internal/cadence/runtime.go
+++ b/internal/cadence/runtime.go
@@ -63,11 +63,6 @@ type (
 	listOpenWorkflowsFn func(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
 )
 
-const (
-	temporalClientKeepAliveTime    = 10 * time.Second
-	temporalClientKeepAliveTimeout = 30 * time.Second
-)
-
 func NewRuntime(params RuntimeParams) (Runtime, error) {
 	if params.TestEnv != nil {
 		return newTestRuntime(params.TestEnv, params.Logger)
@@ -123,9 +118,12 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 }
 
 func newConnectionOptions(address string, cadenceConfig config.CadenceConfig, env config.Env) (client.ConnectionOptions, error) {
-	connectionOptions := client.ConnectionOptions{
-		KeepAliveTime:    temporalClientKeepAliveTime,
-		KeepAliveTimeout: temporalClientKeepAliveTimeout,
+	connectionOptions := client.ConnectionOptions{}
+	if cadenceConfig.KeepAliveTime > 0 {
+		connectionOptions.KeepAliveTime = cadenceConfig.KeepAliveTime
+	}
+	if cadenceConfig.KeepAliveTimeout > 0 {
+		connectionOptions.KeepAliveTimeout = cadenceConfig.KeepAliveTimeout
 	}
 
 	tlsConfig := cadenceConfig.TLSConfig

--- a/internal/cadence/runtime.go
+++ b/internal/cadence/runtime.go
@@ -73,7 +73,7 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 	runtimeLogger := logur.LoggerToKV(zapadapter.New(logger))
 
 	address := params.Config.Cadence.Address
-	connectionOptions, err := newConnectionOptions(address, params.Config.Cadence, params.Config.Env())
+	connectionOptions, err := newConnectionOptions(params.Config.Cadence, params.Config.Env())
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 
 }
 
-func newConnectionOptions(address string, cadenceConfig config.CadenceConfig, env config.Env) (client.ConnectionOptions, error) {
+func newConnectionOptions(cadenceConfig config.CadenceConfig, env config.Env) (client.ConnectionOptions, error) {
 	connectionOptions := client.ConnectionOptions{}
 	if cadenceConfig.KeepAliveTime > 0 {
 		connectionOptions.KeepAliveTime = cadenceConfig.KeepAliveTime
@@ -128,9 +128,9 @@ func newConnectionOptions(address string, cadenceConfig config.CadenceConfig, en
 
 	tlsConfig := cadenceConfig.TLSConfig
 	if tlsConfig.Enabled && env != config.EnvLocal {
-		host, _, err := net.SplitHostPort(address)
+		host, _, err := net.SplitHostPort(cadenceConfig.Address)
 		if err != nil {
-			return client.ConnectionOptions{}, xerrors.Errorf("failed to parse address (%v): %w", address, err)
+			return client.ConnectionOptions{}, xerrors.Errorf("failed to parse address (%v): %w", cadenceConfig.Address, err)
 		}
 
 		connectionOptions.TLS = &tls.Config{

--- a/internal/cadence/runtime.go
+++ b/internal/cadence/runtime.go
@@ -63,6 +63,11 @@ type (
 	listOpenWorkflowsFn func(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
 )
 
+const (
+	temporalClientKeepAliveTime    = 10 * time.Second
+	temporalClientKeepAliveTimeout = 30 * time.Second
+)
+
 func NewRuntime(params RuntimeParams) (Runtime, error) {
 	if params.TestEnv != nil {
 		return newTestRuntime(params.TestEnv, params.Logger)
@@ -73,35 +78,9 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 	runtimeLogger := logur.LoggerToKV(zapadapter.New(logger))
 
 	address := params.Config.Cadence.Address
-	tlsConfig := params.Config.Cadence.TLSConfig
-	connectionOptions := client.ConnectionOptions{}
-	if tlsConfig.Enabled && params.Config.Env() != config.EnvLocal {
-		host, _, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to parse address (%v): %w", address, err)
-		}
-
-		connectionOptions.TLS = &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			ServerName:         host,
-			InsecureSkipVerify: !tlsConfig.ValidateHostname,
-		}
-
-		if tlsConfig.CertificateAuthority != "" {
-			caCertPool := x509.NewCertPool()
-			if !caCertPool.AppendCertsFromPEM([]byte(tlsConfig.CertificateAuthority)) {
-				return nil, xerrors.Errorf("failed to parse CA certificate: %v", tlsConfig.CertificateAuthority)
-			}
-			connectionOptions.TLS.RootCAs = caCertPool
-		}
-
-		if tlsConfig.ClientCertificate != "" && tlsConfig.ClientPrivateKey != "" {
-			clientCert, err := tls.X509KeyPair([]byte(tlsConfig.ClientCertificate), []byte(tlsConfig.ClientPrivateKey))
-			if err != nil {
-				return nil, xerrors.Errorf("failed to parse client certificate or key (%v): %w", tlsConfig.ClientCertificate, err)
-			}
-			connectionOptions.TLS.Certificates = []tls.Certificate{clientCert}
-		}
+	connectionOptions, err := newConnectionOptions(address, params.Config.Cadence, params.Config.Env())
+	if err != nil {
+		return nil, err
 	}
 
 	options := client.Options{
@@ -141,6 +120,45 @@ func NewRuntime(params RuntimeParams) (Runtime, error) {
 
 	return runtime, nil
 
+}
+
+func newConnectionOptions(address string, cadenceConfig config.CadenceConfig, env config.Env) (client.ConnectionOptions, error) {
+	connectionOptions := client.ConnectionOptions{
+		KeepAliveTime:    temporalClientKeepAliveTime,
+		KeepAliveTimeout: temporalClientKeepAliveTimeout,
+	}
+
+	tlsConfig := cadenceConfig.TLSConfig
+	if tlsConfig.Enabled && env != config.EnvLocal {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return client.ConnectionOptions{}, xerrors.Errorf("failed to parse address (%v): %w", address, err)
+		}
+
+		connectionOptions.TLS = &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ServerName:         host,
+			InsecureSkipVerify: !tlsConfig.ValidateHostname,
+		}
+
+		if tlsConfig.CertificateAuthority != "" {
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM([]byte(tlsConfig.CertificateAuthority)) {
+				return client.ConnectionOptions{}, xerrors.Errorf("failed to parse CA certificate: %v", tlsConfig.CertificateAuthority)
+			}
+			connectionOptions.TLS.RootCAs = caCertPool
+		}
+
+		if tlsConfig.ClientCertificate != "" && tlsConfig.ClientPrivateKey != "" {
+			clientCert, err := tls.X509KeyPair([]byte(tlsConfig.ClientCertificate), []byte(tlsConfig.ClientPrivateKey))
+			if err != nil {
+				return client.ConnectionOptions{}, xerrors.Errorf("failed to parse client certificate or key (%v): %w", tlsConfig.ClientCertificate, err)
+			}
+			connectionOptions.TLS.Certificates = []tls.Certificate{clientCert}
+		}
+	}
+
+	return connectionOptions, nil
 }
 
 func newWorkerOptions(workerConfig config.WorkerConfig) worker.Options {

--- a/internal/cadence/runtime_test.go
+++ b/internal/cadence/runtime_test.go
@@ -2,6 +2,7 @@ package cadence
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 	"time"
 
@@ -12,6 +13,46 @@ import (
 
 	"github.com/coinbase/chainstorage/internal/config"
 )
+
+func TestNewConnectionOptionsSetsTemporalKeepAlive(t *testing.T) {
+	require := require.New(t)
+
+	options, err := newConnectionOptions(
+		"temporal.example.com:7233",
+		config.CadenceConfig{},
+		config.EnvProduction,
+	)
+
+	require.NoError(err)
+	require.Equal(10*time.Second, options.KeepAliveTime)
+	require.Equal(30*time.Second, options.KeepAliveTimeout)
+	require.False(options.DisableKeepAliveCheck)
+	require.False(options.DisableKeepAlivePermitWithoutStream)
+	require.Nil(options.TLS)
+}
+
+func TestNewConnectionOptionsPreservesTLSConfig(t *testing.T) {
+	require := require.New(t)
+
+	options, err := newConnectionOptions(
+		"temporal.example.com:7233",
+		config.CadenceConfig{
+			TLSConfig: config.CadenceTLSConfig{
+				Enabled:          true,
+				ValidateHostname: true,
+			},
+		},
+		config.EnvProduction,
+	)
+
+	require.NoError(err)
+	require.NotNil(options.TLS)
+	require.Equal(uint16(tls.VersionTLS12), options.TLS.MinVersion)
+	require.Equal("temporal.example.com", options.TLS.ServerName)
+	require.False(options.TLS.InsecureSkipVerify)
+	require.Equal(10*time.Second, options.KeepAliveTime)
+	require.Equal(30*time.Second, options.KeepAliveTimeout)
+}
 
 func TestNewWorkerOptionsPreservesDefaultActivityConcurrency(t *testing.T) {
 	require := require.New(t)

--- a/internal/cadence/runtime_test.go
+++ b/internal/cadence/runtime_test.go
@@ -18,8 +18,9 @@ func TestNewConnectionOptionsLeavesTemporalKeepAliveUnsetByDefault(t *testing.T)
 	require := require.New(t)
 
 	options, err := newConnectionOptions(
-		"temporal.example.com:7233",
-		config.CadenceConfig{},
+		config.CadenceConfig{
+			Address: "temporal.example.com:7233",
+		},
 		config.EnvProduction,
 	)
 
@@ -35,8 +36,8 @@ func TestNewConnectionOptionsAppliesConfiguredTemporalKeepAlive(t *testing.T) {
 	require := require.New(t)
 
 	options, err := newConnectionOptions(
-		"temporal.example.com:7233",
 		config.CadenceConfig{
+			Address:          "temporal.example.com:7233",
 			KeepAliveTime:    10 * time.Second,
 			KeepAliveTimeout: 30 * time.Second,
 		},
@@ -55,8 +56,8 @@ func TestNewConnectionOptionsPreservesTLSConfig(t *testing.T) {
 	require := require.New(t)
 
 	options, err := newConnectionOptions(
-		"temporal.example.com:7233",
 		config.CadenceConfig{
+			Address:          "temporal.example.com:7233",
 			KeepAliveTime:    10 * time.Second,
 			KeepAliveTimeout: 30 * time.Second,
 			TLSConfig: config.CadenceTLSConfig{
@@ -80,8 +81,8 @@ func TestNewConnectionOptionsSuppressesTLSConfigForLocalEnv(t *testing.T) {
 	require := require.New(t)
 
 	options, err := newConnectionOptions(
-		"temporal.example.com:7233",
 		config.CadenceConfig{
+			Address: "temporal.example.com:7233",
 			TLSConfig: config.CadenceTLSConfig{
 				Enabled: true,
 			},
@@ -97,8 +98,8 @@ func TestNewConnectionOptionsRejectsInvalidCA(t *testing.T) {
 	require := require.New(t)
 
 	_, err := newConnectionOptions(
-		"temporal.example.com:7233",
 		config.CadenceConfig{
+			Address: "temporal.example.com:7233",
 			TLSConfig: config.CadenceTLSConfig{
 				Enabled:              true,
 				CertificateAuthority: "not-pem",

--- a/internal/cadence/runtime_test.go
+++ b/internal/cadence/runtime_test.go
@@ -14,12 +14,32 @@ import (
 	"github.com/coinbase/chainstorage/internal/config"
 )
 
-func TestNewConnectionOptionsSetsTemporalKeepAlive(t *testing.T) {
+func TestNewConnectionOptionsLeavesTemporalKeepAliveUnsetByDefault(t *testing.T) {
 	require := require.New(t)
 
 	options, err := newConnectionOptions(
 		"temporal.example.com:7233",
 		config.CadenceConfig{},
+		config.EnvProduction,
+	)
+
+	require.NoError(err)
+	require.Zero(options.KeepAliveTime)
+	require.Zero(options.KeepAliveTimeout)
+	require.False(options.DisableKeepAliveCheck)
+	require.False(options.DisableKeepAlivePermitWithoutStream)
+	require.Nil(options.TLS)
+}
+
+func TestNewConnectionOptionsAppliesConfiguredTemporalKeepAlive(t *testing.T) {
+	require := require.New(t)
+
+	options, err := newConnectionOptions(
+		"temporal.example.com:7233",
+		config.CadenceConfig{
+			KeepAliveTime:    10 * time.Second,
+			KeepAliveTimeout: 30 * time.Second,
+		},
 		config.EnvProduction,
 	)
 
@@ -37,6 +57,8 @@ func TestNewConnectionOptionsPreservesTLSConfig(t *testing.T) {
 	options, err := newConnectionOptions(
 		"temporal.example.com:7233",
 		config.CadenceConfig{
+			KeepAliveTime:    10 * time.Second,
+			KeepAliveTimeout: 30 * time.Second,
 			TLSConfig: config.CadenceTLSConfig{
 				Enabled:          true,
 				ValidateHostname: true,
@@ -52,6 +74,40 @@ func TestNewConnectionOptionsPreservesTLSConfig(t *testing.T) {
 	require.False(options.TLS.InsecureSkipVerify)
 	require.Equal(10*time.Second, options.KeepAliveTime)
 	require.Equal(30*time.Second, options.KeepAliveTimeout)
+}
+
+func TestNewConnectionOptionsSuppressesTLSConfigForLocalEnv(t *testing.T) {
+	require := require.New(t)
+
+	options, err := newConnectionOptions(
+		"temporal.example.com:7233",
+		config.CadenceConfig{
+			TLSConfig: config.CadenceTLSConfig{
+				Enabled: true,
+			},
+		},
+		config.EnvLocal,
+	)
+
+	require.NoError(err)
+	require.Nil(options.TLS)
+}
+
+func TestNewConnectionOptionsRejectsInvalidCA(t *testing.T) {
+	require := require.New(t)
+
+	_, err := newConnectionOptions(
+		"temporal.example.com:7233",
+		config.CadenceConfig{
+			TLSConfig: config.CadenceTLSConfig{
+				Enabled:              true,
+				CertificateAuthority: "not-pem",
+			},
+		},
+		config.EnvProduction,
+	)
+
+	require.ErrorContains(err, "failed to parse CA certificate")
 }
 
 func TestNewWorkerOptionsPreservesDefaultActivityConcurrency(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,10 +177,12 @@ type (
 	}
 
 	CadenceConfig struct {
-		Address         string           `mapstructure:"address" validate:"required"`
-		Domain          string           `mapstructure:"domain" validate:"required"`
-		RetentionPeriod int32            `mapstructure:"retention_period" validate:"required"`
-		TLSConfig       CadenceTLSConfig `mapstructure:"tls" validate:"required"`
+		Address          string           `mapstructure:"address" validate:"required"`
+		Domain           string           `mapstructure:"domain" validate:"required"`
+		RetentionPeriod  int32            `mapstructure:"retention_period" validate:"required"`
+		KeepAliveTime    time.Duration    `mapstructure:"keep_alive_time"`
+		KeepAliveTimeout time.Duration    `mapstructure:"keep_alive_timeout"`
+		TLSConfig        CadenceTLSConfig `mapstructure:"tls" validate:"required"`
 	}
 
 	CadenceTLSConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,6 +142,20 @@ func TestValidateConfigs(t *testing.T) {
 	})
 }
 
+func TestSolanaProductionCadenceKeepAliveConfig(t *testing.T) {
+	require := testutil.Require(t)
+
+	cfg, err := config.New(
+		config.WithEnvironment(config.EnvProduction),
+		config.WithBlockchain(common.Blockchain_BLOCKCHAIN_SOLANA),
+		config.WithNetwork(common.Network_NETWORK_SOLANA_MAINNET),
+	)
+
+	require.NoError(err)
+	require.Equal(10*time.Second, cfg.Cadence.KeepAliveTime)
+	require.Equal(30*time.Second, cfg.Cadence.KeepAliveTimeout)
+}
+
 func TestDerivedConfigValues(t *testing.T) {
 	testapp.TestAllConfigs(t, func(t *testing.T, cfg *config.Config) {
 		require := testutil.Require(t)


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1037/fix-chainstorage-temporal-grpc-retries-through-linkerd

## Summary
- add optional `cadence.keep_alive_time` / `cadence.keep_alive_timeout` settings for the Temporal Go SDK client
- enable the canary only for Solana mainnet production with `10s` keepalive time and `30s` keepalive timeout
- preserve existing TLS behavior and add focused tests for keepalive config, TLS preservation, local TLS suppression, invalid CA handling, and Solana prod config parsing

## Why
This is the Chainstorage-side canary for the Temporal transport issue. The observed failures do not look like a Linkerd idle-timeout expiry; they look like long-lived gRPC connection liveness/reconnect handling problems while Linkerd is in the Temporal 7233 path. This PR does not change Temporal service routing, Linkerd opaque ports, or skip-outbound annotations.

## Test
- go test -count=1 ./internal/cadence
- go test -count=1 ./internal/config -run TestSolanaProductionCadenceKeepAliveConfig

## Rollout / Canary
After deployment, run a bounded Solana CSCB historical backfill without Chainstorage outbound 7233 skip and monitor for RecordActivityHeartbeat errors, activity retries, and Linkerd 7233 connection closed/channel closed logs.