### PR TITLE
fix(INF-1046): guard CSCB legacy object retirement

### DIFF
--- a/cmd/admin/retirement.go
+++ b/cmd/admin/retirement.go
@@ -50,11 +50,11 @@ func newLegacyRetirementPlanCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plan-legacy-single-blocks",
 		Short: "dry-run legacy single-block object retirement after CSCB validation",
-		Long: `Plan retirement for legacy single-block S3 objects that already have validated CSCB shadow metadata.
+		Long: `Plan retirement for legacy single-block S3 objects whose active metadata has already been promoted to validated CSCB metadata.
 
 The command is dry-run by default. It emits one auditable JSON report containing the bucket,
 legacy key, version id when available, height, hash, legacy bytes, consolidated key,
-validated_at, eligible_at, action, and skip reason for every scanned canonical row.
+validated_at, retired_at, eligible_at, action, and skip reason for every scanned canonical row.
 
 Production deletion is disabled. Non-production execution deletes only an explicit S3 object
 version; rows without a version id are skipped to avoid delete-marker-only cleanup.`,
@@ -67,7 +67,7 @@ version; rows without a version id are skipped to avoid delete-marker-only clean
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.startHeight, "start-height", 0, "inclusive block start height")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.endHeight, "end-height", 0, "exclusive block end height")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.limit, "limit", 0, "maximum rows to scan; default scans the full range")
-	cmd.Flags().DurationVar(&legacyRetirementFlags.gracePeriod, "grace-period", 7*24*time.Hour, "minimum age after validated_at before a row is eligible")
+	cmd.Flags().DurationVar(&legacyRetirementFlags.gracePeriod, "grace-period", 0, "fallback minimum age after validated_at when legacy_object_retire_after is not set; default uses aws.storage.consolidation.legacy_object_retention")
 	cmd.Flags().StringVar(&legacyRetirementFlags.approveChain, "approve-chain", "", "explicit chain approval, e.g. solana-mainnet")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.approveStartHeight, "approve-start-height", 0, "explicit approved start height")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.approveEndHeight, "approve-end-height", 0, "explicit approved end height")
@@ -111,6 +111,10 @@ func runLegacyRetirementPlan(ctx context.Context, flags retirementFlags) error {
 	}
 
 	tag := cfg.GetEffectiveBlockTag(flags.tag)
+	gracePeriod := flags.gracePeriod
+	if gracePeriod == 0 {
+		gracePeriod = cfg.AWS.Storage.Consolidation.LegacyObjectRetention
+	}
 	targetChain := approvalChainFromFlags()
 	logger.Info("planning legacy single-block retirement",
 		zap.String("environment", string(cfg.Env())),
@@ -145,7 +149,7 @@ func runLegacyRetirementPlan(ctx context.Context, flags retirementFlags) error {
 		EndHeight:               flags.endHeight,
 		Limit:                   flags.limit,
 		Now:                     time.Now().UTC(),
-		GracePeriod:             flags.gracePeriod,
+		GracePeriod:             gracePeriod,
 		Execute:                 flags.execute,
 		ClientMigrationApproved: flags.clientMigrationApproved,
 		FallbackErrorCount:      flags.fallbackErrorCount,

--- a/cmd/admin/retirement.go
+++ b/cmd/admin/retirement.go
@@ -25,7 +25,6 @@ type retirementFlags struct {
 	startHeight             uint64
 	endHeight               uint64
 	limit                   uint64
-	gracePeriod             time.Duration
 	approveChain            string
 	approveStartHeight      uint64
 	approveEndHeight        uint64
@@ -67,7 +66,6 @@ version; rows without a version id are skipped to avoid delete-marker-only clean
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.startHeight, "start-height", 0, "inclusive block start height")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.endHeight, "end-height", 0, "exclusive block end height")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.limit, "limit", 0, "maximum rows to scan; default scans the full range")
-	cmd.Flags().DurationVar(&legacyRetirementFlags.gracePeriod, "grace-period", 0, "fallback minimum age after validated_at when legacy_object_retire_after is not set; default uses aws.storage.consolidation.legacy_object_retention")
 	cmd.Flags().StringVar(&legacyRetirementFlags.approveChain, "approve-chain", "", "explicit chain approval, e.g. solana-mainnet")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.approveStartHeight, "approve-start-height", 0, "explicit approved start height")
 	cmd.Flags().Uint64Var(&legacyRetirementFlags.approveEndHeight, "approve-end-height", 0, "explicit approved end height")
@@ -111,10 +109,6 @@ func runLegacyRetirementPlan(ctx context.Context, flags retirementFlags) error {
 	}
 
 	tag := cfg.GetEffectiveBlockTag(flags.tag)
-	gracePeriod := flags.gracePeriod
-	if gracePeriod == 0 {
-		gracePeriod = cfg.AWS.Storage.Consolidation.LegacyObjectRetention
-	}
 	targetChain := approvalChainFromFlags()
 	logger.Info("planning legacy single-block retirement",
 		zap.String("environment", string(cfg.Env())),
@@ -149,7 +143,6 @@ func runLegacyRetirementPlan(ctx context.Context, flags retirementFlags) error {
 		EndHeight:               flags.endHeight,
 		Limit:                   flags.limit,
 		Now:                     time.Now().UTC(),
-		GracePeriod:             gracePeriod,
 		Execute:                 flags.execute,
 		ClientMigrationApproved: flags.clientMigrationApproved,
 		FallbackErrorCount:      flags.fallbackErrorCount,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -455,6 +455,7 @@ type (
 		ReadShadowFirst                     bool              `mapstructure:"read_shadow_first"`
 		PromotionGateHeight                 *uint64           `mapstructure:"promotion_gate_height"`
 		SafePromotionLag                    *uint64           `mapstructure:"safe_promotion_lag"`
+		LegacyObjectRetention               time.Duration     `mapstructure:"legacy_object_retention"`
 		LegacyShadowWriteAfterSyncerCutover bool              `mapstructure:"legacy_shadow_write_after_syncer_cutover"`
 	}
 
@@ -627,6 +628,7 @@ const (
 	ConsolidationModeHistoricalBackfill        ConsolidationMode = "historical_backfill"
 	ConsolidationModePromoteFinalized          ConsolidationMode = "promote_finalized"
 	ConsolidationModeSyncerConsolidatedPrimary ConsolidationMode = "syncer_consolidated_primary"
+	DefaultLegacyObjectRetention                                 = 72 * time.Hour
 
 	AWSAccountDevelopment AWSAccount = "development"
 	AWSAccountProduction  AWSAccount = "production"
@@ -719,6 +721,7 @@ func New(opts ...ConfigOption) (*Config, error) {
 	v.SetDefault("aws.storage.consolidation.shard_size", 10000)
 	v.SetDefault("aws.storage.consolidation.multipart_threshold", 134217728)
 	v.SetDefault("aws.storage.consolidation.read_shadow_first", false)
+	v.SetDefault("aws.storage.consolidation.legacy_object_retention", DefaultLegacyObjectRetention.String())
 	if err := v.BindEnv("aws.storage.consolidation.promotion_gate_height"); err != nil {
 		return nil, xerrors.Errorf("failed to bind promotion_gate_height env: %w", err)
 	}
@@ -851,6 +854,9 @@ func (c *Config) validateConsolidationConfig() error {
 	}
 	if consolidation.ShadowTimeout <= 0 {
 		return xerrors.New("consolidation shadow_timeout must be positive")
+	}
+	if consolidation.LegacyObjectRetention <= 0 {
+		return xerrors.New("consolidation legacy_object_retention must be positive")
 	}
 	if consolidation.Mode == ConsolidationModePromoteFinalized && consolidation.SafePromotionLag == nil {
 		return xerrors.New("consolidation promote_finalized requires safe_promotion_lag")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -909,6 +909,32 @@ func TestConsolidationHistoricalBackfillModeAcceptedAsDeprecatedAlias(t *testing
 	require.Equal(config.ConsolidationModeHistoricalBackfill, cfg.AWS.Storage.Consolidation.Mode)
 }
 
+func TestConsolidationLegacyObjectRetentionConfig(t *testing.T) {
+	require := testutil.Require(t)
+
+	cfg, err := config.New()
+	require.NoError(err)
+	require.Equal(config.DefaultLegacyObjectRetention, cfg.AWS.Storage.Consolidation.LegacyObjectRetention)
+
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_LEGACY_OBJECT_RETENTION", "24h")
+	cfg, err = config.New()
+	require.NoError(err)
+	require.Equal(24*time.Hour, cfg.AWS.Storage.Consolidation.LegacyObjectRetention)
+}
+
+func TestConsolidationLegacyObjectRetentionMustBePositiveWhenEnabled(t *testing.T) {
+	require := testutil.Require(t)
+
+	t.Setenv("CHAINSTORAGE_STORAGE_TYPE_META", "POSTGRES")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_ENABLED", "true")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_MODE", string(config.ConsolidationModeAutoConsolidate))
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_LEGACY_OBJECT_RETENTION", "0s")
+
+	_, err := config.New()
+	require.Error(err)
+	require.Contains(err.Error(), "legacy_object_retention must be positive")
+}
+
 func TestConsolidationPromoteFinalizedRequiresSafePromotionLag(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -1082,6 +1108,7 @@ func defaultConsolidationConfig() config.ConsolidationConfig {
 		ShardSize:              10000,
 		MultipartThreshold:     134217728,
 		ReadShadowFirst:        false,
+		LegacyObjectRetention:  config.DefaultLegacyObjectRetention,
 	}
 }
 

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -364,13 +364,14 @@ func (t *batchConsolidatorTask) verifyAutoConsolidateCoverage(ctx context.Contex
 	if err != nil {
 		return xerrors.Errorf("failed to get auto_consolidate coverage stats for range [%d, %d): %w", startHeight, endHeight, err)
 	}
-	expectedBlocks := endHeight - startHeight
-	actualBlocks := uint64(0)
+	eligibleBlocks := uint64(0)
+	shadowBlocks := uint64(0)
 	if stats != nil {
-		actualBlocks = stats.Blocks
+		eligibleBlocks = stats.EligibleBlocks
+		shadowBlocks = stats.Blocks
 	}
-	if actualBlocks != expectedBlocks {
-		return xerrors.Errorf("auto_consolidate coverage mismatch for range [%d, %d): expected %d blocks, got %d", startHeight, endHeight, expectedBlocks, actualBlocks)
+	if shadowBlocks != eligibleBlocks {
+		return xerrors.Errorf("auto_consolidate coverage mismatch for range [%d, %d): expected %d eligible blocks, got %d shadow blocks", startHeight, endHeight, eligibleBlocks, shadowBlocks)
 	}
 	return nil
 }

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -227,6 +227,16 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 				)
 				return nil
 			}
+			if err := t.verifyAutoConsolidateCoverage(ctx, tag, cronConfig.StartHeight, cursorEnd); err != nil {
+				t.logger.Info(
+					"batch_consolidator cron skipped cursor bootstrap because already consolidated range did not pass coverage verification",
+					zap.Uint32("tag", tag),
+					zap.Uint64("configured_start_height", cronConfig.StartHeight),
+					zap.Uint64("cursor_height", cursorEnd),
+					zap.Error(err),
+				)
+				return nil
+			}
 			if err := t.metaStorage.SetBlockConsolidationCursor(ctx, metastorage.BatchConsolidatorAutoConsolidateCursor, tag, cursorEnd); err != nil {
 				return xerrors.Errorf("failed to bootstrap auto_consolidate cursor to height %d: %w", cursorEnd, err)
 			}
@@ -344,6 +354,25 @@ func (t *batchConsolidatorTask) firstAutoConsolidateWindowStart(
 		return 0, false, nil
 	}
 	return windowStart, true, nil
+}
+
+func (t *batchConsolidatorTask) verifyAutoConsolidateCoverage(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) error {
+	if endHeight <= startHeight {
+		return xerrors.Errorf("invalid auto_consolidate coverage range [%d, %d)", startHeight, endHeight)
+	}
+	stats, err := t.metaStorage.GetBlockConsolidationShadowStats(ctx, tag, startHeight, endHeight)
+	if err != nil {
+		return xerrors.Errorf("failed to get auto_consolidate coverage stats for range [%d, %d): %w", startHeight, endHeight, err)
+	}
+	expectedBlocks := endHeight - startHeight
+	actualBlocks := uint64(0)
+	if stats != nil {
+		actualBlocks = stats.Blocks
+	}
+	if actualBlocks != expectedBlocks {
+		return xerrors.Errorf("auto_consolidate coverage mismatch for range [%d, %d): expected %d blocks, got %d", startHeight, endHeight, expectedBlocks, actualBlocks)
+	}
+	return nil
 }
 
 func (t *batchConsolidatorTask) openBatchConsolidatorWorkflow(ctx context.Context) (string, bool, error) {

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -244,7 +244,33 @@ func TestBatchConsolidatorCronBootstrapsCursorWhenNoMissingShadow(t *testing.T) 
 		Return(uint64(0), false, nil)
 	metaStorage.EXPECT().
 		GetBlockConsolidationShadowStats(gomock.Any(), tag, uint64(1_000), uint64(11_000)).
-		Return(&metastorage.ConsolidationShadowStats{Objects: 10, Blocks: 10_000}, nil)
+		Return(&metastorage.ConsolidationShadowStats{Objects: 10, Blocks: 10_000, EligibleBlocks: 10_000}, nil)
+	metaStorage.EXPECT().
+		SetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag, uint64(11_000)).
+		Return(nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestBatchConsolidatorCronBootstrapsCursorWithSkippedBlocks(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 12_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(11_901)).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetBlockConsolidationShadowStats(gomock.Any(), tag, uint64(1_000), uint64(11_000)).
+		Return(&metastorage.ConsolidationShadowStats{Objects: 10, Blocks: 9_990, EligibleBlocks: 9_990}, nil)
 	metaStorage.EXPECT().
 		SetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag, uint64(11_000)).
 		Return(nil)
@@ -270,7 +296,7 @@ func TestBatchConsolidatorCronDoesNotBootstrapCursorWithoutFullCoverage(t *testi
 		Return(uint64(0), false, nil)
 	metaStorage.EXPECT().
 		GetBlockConsolidationShadowStats(gomock.Any(), tag, uint64(1_000), uint64(11_000)).
-		Return(&metastorage.ConsolidationShadowStats{Objects: 9, Blocks: 9_999}, nil)
+		Return(&metastorage.ConsolidationShadowStats{Objects: 9, Blocks: 9_999, EligibleBlocks: 10_000}, nil)
 	metaStorage.EXPECT().
 		SetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -243,8 +243,37 @@ func TestBatchConsolidatorCronBootstrapsCursorWhenNoMissingShadow(t *testing.T) 
 		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(11_901)).
 		Return(uint64(0), false, nil)
 	metaStorage.EXPECT().
+		GetBlockConsolidationShadowStats(gomock.Any(), tag, uint64(1_000), uint64(11_000)).
+		Return(&metastorage.ConsolidationShadowStats{Objects: 10, Blocks: 10_000}, nil)
+	metaStorage.EXPECT().
 		SetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag, uint64(11_000)).
 		Return(nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestBatchConsolidatorCronDoesNotBootstrapCursorWithoutFullCoverage(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 12_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(11_901)).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetBlockConsolidationShadowStats(gomock.Any(), tag, uint64(1_000), uint64(11_000)).
+		Return(&metastorage.ConsolidationShadowStats{Objects: 9, Blocks: 9_999}, nil)
+	metaStorage.EXPECT().
+		SetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
 
 	require.NoError(t, task.Run(context.Background()))
 	require.Empty(t, runtime.executions)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -424,8 +424,8 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 	}
 
 	if shouldReadFromConsolidated(req.GetReadSource(), false) {
-		if shadow, ok := s.getShadowBlockMetadata(ctx, block); ok {
-			blockFile, err := s.newBlockFile(shadow)
+		if consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block); ok {
+			blockFile, err := s.newBlockFile(consolidated)
 			if err == nil {
 				s.emitBlocksMetric(formatFile, clientID, 1)
 				return &api.GetBlockFileResponse{File: blockFile}, nil
@@ -436,13 +436,29 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 				zap.Uint32("tag", block.GetTag()),
 				zap.Uint64("height", block.GetHeight()),
 				zap.String("hash", block.GetHash()),
-				zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+				zap.String("consolidated_object_key", consolidated.GetObjectKeyMain()),
 				zap.Error(err),
 			)
+			if legacy, ok := s.getLegacyBlockMetadata(ctx, block); ok {
+				if blockFile, err := s.newBlockFile(legacy); err == nil {
+					s.emitBlocksMetric(formatFile, clientID, 1)
+					s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
+					return &api.GetBlockFileResponse{File: blockFile}, nil
+				}
+			}
 		}
 	}
 
 	blockFile, err := s.newBlockFile(block)
+	if err != nil && isConsolidatedBlockMetadata(block) {
+		if legacy, ok := s.getLegacyBlockMetadata(ctx, block); ok {
+			if legacyBlockFile, legacyErr := s.newBlockFile(legacy); legacyErr == nil {
+				s.emitBlocksMetric(formatFile, clientID, 1)
+				s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
+				return &api.GetBlockFileResponse{File: legacyBlockFile}, nil
+			}
+		}
+	}
 	if err != nil {
 		return nil, xerrors.Errorf("failed to prepare block file: %w", err)
 	}
@@ -480,7 +496,14 @@ func (s *Server) GetBlockFilesByRange(ctx context.Context, req *api.GetBlockFile
 			zap.Int("shadow_blocks", shadowCount),
 			zap.Error(err),
 		)
-		blockFiles, err = s.newBlockFiles(blocks)
+		if legacyBlocks, ok := s.selectLegacyBlockMetadata(ctx, blocks); ok {
+			blockFiles, err = s.newBlockFiles(legacyBlocks)
+		}
+	}
+	if err != nil && hasConsolidatedBlockMetadata(blocks) {
+		if legacyBlocks, ok := s.selectLegacyBlockMetadata(ctx, blocks); ok {
+			blockFiles, err = s.newBlockFiles(legacyBlocks)
+		}
 	}
 	if err != nil {
 		return nil, xerrors.Errorf("newBlockFile error: %w", err)
@@ -963,18 +986,23 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		return output, nil
 	}
 
-	shadow, ok := s.getShadowBlockMetadata(ctx, block)
+	consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block)
 	if !ok {
-		output, err := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
+		legacy, ok := s.getLegacyBlockMetadata(ctx, block)
+		if !ok {
+			s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
+			return nil, xerrors.Errorf("failed to find legacy fallback block metadata for height %d: %w", block.GetHeight(), storage.ErrItemNotFound)
+		}
+		output, err := s.downloadBlockWithShadowMetrics(ctx, legacy, shadowPathLegacy)
 		if err != nil {
 			s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
-			return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", block, err)
+			return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", legacy, err)
 		}
 		s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
 		return output, nil
 	}
 
-	output, err := s.downloadBlockWithShadowMetrics(ctx, shadow, shadowPathConsolidated)
+	output, err := s.downloadBlockWithShadowMetrics(ctx, consolidated, shadowPathConsolidated)
 	if err == nil {
 		s.emitShadowReadMetric(shadowOutcomeSuccess, 1)
 		return blockWithPrimaryMetadata(output, block), nil
@@ -986,13 +1014,18 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		zap.Uint32("tag", block.GetTag()),
 		zap.Uint64("height", block.GetHeight()),
 		zap.String("hash", block.GetHash()),
-		zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+		zap.String("consolidated_object_key", consolidated.GetObjectKeyMain()),
 		zap.Error(err),
 	)
-	fallback, fallbackErr := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
+	legacy, ok := s.getLegacyBlockMetadata(ctx, block)
+	if !ok {
+		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
+		return nil, err
+	}
+	fallback, fallbackErr := s.downloadBlockWithShadowMetrics(ctx, legacy, shadowPathLegacy)
 	if fallbackErr != nil {
 		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
-		return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", block, fallbackErr)
+		return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", legacy, fallbackErr)
 	}
 	s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
 	return fallback, nil
@@ -1027,7 +1060,12 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 		zap.Int("shadow_blocks", shadowCount),
 		zap.Error(err),
 	)
-	fallback, fallbackErr := s.downloadBlocksWithShadowMetrics(ctx, blocks)
+	legacyBlocks, ok := s.selectLegacyBlockMetadata(ctx, blocks)
+	if !ok {
+		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(len(blocks)))
+		return nil, err
+	}
+	fallback, fallbackErr := s.downloadBlocksWithShadowMetrics(ctx, legacyBlocks)
 	if fallbackErr != nil {
 		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(len(blocks)))
 		return nil, xerrors.Errorf("failed to download fallback legacy blocks from blob storage: %w", fallbackErr)
@@ -1056,6 +1094,38 @@ func shouldReadFromConsolidated(readSource api.BlockReadSource, defaultReadShado
 	default:
 		return defaultReadShadowFirst
 	}
+}
+
+func (s *Server) getConsolidatedBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
+	if isConsolidatedBlockMetadata(block) {
+		return block, true
+	}
+	return s.getShadowBlockMetadata(ctx, block)
+}
+
+func (s *Server) getLegacyBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
+	if !isConsolidatedBlockMetadata(block) {
+		return block, true
+	}
+
+	legacy, err := s.metaStorage.GetBlockConsolidationLegacy(ctx, block)
+	if err != nil {
+		if xerrors.Is(err, storage.ErrItemNotFound) {
+			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
+			return nil, false
+		}
+		s.emitShadowReadMetric(shadowOutcomeError, 1)
+		s.logger.Warn(
+			"legacy metadata lookup for promoted consolidated block failed",
+			zap.Uint32("tag", block.GetTag()),
+			zap.Uint64("height", block.GetHeight()),
+			zap.String("hash", block.GetHash()),
+			zap.String("consolidated_object_key", block.GetObjectKeyMain()),
+			zap.Error(err),
+		)
+		return nil, false
+	}
+	return legacy, true
 }
 
 func (s *Server) getShadowBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
@@ -1126,6 +1196,11 @@ func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.Bl
 	for i, block := range blocks {
 		shadow := shadows[i]
 		if shadow == nil {
+			if isConsolidatedBlockMetadata(block) {
+				selected[i] = block
+				shadowCount++
+				continue
+			}
 			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
 			selected[i] = block
 			fallbackCount++
@@ -1153,6 +1228,45 @@ func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.Bl
 		}
 	}
 	return selected, shadowCount, fallbackCount, selectionErr
+}
+
+func (s *Server) selectLegacyBlockMetadata(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, bool) {
+	if !hasConsolidatedBlockMetadata(blocks) {
+		return blocks, true
+	}
+
+	selected := make([]*api.BlockMetadata, len(blocks))
+	legacyBlocks, err := s.metaStorage.GetBlocksConsolidationLegacy(ctx, blocks)
+	if err != nil {
+		s.emitShadowReadMetric(shadowOutcomeError, int64(len(blocks)))
+		s.logger.Warn(
+			"legacy metadata batch lookup for promoted consolidated blocks failed",
+			zap.Int("num_blocks", len(blocks)),
+			zap.Error(err),
+		)
+		return nil, false
+	}
+	if len(legacyBlocks) != len(blocks) {
+		s.emitShadowReadMetric(shadowOutcomeError, int64(len(blocks)))
+		s.logger.Warn(
+			"legacy metadata batch lookup returned invalid result count",
+			zap.Int("num_blocks", len(blocks)),
+			zap.Int("num_legacy_blocks", len(legacyBlocks)),
+		)
+		return nil, false
+	}
+	for i, block := range blocks {
+		if isConsolidatedBlockMetadata(block) {
+			if legacyBlocks[i] == nil {
+				s.emitShadowReadMetric(shadowOutcomeMiss, 1)
+				return nil, false
+			}
+			selected[i] = legacyBlocks[i]
+			continue
+		}
+		selected[i] = block
+	}
+	return selected, true
 }
 
 func (s *Server) downloadBlockWithShadowMetrics(ctx context.Context, block *api.BlockMetadata, path string) (*api.Block, error) {
@@ -1222,6 +1336,15 @@ func blocksWithPrimaryMetadata(blocks []*api.Block, metadatas []*api.BlockMetada
 
 func isConsolidatedBlockMetadata(metadata *api.BlockMetadata) bool {
 	return metadata.GetObjectFormat() == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH && metadata.GetByteLength() > 0
+}
+
+func hasConsolidatedBlockMetadata(metadatas []*api.BlockMetadata) bool {
+	for _, metadata := range metadatas {
+		if isConsolidatedBlockMetadata(metadata) {
+			return true
+		}
+	}
+	return false
 }
 
 func shadowReadErrorOutcome(err error) string {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -424,11 +424,14 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 	}
 
 	if shouldReadFromConsolidated(req.GetReadSource(), false) {
-		if shadow, ok := s.getShadowBlockMetadata(ctx, block); ok {
-			blockFile, err := s.newBlockFile(shadow)
+		if consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block); ok {
+			blockFile, err := s.newBlockFile(consolidated)
 			if err == nil {
 				s.emitBlocksMetric(formatFile, clientID, 1)
 				return &api.GetBlockFileResponse{File: blockFile}, nil
+			}
+			if isConsolidatedBlockMetadata(block) {
+				return nil, xerrors.Errorf("failed to prepare consolidated block file: %w", err)
 			}
 			s.emitShadowReadMetric(shadowOutcomeError, 1)
 			s.logger.Warn(
@@ -436,7 +439,7 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 				zap.Uint32("tag", block.GetTag()),
 				zap.Uint64("height", block.GetHeight()),
 				zap.String("hash", block.GetHash()),
-				zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+				zap.String("consolidated_object_key", consolidated.GetObjectKeyMain()),
 				zap.Error(err),
 			)
 		}
@@ -473,6 +476,9 @@ func (s *Server) GetBlockFilesByRange(ctx context.Context, req *api.GetBlockFile
 
 	blockFiles, err := s.newBlockFiles(selectedBlocks)
 	if err != nil && shadowCount > 0 {
+		if allConsolidatedBlockMetadata(blocks) {
+			return nil, xerrors.Errorf("newBlockFile error: %w", err)
+		}
 		s.emitShadowReadMetric(shadowOutcomeError, int64(shadowCount))
 		s.logger.Warn(
 			"failed to prepare consolidated block files; falling back to legacy",
@@ -963,7 +969,7 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		return output, nil
 	}
 
-	shadow, ok := s.getShadowBlockMetadata(ctx, block)
+	consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block)
 	if !ok {
 		output, err := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
 		if err != nil {
@@ -974,10 +980,14 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		return output, nil
 	}
 
-	output, err := s.downloadBlockWithShadowMetrics(ctx, shadow, shadowPathConsolidated)
+	output, err := s.downloadBlockWithShadowMetrics(ctx, consolidated, shadowPathConsolidated)
 	if err == nil {
 		s.emitShadowReadMetric(shadowOutcomeSuccess, 1)
 		return blockWithPrimaryMetadata(output, block), nil
+	}
+	if isConsolidatedBlockMetadata(block) {
+		s.emitShadowReadMetric(shadowReadErrorOutcome(err), 1)
+		return nil, err
 	}
 
 	s.emitShadowReadMetric(shadowReadErrorOutcome(err), 1)
@@ -986,7 +996,7 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		zap.Uint32("tag", block.GetTag()),
 		zap.Uint64("height", block.GetHeight()),
 		zap.String("hash", block.GetHash()),
-		zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
+		zap.String("consolidated_object_key", consolidated.GetObjectKeyMain()),
 		zap.Error(err),
 	)
 	fallback, fallbackErr := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
@@ -1018,6 +1028,10 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 	if shadowCount == 0 {
 		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(fallbackCount))
 		return nil, xerrors.Errorf("failed to download blocks from blob storage: %w", err)
+	}
+	if allConsolidatedBlockMetadata(blocks) {
+		s.emitShadowReadMetric(shadowReadErrorOutcome(err), int64(shadowCount))
+		return nil, err
 	}
 
 	s.emitShadowReadMetric(shadowReadErrorOutcome(err), int64(shadowCount))
@@ -1056,6 +1070,13 @@ func shouldReadFromConsolidated(readSource api.BlockReadSource, defaultReadShado
 	default:
 		return defaultReadShadowFirst
 	}
+}
+
+func (s *Server) getConsolidatedBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
+	if isConsolidatedBlockMetadata(block) {
+		return block, true
+	}
+	return s.getShadowBlockMetadata(ctx, block)
 }
 
 func (s *Server) getShadowBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
@@ -1126,6 +1147,11 @@ func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.Bl
 	for i, block := range blocks {
 		shadow := shadows[i]
 		if shadow == nil {
+			if isConsolidatedBlockMetadata(block) {
+				selected[i] = block
+				shadowCount++
+				continue
+			}
 			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
 			selected[i] = block
 			fallbackCount++
@@ -1222,6 +1248,18 @@ func blocksWithPrimaryMetadata(blocks []*api.Block, metadatas []*api.BlockMetada
 
 func isConsolidatedBlockMetadata(metadata *api.BlockMetadata) bool {
 	return metadata.GetObjectFormat() == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH && metadata.GetByteLength() > 0
+}
+
+func allConsolidatedBlockMetadata(metadatas []*api.BlockMetadata) bool {
+	if len(metadatas) == 0 {
+		return false
+	}
+	for _, metadata := range metadatas {
+		if !isConsolidatedBlockMetadata(metadata) {
+			return false
+		}
+	}
+	return true
 }
 
 func shadowReadErrorOutcome(err error) string {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -424,8 +424,8 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 	}
 
 	if shouldReadFromConsolidated(req.GetReadSource(), false) {
-		if consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block); ok {
-			blockFile, err := s.newBlockFile(consolidated)
+		if shadow, ok := s.getShadowBlockMetadata(ctx, block); ok {
+			blockFile, err := s.newBlockFile(shadow)
 			if err == nil {
 				s.emitBlocksMetric(formatFile, clientID, 1)
 				return &api.GetBlockFileResponse{File: blockFile}, nil
@@ -436,29 +436,13 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 				zap.Uint32("tag", block.GetTag()),
 				zap.Uint64("height", block.GetHeight()),
 				zap.String("hash", block.GetHash()),
-				zap.String("consolidated_object_key", consolidated.GetObjectKeyMain()),
+				zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
 				zap.Error(err),
 			)
-			if legacy, ok := s.getLegacyBlockMetadata(ctx, block); ok {
-				if blockFile, err := s.newBlockFile(legacy); err == nil {
-					s.emitBlocksMetric(formatFile, clientID, 1)
-					s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
-					return &api.GetBlockFileResponse{File: blockFile}, nil
-				}
-			}
 		}
 	}
 
 	blockFile, err := s.newBlockFile(block)
-	if err != nil && isConsolidatedBlockMetadata(block) {
-		if legacy, ok := s.getLegacyBlockMetadata(ctx, block); ok {
-			if legacyBlockFile, legacyErr := s.newBlockFile(legacy); legacyErr == nil {
-				s.emitBlocksMetric(formatFile, clientID, 1)
-				s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
-				return &api.GetBlockFileResponse{File: legacyBlockFile}, nil
-			}
-		}
-	}
 	if err != nil {
 		return nil, xerrors.Errorf("failed to prepare block file: %w", err)
 	}
@@ -496,14 +480,7 @@ func (s *Server) GetBlockFilesByRange(ctx context.Context, req *api.GetBlockFile
 			zap.Int("shadow_blocks", shadowCount),
 			zap.Error(err),
 		)
-		if legacyBlocks, ok := s.selectLegacyBlockMetadata(ctx, blocks); ok {
-			blockFiles, err = s.newBlockFiles(legacyBlocks)
-		}
-	}
-	if err != nil && hasConsolidatedBlockMetadata(blocks) {
-		if legacyBlocks, ok := s.selectLegacyBlockMetadata(ctx, blocks); ok {
-			blockFiles, err = s.newBlockFiles(legacyBlocks)
-		}
+		blockFiles, err = s.newBlockFiles(blocks)
 	}
 	if err != nil {
 		return nil, xerrors.Errorf("newBlockFile error: %w", err)
@@ -986,23 +963,18 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		return output, nil
 	}
 
-	consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block)
+	shadow, ok := s.getShadowBlockMetadata(ctx, block)
 	if !ok {
-		legacy, ok := s.getLegacyBlockMetadata(ctx, block)
-		if !ok {
-			s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
-			return nil, xerrors.Errorf("failed to find legacy fallback block metadata for height %d: %w", block.GetHeight(), storage.ErrItemNotFound)
-		}
-		output, err := s.downloadBlockWithShadowMetrics(ctx, legacy, shadowPathLegacy)
+		output, err := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
 		if err != nil {
 			s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
-			return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", legacy, err)
+			return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", block, err)
 		}
 		s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
 		return output, nil
 	}
 
-	output, err := s.downloadBlockWithShadowMetrics(ctx, consolidated, shadowPathConsolidated)
+	output, err := s.downloadBlockWithShadowMetrics(ctx, shadow, shadowPathConsolidated)
 	if err == nil {
 		s.emitShadowReadMetric(shadowOutcomeSuccess, 1)
 		return blockWithPrimaryMetadata(output, block), nil
@@ -1014,18 +986,13 @@ func (s *Server) getBlockFromBlobStorage(ctx context.Context, block *api.BlockMe
 		zap.Uint32("tag", block.GetTag()),
 		zap.Uint64("height", block.GetHeight()),
 		zap.String("hash", block.GetHash()),
-		zap.String("consolidated_object_key", consolidated.GetObjectKeyMain()),
+		zap.String("shadow_object_key", shadow.GetObjectKeyMain()),
 		zap.Error(err),
 	)
-	legacy, ok := s.getLegacyBlockMetadata(ctx, block)
-	if !ok {
-		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
-		return nil, err
-	}
-	fallback, fallbackErr := s.downloadBlockWithShadowMetrics(ctx, legacy, shadowPathLegacy)
+	fallback, fallbackErr := s.downloadBlockWithShadowMetrics(ctx, block, shadowPathLegacy)
 	if fallbackErr != nil {
 		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, 1)
-		return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", legacy, fallbackErr)
+		return nil, xerrors.Errorf("failed to download fallback legacy block from blob storage (input={%+v}): %w", block, fallbackErr)
 	}
 	s.emitShadowReadMetric(shadowOutcomeFallbackSuccess, 1)
 	return fallback, nil
@@ -1060,12 +1027,7 @@ func (s *Server) getBlocksFromBlobStorage(ctx context.Context, blocks []*api.Blo
 		zap.Int("shadow_blocks", shadowCount),
 		zap.Error(err),
 	)
-	legacyBlocks, ok := s.selectLegacyBlockMetadata(ctx, blocks)
-	if !ok {
-		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(len(blocks)))
-		return nil, err
-	}
-	fallback, fallbackErr := s.downloadBlocksWithShadowMetrics(ctx, legacyBlocks)
+	fallback, fallbackErr := s.downloadBlocksWithShadowMetrics(ctx, blocks)
 	if fallbackErr != nil {
 		s.emitShadowReadMetric(shadowOutcomeFallbackFailure, int64(len(blocks)))
 		return nil, xerrors.Errorf("failed to download fallback legacy blocks from blob storage: %w", fallbackErr)
@@ -1094,38 +1056,6 @@ func shouldReadFromConsolidated(readSource api.BlockReadSource, defaultReadShado
 	default:
 		return defaultReadShadowFirst
 	}
-}
-
-func (s *Server) getConsolidatedBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
-	if isConsolidatedBlockMetadata(block) {
-		return block, true
-	}
-	return s.getShadowBlockMetadata(ctx, block)
-}
-
-func (s *Server) getLegacyBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
-	if !isConsolidatedBlockMetadata(block) {
-		return block, true
-	}
-
-	legacy, err := s.metaStorage.GetBlockConsolidationLegacy(ctx, block)
-	if err != nil {
-		if xerrors.Is(err, storage.ErrItemNotFound) {
-			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
-			return nil, false
-		}
-		s.emitShadowReadMetric(shadowOutcomeError, 1)
-		s.logger.Warn(
-			"legacy metadata lookup for promoted consolidated block failed",
-			zap.Uint32("tag", block.GetTag()),
-			zap.Uint64("height", block.GetHeight()),
-			zap.String("hash", block.GetHash()),
-			zap.String("consolidated_object_key", block.GetObjectKeyMain()),
-			zap.Error(err),
-		)
-		return nil, false
-	}
-	return legacy, true
 }
 
 func (s *Server) getShadowBlockMetadata(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, bool) {
@@ -1196,11 +1126,6 @@ func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.Bl
 	for i, block := range blocks {
 		shadow := shadows[i]
 		if shadow == nil {
-			if isConsolidatedBlockMetadata(block) {
-				selected[i] = block
-				shadowCount++
-				continue
-			}
 			s.emitShadowReadMetric(shadowOutcomeMiss, 1)
 			selected[i] = block
 			fallbackCount++
@@ -1228,45 +1153,6 @@ func (s *Server) selectShadowBlockMetadata(ctx context.Context, blocks []*api.Bl
 		}
 	}
 	return selected, shadowCount, fallbackCount, selectionErr
-}
-
-func (s *Server) selectLegacyBlockMetadata(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, bool) {
-	if !hasConsolidatedBlockMetadata(blocks) {
-		return blocks, true
-	}
-
-	selected := make([]*api.BlockMetadata, len(blocks))
-	legacyBlocks, err := s.metaStorage.GetBlocksConsolidationLegacy(ctx, blocks)
-	if err != nil {
-		s.emitShadowReadMetric(shadowOutcomeError, int64(len(blocks)))
-		s.logger.Warn(
-			"legacy metadata batch lookup for promoted consolidated blocks failed",
-			zap.Int("num_blocks", len(blocks)),
-			zap.Error(err),
-		)
-		return nil, false
-	}
-	if len(legacyBlocks) != len(blocks) {
-		s.emitShadowReadMetric(shadowOutcomeError, int64(len(blocks)))
-		s.logger.Warn(
-			"legacy metadata batch lookup returned invalid result count",
-			zap.Int("num_blocks", len(blocks)),
-			zap.Int("num_legacy_blocks", len(legacyBlocks)),
-		)
-		return nil, false
-	}
-	for i, block := range blocks {
-		if isConsolidatedBlockMetadata(block) {
-			if legacyBlocks[i] == nil {
-				s.emitShadowReadMetric(shadowOutcomeMiss, 1)
-				return nil, false
-			}
-			selected[i] = legacyBlocks[i]
-			continue
-		}
-		selected[i] = block
-	}
-	return selected, true
 }
 
 func (s *Server) downloadBlockWithShadowMetrics(ctx context.Context, block *api.BlockMetadata, path string) (*api.Block, error) {
@@ -1336,15 +1222,6 @@ func blocksWithPrimaryMetadata(blocks []*api.Block, metadatas []*api.BlockMetada
 
 func isConsolidatedBlockMetadata(metadata *api.BlockMetadata) bool {
 	return metadata.GetObjectFormat() == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH && metadata.GetByteLength() > 0
-}
-
-func hasConsolidatedBlockMetadata(metadatas []*api.BlockMetadata) bool {
-	for _, metadata := range metadatas {
-		if isConsolidatedBlockMetadata(metadata) {
-			return true
-		}
-	}
-	return false
 }
 
 func shadowReadErrorOutcome(err error) string {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -467,6 +467,31 @@ func (s *handlerTestSuite) TestGetBlockFile_ReadSourceConsolidatedFallsBackOnPre
 	require.Equal(expected, resp.File)
 }
 
+func (s *handlerTestSuite) TestGetBlockFile_PromotedConsolidatedPresignErrorDoesNotFallbackToLegacy() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	tag := s.app.Config().Chain.BlockTag.Stable
+	legacyMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	promotedMetadata := makeShadowBlockMetadata(legacyMetadata)
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, promotedMetadata.GetHeight(), promotedMetadata.GetHash()).Times(1).Return(promotedMetadata, nil),
+		s.blobStorage.EXPECT().PreSign(gomock.Any(), promotedMetadata.GetObjectKeyMain()).Times(1).Return("", xerrors.New("presign failed")),
+	)
+
+	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
+		Height:     promotedMetadata.GetHeight(),
+		Hash:       promotedMetadata.GetHash(),
+		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.Error(err)
+	require.Nil(resp)
+	require.Contains(err.Error(), "failed to prepare consolidated block file")
+}
+
 func (s *handlerTestSuite) TestGetBlockFile_Gzip() {
 	const (
 		height        uint64 = 13193825
@@ -1118,6 +1143,39 @@ func (s *handlerTestSuite) TestGetRawBlock_ReadSourceConsolidatedFallsBackOnShad
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
 }
 
+func (s *handlerTestSuite) TestGetRawBlock_PromotedConsolidatedDownloadErrorDoesNotFallbackToLegacy() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+
+	tag := s.app.Config().Chain.BlockTag.Stable
+	legacyMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	promotedMetadata := makeShadowBlockMetadata(legacyMetadata)
+	downloadErr := xerrors.New("consolidated object missing")
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, promotedMetadata.GetHeight(), promotedMetadata.GetHash()).Times(1).Return(promotedMetadata, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), promotedMetadata).Times(1).Return(nil, downloadErr),
+	)
+
+	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
+		Height:     promotedMetadata.GetHeight(),
+		Hash:       promotedMetadata.GetHash(),
+		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.Error(err)
+	require.Nil(resp)
+	require.Contains(err.Error(), downloadErr.Error())
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
+	require.NotContains(snapshot.Counters(), "server.shadow_read+outcome=fallback_success")
+}
+
 func (s *handlerTestSuite) TestGetRawBlock_ReadSourceConsolidatedFallsBackOnMiss() {
 	const (
 		height uint64 = 13193825
@@ -1438,6 +1496,47 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadSourceConsolidatedFallsBa
 	snapshot := scope.Snapshot()
 	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
 	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
+func (s *handlerTestSuite) TestGetRawBlocksByRange_PromotedConsolidatedDownloadErrorDoesNotFallbackToLegacy() {
+	const (
+		startHeight uint64 = 9000
+		endHeight   uint64 = 9003
+		numBlocks          = int(endHeight - startHeight)
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+
+	tag := s.app.Config().GetLatestBlockTag()
+	legacyMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, numBlocks, tag)
+	promotedMetadatas := make([]*api.BlockMetadata, len(legacyMetadatas))
+	for i, legacyMetadata := range legacyMetadatas {
+		promotedMetadatas[i] = makeShadowBlockMetadata(legacyMetadata)
+	}
+	downloadErr := xerrors.New("consolidated object missing")
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(promotedMetadatas, nil),
+		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
+		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), promotedMetadatas).Times(1).Return(make([]*api.BlockMetadata, len(promotedMetadatas)), nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), promotedMetadatas).Times(1).Return(nil, downloadErr),
+	)
+
+	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+		ReadSource:  api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.Error(err)
+	require.Nil(resp)
+	require.Contains(err.Error(), downloadErr.Error())
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
+	require.NotContains(snapshot.Counters(), "server.shadow_read+outcome=fallback_success")
 }
 
 func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadSourceConsolidatedUsesBatchLookupWithMiss() {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -136,6 +136,16 @@ func makeShadowBlockMetadata(block *api.BlockMetadata) *api.BlockMetadata {
 	return shadow
 }
 
+func makeLegacyBlockMetadata(block *api.BlockMetadata, objectKey string) *api.BlockMetadata {
+	legacy := proto.Clone(block).(*api.BlockMetadata)
+	legacy.ObjectKeyMain = objectKey
+	legacy.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
+	legacy.ByteOffset = 0
+	legacy.ByteLength = 0
+	legacy.UncompressedLength = 0
+	return legacy
+}
+
 func TestIsShadowValidationError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -455,6 +465,49 @@ func (s *handlerTestSuite) TestGetBlockFile_ReadSourceConsolidatedFallsBackOnPre
 		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(shadowMetadata, nil),
 		s.blobStorage.EXPECT().PreSign(gomock.Any(), shadowMetadata.GetObjectKeyMain()).Times(1).Return("", xerrors.New("presign failed")),
 		s.blobStorage.EXPECT().PreSign(gomock.Any(), objectKeyMain).Times(1).Return("http://endpoint/legacy", nil),
+	)
+
+	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
+		Height:     height,
+		Hash:       hash,
+		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(expected, resp.File)
+}
+
+func (s *handlerTestSuite) TestGetBlockFile_PromotedConsolidatedFallsBackToLegacy() {
+	const (
+		height              uint64 = 13193825
+		hash                       = "0xda5a0439434adf072394e0b94f78e56032c5409a2c58668995f306b171ff4ace"
+		parentHash                 = "0xba6a6c85739b50384625e10718524fb2c1fcf88858eabf6db9bd851902b53546"
+		legacyObjectKeyMain        = "legacy/foo/bar"
+	)
+
+	require := testutil.Require(s.T())
+	tag := s.app.Config().Chain.BlockTag.Stable
+	legacyMetadata := &api.BlockMetadata{
+		Tag:           tag,
+		Hash:          hash,
+		ParentHash:    parentHash,
+		Height:        height,
+		ObjectKeyMain: legacyObjectKeyMain,
+	}
+	promotedMetadata := makeShadowBlockMetadata(legacyMetadata)
+	expected := &api.BlockFile{
+		Tag:        tag,
+		Hash:       hash,
+		ParentHash: parentHash,
+		Height:     height,
+		FileUrl:    "http://endpoint/legacy",
+	}
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, height, hash).Times(1).Return(promotedMetadata, nil),
+		s.blobStorage.EXPECT().PreSign(gomock.Any(), promotedMetadata.GetObjectKeyMain()).Times(1).Return("", xerrors.New("presign failed")),
+		s.metaStorage.EXPECT().GetBlockConsolidationLegacy(gomock.Any(), promotedMetadata).Times(1).Return(legacyMetadata, nil),
+		s.blobStorage.EXPECT().PreSign(gomock.Any(), legacyObjectKeyMain).Times(1).Return("http://endpoint/legacy", nil),
 	)
 
 	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
@@ -1118,6 +1171,41 @@ func (s *handlerTestSuite) TestGetRawBlock_ReadSourceConsolidatedFallsBackOnShad
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
 }
 
+func (s *handlerTestSuite) TestGetRawBlock_PromotedConsolidatedFallsBackToLegacy() {
+	const (
+		height uint64 = 13193825
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+
+	tag := s.app.Config().Chain.BlockTag.Stable
+	legacyMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
+	promotedMetadata := makeShadowBlockMetadata(legacyMetadata)
+	legacyBlock := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, promotedMetadata.GetHeight(), promotedMetadata.GetHash()).Times(1).Return(promotedMetadata, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), promotedMetadata).Times(1).Return(nil, xerrors.New("consolidated object missing")),
+		s.metaStorage.EXPECT().GetBlockConsolidationLegacy(gomock.Any(), promotedMetadata).Times(1).Return(legacyMetadata, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), legacyMetadata).Times(1).Return(legacyBlock, nil),
+	)
+
+	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
+		Height:     promotedMetadata.GetHeight(),
+		Hash:       promotedMetadata.GetHash(),
+		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(legacyBlock, resp.Block)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
+	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
 func (s *handlerTestSuite) TestGetRawBlock_ReadSourceConsolidatedFallsBackOnMiss() {
 	const (
 		height uint64 = 13193825
@@ -1434,6 +1522,53 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadSourceConsolidatedFallsBa
 	require.NoError(err)
 	require.NotNil(resp)
 	require.Equal(blocks, resp.Blocks)
+
+	snapshot := scope.Snapshot()
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
+	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
+}
+
+func (s *handlerTestSuite) TestGetRawBlocksByRange_PromotedConsolidatedFallsBackToLegacy() {
+	const (
+		startHeight uint64 = 9000
+		endHeight   uint64 = 9003
+		numBlocks          = int(endHeight - startHeight)
+	)
+
+	require := testutil.Require(s.T())
+	scope := tally.NewTestScope("", nil)
+	s.server.metrics = newServerMetrics(scope)
+
+	tag := s.app.Config().GetLatestBlockTag()
+	legacyMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, numBlocks, tag)
+	promotedMetadatas := make([]*api.BlockMetadata, len(legacyMetadatas))
+	for i, legacyMetadata := range legacyMetadatas {
+		promotedMetadatas[i] = makeShadowBlockMetadata(legacyMetadata)
+	}
+	legacyBlocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+	expectedBlocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+	for i, block := range expectedBlocks {
+		block.Metadata = promotedMetadatas[i]
+	}
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(promotedMetadatas, nil),
+		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
+		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), promotedMetadatas).Times(1).Return(make([]*api.BlockMetadata, len(promotedMetadatas)), nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), promotedMetadatas).Times(1).Return(nil, xerrors.New("consolidated object missing")),
+		s.metaStorage.EXPECT().GetBlocksConsolidationLegacy(gomock.Any(), promotedMetadatas).Times(1).Return(legacyMetadatas, nil),
+		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), legacyMetadatas).Times(1).Return(legacyBlocks, nil),
+	)
+
+	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
+		Tag:         tag,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+		ReadSource:  api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(expectedBlocks, resp.Blocks)
 
 	snapshot := scope.Snapshot()
 	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -136,16 +136,6 @@ func makeShadowBlockMetadata(block *api.BlockMetadata) *api.BlockMetadata {
 	return shadow
 }
 
-func makeLegacyBlockMetadata(block *api.BlockMetadata, objectKey string) *api.BlockMetadata {
-	legacy := proto.Clone(block).(*api.BlockMetadata)
-	legacy.ObjectKeyMain = objectKey
-	legacy.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
-	legacy.ByteOffset = 0
-	legacy.ByteLength = 0
-	legacy.UncompressedLength = 0
-	return legacy
-}
-
 func TestIsShadowValidationError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -465,49 +455,6 @@ func (s *handlerTestSuite) TestGetBlockFile_ReadSourceConsolidatedFallsBackOnPre
 		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(shadowMetadata, nil),
 		s.blobStorage.EXPECT().PreSign(gomock.Any(), shadowMetadata.GetObjectKeyMain()).Times(1).Return("", xerrors.New("presign failed")),
 		s.blobStorage.EXPECT().PreSign(gomock.Any(), objectKeyMain).Times(1).Return("http://endpoint/legacy", nil),
-	)
-
-	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
-		Height:     height,
-		Hash:       hash,
-		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
-	})
-	require.NoError(err)
-	require.NotNil(resp)
-	require.Equal(expected, resp.File)
-}
-
-func (s *handlerTestSuite) TestGetBlockFile_PromotedConsolidatedFallsBackToLegacy() {
-	const (
-		height              uint64 = 13193825
-		hash                       = "0xda5a0439434adf072394e0b94f78e56032c5409a2c58668995f306b171ff4ace"
-		parentHash                 = "0xba6a6c85739b50384625e10718524fb2c1fcf88858eabf6db9bd851902b53546"
-		legacyObjectKeyMain        = "legacy/foo/bar"
-	)
-
-	require := testutil.Require(s.T())
-	tag := s.app.Config().Chain.BlockTag.Stable
-	legacyMetadata := &api.BlockMetadata{
-		Tag:           tag,
-		Hash:          hash,
-		ParentHash:    parentHash,
-		Height:        height,
-		ObjectKeyMain: legacyObjectKeyMain,
-	}
-	promotedMetadata := makeShadowBlockMetadata(legacyMetadata)
-	expected := &api.BlockFile{
-		Tag:        tag,
-		Hash:       hash,
-		ParentHash: parentHash,
-		Height:     height,
-		FileUrl:    "http://endpoint/legacy",
-	}
-
-	gomock.InOrder(
-		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, height, hash).Times(1).Return(promotedMetadata, nil),
-		s.blobStorage.EXPECT().PreSign(gomock.Any(), promotedMetadata.GetObjectKeyMain()).Times(1).Return("", xerrors.New("presign failed")),
-		s.metaStorage.EXPECT().GetBlockConsolidationLegacy(gomock.Any(), promotedMetadata).Times(1).Return(legacyMetadata, nil),
-		s.blobStorage.EXPECT().PreSign(gomock.Any(), legacyObjectKeyMain).Times(1).Return("http://endpoint/legacy", nil),
 	)
 
 	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
@@ -1171,41 +1118,6 @@ func (s *handlerTestSuite) TestGetRawBlock_ReadSourceConsolidatedFallsBackOnShad
 	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
 }
 
-func (s *handlerTestSuite) TestGetRawBlock_PromotedConsolidatedFallsBackToLegacy() {
-	const (
-		height uint64 = 13193825
-	)
-
-	require := testutil.Require(s.T())
-	scope := tally.NewTestScope("", nil)
-	s.server.metrics = newServerMetrics(scope)
-
-	tag := s.app.Config().Chain.BlockTag.Stable
-	legacyMetadata := testutil.MakeBlockMetadatasFromStartHeight(height, 1, tag)[0]
-	promotedMetadata := makeShadowBlockMetadata(legacyMetadata)
-	legacyBlock := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
-
-	gomock.InOrder(
-		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, promotedMetadata.GetHeight(), promotedMetadata.GetHash()).Times(1).Return(promotedMetadata, nil),
-		s.blobStorage.EXPECT().Download(gomock.Any(), promotedMetadata).Times(1).Return(nil, xerrors.New("consolidated object missing")),
-		s.metaStorage.EXPECT().GetBlockConsolidationLegacy(gomock.Any(), promotedMetadata).Times(1).Return(legacyMetadata, nil),
-		s.blobStorage.EXPECT().Download(gomock.Any(), legacyMetadata).Times(1).Return(legacyBlock, nil),
-	)
-
-	resp, err := s.server.GetRawBlock(context.Background(), &api.GetRawBlockRequest{
-		Height:     promotedMetadata.GetHeight(),
-		Hash:       promotedMetadata.GetHash(),
-		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
-	})
-	require.NoError(err)
-	require.NotNil(resp)
-	require.Equal(legacyBlock, resp.Block)
-
-	snapshot := scope.Snapshot()
-	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
-	require.Equal(int64(1), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
-}
-
 func (s *handlerTestSuite) TestGetRawBlock_ReadSourceConsolidatedFallsBackOnMiss() {
 	const (
 		height uint64 = 13193825
@@ -1522,53 +1434,6 @@ func (s *handlerTestSuite) TestGetRawBlocksByRange_ReadSourceConsolidatedFallsBa
 	require.NoError(err)
 	require.NotNil(resp)
 	require.Equal(blocks, resp.Blocks)
-
-	snapshot := scope.Snapshot()
-	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())
-	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=fallback_success"].Value())
-}
-
-func (s *handlerTestSuite) TestGetRawBlocksByRange_PromotedConsolidatedFallsBackToLegacy() {
-	const (
-		startHeight uint64 = 9000
-		endHeight   uint64 = 9003
-		numBlocks          = int(endHeight - startHeight)
-	)
-
-	require := testutil.Require(s.T())
-	scope := tally.NewTestScope("", nil)
-	s.server.metrics = newServerMetrics(scope)
-
-	tag := s.app.Config().GetLatestBlockTag()
-	legacyMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, numBlocks, tag)
-	promotedMetadatas := make([]*api.BlockMetadata, len(legacyMetadatas))
-	for i, legacyMetadata := range legacyMetadatas {
-		promotedMetadatas[i] = makeShadowBlockMetadata(legacyMetadata)
-	}
-	legacyBlocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
-	expectedBlocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
-	for i, block := range expectedBlocks {
-		block.Metadata = promotedMetadatas[i]
-	}
-
-	gomock.InOrder(
-		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), tag, startHeight, endHeight).Times(1).Return(promotedMetadatas, nil),
-		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), tag).Times(1).Return(testutil.MakeBlockMetadata(10000, tag), nil),
-		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), promotedMetadatas).Times(1).Return(make([]*api.BlockMetadata, len(promotedMetadatas)), nil),
-		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), promotedMetadatas).Times(1).Return(nil, xerrors.New("consolidated object missing")),
-		s.metaStorage.EXPECT().GetBlocksConsolidationLegacy(gomock.Any(), promotedMetadatas).Times(1).Return(legacyMetadatas, nil),
-		s.blobStorage.EXPECT().DownloadMany(gomock.Any(), legacyMetadatas).Times(1).Return(legacyBlocks, nil),
-	)
-
-	resp, err := s.server.GetRawBlocksByRange(context.Background(), &api.GetRawBlocksByRangeRequest{
-		Tag:         tag,
-		StartHeight: startHeight,
-		EndHeight:   endHeight,
-		ReadSource:  api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
-	})
-	require.NoError(err)
-	require.NotNil(resp)
-	require.Equal(expectedBlocks, resp.Blocks)
 
 	snapshot := scope.Snapshot()
 	require.Equal(int64(numBlocks), snapshot.Counters()["server.shadow_read+outcome=error"].Value())

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -313,7 +314,7 @@ func (a *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for DynamoDB")
 }
 
-func (a *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*internal.ConsolidationPromotionResult, error) {
+func (a *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64, legacyObjectRetention time.Duration) (*internal.ConsolidationPromotionResult, error) {
 	return nil, xerrors.New("PromoteBlockConsolidationShadows not implemented for DynamoDB")
 }
 

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -286,6 +286,14 @@ func (a *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blo
 	return nil, xerrors.New("GetBlocksConsolidationShadow not implemented for DynamoDB")
 }
 
+func (a *blockStorageImpl) GetBlockConsolidationLegacy(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlockConsolidationLegacy not implemented for DynamoDB")
+}
+
+func (a *blockStorageImpl) GetBlocksConsolidationLegacy(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlocksConsolidationLegacy not implemented for DynamoDB")
+}
+
 func (a *blockStorageImpl) GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*internal.BlockMetadataRecord, error) {
 	return nil, xerrors.New("GetBlocksMissingConsolidationShadow not implemented for DynamoDB")
 }

--- a/internal/storage/metastorage/dynamodb/block_storage.go
+++ b/internal/storage/metastorage/dynamodb/block_storage.go
@@ -286,14 +286,6 @@ func (a *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blo
 	return nil, xerrors.New("GetBlocksConsolidationShadow not implemented for DynamoDB")
 }
 
-func (a *blockStorageImpl) GetBlockConsolidationLegacy(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
-	return nil, xerrors.New("GetBlockConsolidationLegacy not implemented for DynamoDB")
-}
-
-func (a *blockStorageImpl) GetBlocksConsolidationLegacy(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error) {
-	return nil, xerrors.New("GetBlocksConsolidationLegacy not implemented for DynamoDB")
-}
-
 func (a *blockStorageImpl) GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*internal.BlockMetadataRecord, error) {
 	return nil, xerrors.New("GetBlocksMissingConsolidationShadow not implemented for DynamoDB")
 }

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -259,6 +259,14 @@ func (b *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blo
 	return nil, xerrors.New("GetBlocksConsolidationShadow not implemented for Firestore")
 }
 
+func (b *blockStorageImpl) GetBlockConsolidationLegacy(ctx context.Context, block *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlockConsolidationLegacy not implemented for Firestore")
+}
+
+func (b *blockStorageImpl) GetBlocksConsolidationLegacy(ctx context.Context, blocks []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
+	return nil, xerrors.New("GetBlocksConsolidationLegacy not implemented for Firestore")
+}
+
 func (b *blockStorageImpl) GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*internal.BlockMetadataRecord, error) {
 	return nil, xerrors.New("GetBlocksMissingConsolidationShadow not implemented for Firestore")
 }

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -259,14 +259,6 @@ func (b *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blo
 	return nil, xerrors.New("GetBlocksConsolidationShadow not implemented for Firestore")
 }
 
-func (b *blockStorageImpl) GetBlockConsolidationLegacy(ctx context.Context, block *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
-	return nil, xerrors.New("GetBlockConsolidationLegacy not implemented for Firestore")
-}
-
-func (b *blockStorageImpl) GetBlocksConsolidationLegacy(ctx context.Context, blocks []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
-	return nil, xerrors.New("GetBlocksConsolidationLegacy not implemented for Firestore")
-}
-
 func (b *blockStorageImpl) GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*internal.BlockMetadataRecord, error) {
 	return nil, xerrors.New("GetBlocksMissingConsolidationShadow not implemented for Firestore")
 }

--- a/internal/storage/metastorage/firestore/block_storage.go
+++ b/internal/storage/metastorage/firestore/block_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"golang.org/x/xerrors"
@@ -286,7 +287,7 @@ func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 	return xerrors.New("PersistBlockConsolidationShadows not implemented for Firestore")
 }
 
-func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*internal.ConsolidationPromotionResult, error) {
+func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64, legacyObjectRetention time.Duration) (*internal.ConsolidationPromotionResult, error) {
 	return nil, xerrors.New("PromoteBlockConsolidationShadows not implemented for Firestore")
 }
 

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -27,6 +27,8 @@ type (
 		GetBlockByTimestamp(ctx context.Context, tag uint32, timestamp uint64) (*api.BlockMetadata, error)
 		GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error)
 		GetBlocksConsolidationShadow(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error)
+		GetBlockConsolidationLegacy(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error)
+		GetBlocksConsolidationLegacy(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error)
 		GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*BlockMetadataRecord, error)
 		GetBlockConsolidationShadowStats(ctx context.Context, tag uint32, startHeight, endHeight uint64) (*ConsolidationShadowStats, error)
 		GetFirstBlockMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error)

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
@@ -33,7 +34,7 @@ type (
 		GetBlockConsolidationCursor(ctx context.Context, name string, tag uint32) (uint64, bool, error)
 		SetBlockConsolidationCursor(ctx context.Context, name string, tag uint32, height uint64) error
 		PersistBlockConsolidationShadows(ctx context.Context, placements []*ConsolidationShadowPlacement) error
-		PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*ConsolidationPromotionResult, error)
+		PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64, legacyObjectRetention time.Duration) (*ConsolidationPromotionResult, error)
 	}
 
 	EventStorage interface {

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -27,8 +27,6 @@ type (
 		GetBlockByTimestamp(ctx context.Context, tag uint32, timestamp uint64) (*api.BlockMetadata, error)
 		GetBlockConsolidationShadow(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error)
 		GetBlocksConsolidationShadow(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error)
-		GetBlockConsolidationLegacy(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error)
-		GetBlocksConsolidationLegacy(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error)
 		GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*BlockMetadataRecord, error)
 		GetBlockConsolidationShadowStats(ctx context.Context, tag uint32, startHeight, endHeight uint64) (*ConsolidationShadowStats, error)
 		GetFirstBlockMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64) (uint64, bool, error)

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -95,8 +95,9 @@ type (
 	}
 
 	ConsolidationShadowStats struct {
-		Objects uint64
-		Blocks  uint64
+		Objects        uint64
+		Blocks         uint64
+		EligibleBlocks uint64
 	}
 
 	ConsolidationPromotionResult struct {

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -146,6 +146,21 @@ func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationCursor(arg0, arg1, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationCursor", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationCursor), arg0, arg1, arg2)
 }
 
+// GetBlockConsolidationLegacy mocks base method.
+func (m *MockMetaStorage) GetBlockConsolidationLegacy(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockConsolidationLegacy", arg0, arg1)
+	ret0, _ := ret[0].(*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockConsolidationLegacy indicates an expected call of GetBlockConsolidationLegacy.
+func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationLegacy(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationLegacy", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationLegacy), arg0, arg1)
+}
+
 // GetBlockConsolidationShadow mocks base method.
 func (m *MockMetaStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -204,6 +219,21 @@ func (m *MockMetaStorage) GetBlocksByHeights(arg0 context.Context, arg1 uint32, 
 func (mr *MockMetaStorageMockRecorder) GetBlocksByHeights(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksByHeights", reflect.TypeOf((*MockMetaStorage)(nil).GetBlocksByHeights), arg0, arg1, arg2)
+}
+
+// GetBlocksConsolidationLegacy mocks base method.
+func (m *MockMetaStorage) GetBlocksConsolidationLegacy(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlocksConsolidationLegacy", arg0, arg1)
+	ret0, _ := ret[0].([]*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlocksConsolidationLegacy indicates an expected call of GetBlocksConsolidationLegacy.
+func (mr *MockMetaStorageMockRecorder) GetBlocksConsolidationLegacy(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksConsolidationLegacy", reflect.TypeOf((*MockMetaStorage)(nil).GetBlocksConsolidationLegacy), arg0, arg1)
 }
 
 // GetBlocksConsolidationShadow mocks base method.
@@ -698,6 +728,21 @@ func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationCursor(arg0, arg1, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationCursor", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationCursor), arg0, arg1, arg2)
 }
 
+// GetBlockConsolidationLegacy mocks base method.
+func (m *MockBlockStorage) GetBlockConsolidationLegacy(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockConsolidationLegacy", arg0, arg1)
+	ret0, _ := ret[0].(*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockConsolidationLegacy indicates an expected call of GetBlockConsolidationLegacy.
+func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationLegacy(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationLegacy", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationLegacy), arg0, arg1)
+}
+
 // GetBlockConsolidationShadow mocks base method.
 func (m *MockBlockStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -756,6 +801,21 @@ func (m *MockBlockStorage) GetBlocksByHeights(arg0 context.Context, arg1 uint32,
 func (mr *MockBlockStorageMockRecorder) GetBlocksByHeights(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksByHeights", reflect.TypeOf((*MockBlockStorage)(nil).GetBlocksByHeights), arg0, arg1, arg2)
+}
+
+// GetBlocksConsolidationLegacy mocks base method.
+func (m *MockBlockStorage) GetBlocksConsolidationLegacy(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlocksConsolidationLegacy", arg0, arg1)
+	ret0, _ := ret[0].([]*chainstorage.BlockMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlocksConsolidationLegacy indicates an expected call of GetBlocksConsolidationLegacy.
+func (mr *MockBlockStorageMockRecorder) GetBlocksConsolidationLegacy(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksConsolidationLegacy", reflect.TypeOf((*MockBlockStorage)(nil).GetBlocksConsolidationLegacy), arg0, arg1)
 }
 
 // GetBlocksConsolidationShadow mocks base method.

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -12,6 +12,7 @@ package metastoragemocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	internal "github.com/coinbase/chainstorage/internal/storage/metastorage/internal"
 	model "github.com/coinbase/chainstorage/internal/storage/metastorage/model"
@@ -416,18 +417,18 @@ func (mr *MockMetaStorageMockRecorder) PersistBlockMetas(arg0, arg1, arg2, arg3 
 }
 
 // PromoteBlockConsolidationShadows mocks base method.
-func (m *MockMetaStorage) PromoteBlockConsolidationShadows(arg0 context.Context, arg1 uint32, arg2, arg3, arg4 uint64) (*internal.ConsolidationPromotionResult, error) {
+func (m *MockMetaStorage) PromoteBlockConsolidationShadows(arg0 context.Context, arg1 uint32, arg2, arg3, arg4 uint64, arg5 time.Duration) (*internal.ConsolidationPromotionResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PromoteBlockConsolidationShadows", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "PromoteBlockConsolidationShadows", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*internal.ConsolidationPromotionResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PromoteBlockConsolidationShadows indicates an expected call of PromoteBlockConsolidationShadows.
-func (mr *MockMetaStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockMetaStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockMetaStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockMetaStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // SetBlockConsolidationCursor mocks base method.
@@ -863,18 +864,18 @@ func (mr *MockBlockStorageMockRecorder) PersistBlockMetas(arg0, arg1, arg2, arg3
 }
 
 // PromoteBlockConsolidationShadows mocks base method.
-func (m *MockBlockStorage) PromoteBlockConsolidationShadows(arg0 context.Context, arg1 uint32, arg2, arg3, arg4 uint64) (*internal.ConsolidationPromotionResult, error) {
+func (m *MockBlockStorage) PromoteBlockConsolidationShadows(arg0 context.Context, arg1 uint32, arg2, arg3, arg4 uint64, arg5 time.Duration) (*internal.ConsolidationPromotionResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PromoteBlockConsolidationShadows", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "PromoteBlockConsolidationShadows", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*internal.ConsolidationPromotionResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PromoteBlockConsolidationShadows indicates an expected call of PromoteBlockConsolidationShadows.
-func (mr *MockBlockStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockBlockStorageMockRecorder) PromoteBlockConsolidationShadows(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockBlockStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PromoteBlockConsolidationShadows", reflect.TypeOf((*MockBlockStorage)(nil).PromoteBlockConsolidationShadows), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // SetBlockConsolidationCursor mocks base method.

--- a/internal/storage/metastorage/mocks/mocks.go
+++ b/internal/storage/metastorage/mocks/mocks.go
@@ -146,21 +146,6 @@ func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationCursor(arg0, arg1, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationCursor", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationCursor), arg0, arg1, arg2)
 }
 
-// GetBlockConsolidationLegacy mocks base method.
-func (m *MockMetaStorage) GetBlockConsolidationLegacy(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlockConsolidationLegacy", arg0, arg1)
-	ret0, _ := ret[0].(*chainstorage.BlockMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBlockConsolidationLegacy indicates an expected call of GetBlockConsolidationLegacy.
-func (mr *MockMetaStorageMockRecorder) GetBlockConsolidationLegacy(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationLegacy", reflect.TypeOf((*MockMetaStorage)(nil).GetBlockConsolidationLegacy), arg0, arg1)
-}
-
 // GetBlockConsolidationShadow mocks base method.
 func (m *MockMetaStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -219,21 +204,6 @@ func (m *MockMetaStorage) GetBlocksByHeights(arg0 context.Context, arg1 uint32, 
 func (mr *MockMetaStorageMockRecorder) GetBlocksByHeights(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksByHeights", reflect.TypeOf((*MockMetaStorage)(nil).GetBlocksByHeights), arg0, arg1, arg2)
-}
-
-// GetBlocksConsolidationLegacy mocks base method.
-func (m *MockMetaStorage) GetBlocksConsolidationLegacy(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlocksConsolidationLegacy", arg0, arg1)
-	ret0, _ := ret[0].([]*chainstorage.BlockMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBlocksConsolidationLegacy indicates an expected call of GetBlocksConsolidationLegacy.
-func (mr *MockMetaStorageMockRecorder) GetBlocksConsolidationLegacy(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksConsolidationLegacy", reflect.TypeOf((*MockMetaStorage)(nil).GetBlocksConsolidationLegacy), arg0, arg1)
 }
 
 // GetBlocksConsolidationShadow mocks base method.
@@ -728,21 +698,6 @@ func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationCursor(arg0, arg1, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationCursor", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationCursor), arg0, arg1, arg2)
 }
 
-// GetBlockConsolidationLegacy mocks base method.
-func (m *MockBlockStorage) GetBlockConsolidationLegacy(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlockConsolidationLegacy", arg0, arg1)
-	ret0, _ := ret[0].(*chainstorage.BlockMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBlockConsolidationLegacy indicates an expected call of GetBlockConsolidationLegacy.
-func (mr *MockBlockStorageMockRecorder) GetBlockConsolidationLegacy(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockConsolidationLegacy", reflect.TypeOf((*MockBlockStorage)(nil).GetBlockConsolidationLegacy), arg0, arg1)
-}
-
 // GetBlockConsolidationShadow mocks base method.
 func (m *MockBlockStorage) GetBlockConsolidationShadow(arg0 context.Context, arg1 *chainstorage.BlockMetadata) (*chainstorage.BlockMetadata, error) {
 	m.ctrl.T.Helper()
@@ -801,21 +756,6 @@ func (m *MockBlockStorage) GetBlocksByHeights(arg0 context.Context, arg1 uint32,
 func (mr *MockBlockStorageMockRecorder) GetBlocksByHeights(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksByHeights", reflect.TypeOf((*MockBlockStorage)(nil).GetBlocksByHeights), arg0, arg1, arg2)
-}
-
-// GetBlocksConsolidationLegacy mocks base method.
-func (m *MockBlockStorage) GetBlocksConsolidationLegacy(arg0 context.Context, arg1 []*chainstorage.BlockMetadata) ([]*chainstorage.BlockMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlocksConsolidationLegacy", arg0, arg1)
-	ret0, _ := ret[0].([]*chainstorage.BlockMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBlocksConsolidationLegacy indicates an expected call of GetBlocksConsolidationLegacy.
-func (mr *MockBlockStorageMockRecorder) GetBlocksConsolidationLegacy(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocksConsolidationLegacy", reflect.TypeOf((*MockBlockStorage)(nil).GetBlocksConsolidationLegacy), arg0, arg1)
 }
 
 // GetBlocksConsolidationShadow mocks base method.

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -783,7 +783,6 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 		FROM canonical_blocks cb
 		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
 		JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
-			AND shadow.legacy_object_key_main = bm.object_key_main
 			AND shadow.tag = cb.tag
 			AND shadow.height = cb.height
 			AND shadow.hash = bm.hash
@@ -794,6 +793,16 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 			AND shadow.height >= $2
 			AND shadow.height < $3
 			AND bm.skipped = false
+			AND (
+				shadow.legacy_object_key_main = bm.object_key_main
+				OR (
+					bm.object_key_main = shadow.consolidated_object_key_main
+					AND bm.object_format = shadow.object_format
+					AND bm.byte_offset = shadow.byte_offset
+					AND bm.byte_length = shadow.byte_length
+					AND bm.uncompressed_length = shadow.uncompressed_length
+				)
+			)
 			AND bm.object_key_main IS NOT NULL
 			AND bm.object_key_main <> ''
 			AND shadow.validated_at IS NOT NULL
@@ -970,16 +979,28 @@ func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 	return nil
 }
 
-func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) (*internal.ConsolidationPromotionResult, error) {
+func (b *blockStorageImpl) PromoteBlockConsolidationShadows(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	limit uint64,
+	legacyObjectRetention time.Duration,
+) (*internal.ConsolidationPromotionResult, error) {
 	if endHeight <= startHeight {
 		return &internal.ConsolidationPromotionResult{}, nil
 	}
 	if limit == 0 {
 		return nil, xerrors.New("consolidation promotion limit must be positive")
 	}
+	if legacyObjectRetention <= 0 {
+		return nil, xerrors.New("legacy object retention must be positive")
+	}
 	if err := b.validateHeight(startHeight); err != nil {
 		return nil, err
 	}
+	legacyObjectRetiredAt := time.Now().UTC()
+	legacyObjectRetireAfter := legacyObjectRetiredAt.Add(legacyObjectRetention)
 
 	tx, err := b.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1093,12 +1114,26 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context,
 				AND bm.skipped = false
 				AND bm.byte_length IS NULL
 			RETURNING bm.id
+		),
+		retired AS (
+			UPDATE block_consolidation_shadow shadow
+			SET
+				legacy_object_retired_at = $6,
+				legacy_object_retire_after = $7
+			FROM candidates
+			WHERE shadow.block_metadata_id = candidates.block_metadata_id
+				AND shadow.tag = candidates.tag
+				AND shadow.height = candidates.height
+				AND shadow.hash = candidates.hash
+				AND shadow.legacy_object_key_main = candidates.legacy_object_key_main
+			RETURNING shadow.block_metadata_id
 		)
 		SELECT
 			(SELECT COUNT(*) FROM candidates),
-			(SELECT COUNT(*) FROM updated)`
+			(SELECT COUNT(*) FROM updated),
+			(SELECT COUNT(*) FROM retired)`
 
-	var candidates, promoted uint64
+	var candidates, promoted, retired uint64
 	if err := tx.QueryRowContext(
 		ctx,
 		promoteQuery,
@@ -1107,11 +1142,16 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(ctx context.Context,
 		endHeight,
 		limit,
 		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
-	).Scan(&candidates, &promoted); err != nil {
+		legacyObjectRetiredAt,
+		legacyObjectRetireAfter,
+	).Scan(&candidates, &promoted, &retired); err != nil {
 		return nil, xerrors.Errorf("failed to promote consolidation shadows: %w", err)
 	}
 	if candidates != promoted {
 		return nil, xerrors.Errorf("consolidation promotion guard failed: selected %d rows but promoted %d", candidates, promoted)
+	}
+	if candidates != retired {
+		return nil, xerrors.Errorf("consolidation retirement guard failed: selected %d rows but marked %d for retirement", candidates, retired)
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, xerrors.Errorf("failed to commit consolidation promotion: %w", err)

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -646,110 +646,6 @@ func (b *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blo
 	return shadows, nil
 }
 
-func (b *blockStorageImpl) GetBlockConsolidationLegacy(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
-	blocks, err := b.GetBlocksConsolidationLegacy(ctx, []*api.BlockMetadata{block})
-	if err != nil {
-		return nil, err
-	}
-	if len(blocks) == 0 || blocks[0] == nil {
-		return nil, xerrors.Errorf("consolidation legacy metadata not found: %w", errors.ErrItemNotFound)
-	}
-	return blocks[0], nil
-}
-
-func (b *blockStorageImpl) GetBlocksConsolidationLegacy(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error) {
-	legacyBlocks := make([]*api.BlockMetadata, len(blocks))
-	placeholders := make([]string, 0, len(blocks))
-	args := make([]interface{}, 0, len(blocks)*9)
-	nextArg := 1
-	for i, block := range blocks {
-		if block.GetSkipped() || block.GetObjectFormat() != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH {
-			continue
-		}
-		placeholders = append(placeholders, fmt.Sprintf(
-			"($%d::int, $%d::int, $%d::bigint, $%d::varchar, $%d::text, $%d::int, $%d::bigint, $%d::bigint, $%d::bigint)",
-			nextArg,
-			nextArg+1,
-			nextArg+2,
-			nextArg+3,
-			nextArg+4,
-			nextArg+5,
-			nextArg+6,
-			nextArg+7,
-			nextArg+8,
-		))
-		args = append(
-			args,
-			i,
-			block.GetTag(),
-			block.GetHeight(),
-			block.GetHash(),
-			block.GetObjectKeyMain(),
-			int32(block.GetObjectFormat()),
-			block.GetByteOffset(),
-			block.GetByteLength(),
-			block.GetUncompressedLength(),
-		)
-		nextArg += 9
-	}
-	if len(placeholders) == 0 {
-		return legacyBlocks, nil
-	}
-
-	query := fmt.Sprintf(`
-		WITH input(ord, tag, height, hash, consolidated_object_key_main, object_format, byte_offset, byte_length, uncompressed_length) AS (
-			VALUES %s
-		)
-		SELECT
-			input.ord,
-			shadow.legacy_object_key_main
-		FROM input
-		LEFT JOIN LATERAL (
-			SELECT legacy_object_key_main
-			FROM block_consolidation_shadow
-			WHERE tag = input.tag
-				AND height = input.height
-				AND hash = input.hash
-				AND consolidated_object_key_main = input.consolidated_object_key_main
-				AND object_format = input.object_format
-				AND byte_offset = input.byte_offset
-				AND byte_length = input.byte_length
-				AND uncompressed_length = input.uncompressed_length
-				AND validated_at IS NOT NULL
-				AND legacy_object_key_main IS NOT NULL
-				AND legacy_object_key_main <> ''
-			ORDER BY created_at DESC
-			LIMIT 1
-		) shadow ON true
-		ORDER BY input.ord ASC`, strings.Join(placeholders, ", "))
-	rows, err := b.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to get consolidation legacy metadata: %w", err)
-	}
-	defer func() {
-		_ = rows.Close()
-	}()
-
-	for rows.Next() {
-		var ord int
-		var legacyKey sql.NullString
-		if err := rows.Scan(&ord, &legacyKey); err != nil {
-			return nil, xerrors.Errorf("failed to scan consolidation legacy metadata: %w", err)
-		}
-		if !legacyKey.Valid {
-			continue
-		}
-		if ord < 0 || ord >= len(blocks) {
-			return nil, xerrors.Errorf("consolidation legacy input order out of range: %d", ord)
-		}
-		legacyBlocks[ord] = makeConsolidationLegacyBlockMetadata(blocks[ord], legacyKey.String)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, xerrors.Errorf("failed to iterate consolidation legacy metadata: %w", err)
-	}
-	return legacyBlocks, nil
-}
-
 func (b *blockStorageImpl) GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*internal.BlockMetadataRecord, error) {
 	if endHeight <= startHeight {
 		return nil, nil
@@ -1281,16 +1177,6 @@ func makeConsolidationShadowBlockMetadata(
 	shadow.ByteLength = byteLength
 	shadow.UncompressedLength = uncompressedLength
 	return shadow
-}
-
-func makeConsolidationLegacyBlockMetadata(block *api.BlockMetadata, objectKey string) *api.BlockMetadata {
-	legacy := proto.Clone(block).(*api.BlockMetadata)
-	legacy.ObjectKeyMain = objectKey
-	legacy.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
-	legacy.ByteOffset = 0
-	legacy.ByteLength = 0
-	legacy.UncompressedLength = 0
-	return legacy
 }
 
 func uint64Value(value sql.NullInt64) uint64 {

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -810,13 +810,25 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 			AND shadow.height >= $2
 			AND shadow.height < $3
 			AND (
-				shadow.legacy_object_key_main = eligible.object_key_main
+				(
+					shadow.legacy_object_key_main = eligible.object_key_main
+					AND eligible.byte_length IS NULL
+					AND shadow.object_format = $4
+					AND shadow.byte_offset >= 0
+					AND shadow.byte_length > 0
+					AND shadow.uncompressed_length IS NOT NULL
+					AND shadow.uncompressed_length > 0
+				)
 				OR (
 					eligible.object_key_main = shadow.consolidated_object_key_main
+					AND eligible.object_format = $4
 					AND eligible.object_format = shadow.object_format
 					AND eligible.byte_offset = shadow.byte_offset
 					AND eligible.byte_length = shadow.byte_length
+					AND eligible.byte_length > 0
 					AND eligible.uncompressed_length = shadow.uncompressed_length
+					AND eligible.uncompressed_length IS NOT NULL
+					AND eligible.uncompressed_length > 0
 				)
 			)
 			AND shadow.validated_at IS NOT NULL
@@ -824,7 +836,7 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 			AND shadow.consolidated_object_key_main <> ''`
 
 	var objects, blocks, eligibleBlocks uint64
-	if err := b.db.QueryRowContext(ctx, query, tag, startHeight, endHeight).Scan(&objects, &blocks, &eligibleBlocks); err != nil {
+	if err := b.db.QueryRowContext(ctx, query, tag, startHeight, endHeight, int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH)).Scan(&objects, &blocks, &eligibleBlocks); err != nil {
 		return nil, xerrors.Errorf("failed to get consolidation shadow stats: %w", err)
 	}
 	return &internal.ConsolidationShadowStats{

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -777,45 +777,60 @@ func (b *blockStorageImpl) GetBlockConsolidationShadowStats(ctx context.Context,
 		return &internal.ConsolidationShadowStats{}, nil
 	}
 	const query = `
+		WITH eligible AS (
+			SELECT
+				bm.id,
+				bm.tag,
+				bm.height,
+				bm.hash,
+				bm.object_key_main,
+				bm.object_format,
+				bm.byte_offset,
+				bm.byte_length,
+				bm.uncompressed_length
+			FROM canonical_blocks cb
+			JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+			WHERE cb.tag = $1
+				AND cb.height >= $2
+				AND cb.height < $3
+				AND bm.skipped = false
+				AND bm.object_key_main IS NOT NULL
+				AND bm.object_key_main <> ''
+		)
 		SELECT
 			COUNT(DISTINCT shadow.consolidated_object_key_main),
+			COUNT(shadow.block_metadata_id),
 			COUNT(*)
-		FROM canonical_blocks cb
-		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
-		JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
-			AND shadow.tag = cb.tag
-			AND shadow.height = cb.height
-			AND shadow.hash = bm.hash
-		WHERE cb.tag = $1
-			AND cb.height >= $2
-			AND cb.height < $3
+		FROM eligible
+		LEFT JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = eligible.id
+			AND shadow.tag = eligible.tag
+			AND shadow.height = eligible.height
+			AND shadow.hash = eligible.hash
 			AND shadow.tag = $1
 			AND shadow.height >= $2
 			AND shadow.height < $3
-			AND bm.skipped = false
 			AND (
-				shadow.legacy_object_key_main = bm.object_key_main
+				shadow.legacy_object_key_main = eligible.object_key_main
 				OR (
-					bm.object_key_main = shadow.consolidated_object_key_main
-					AND bm.object_format = shadow.object_format
-					AND bm.byte_offset = shadow.byte_offset
-					AND bm.byte_length = shadow.byte_length
-					AND bm.uncompressed_length = shadow.uncompressed_length
+					eligible.object_key_main = shadow.consolidated_object_key_main
+					AND eligible.object_format = shadow.object_format
+					AND eligible.byte_offset = shadow.byte_offset
+					AND eligible.byte_length = shadow.byte_length
+					AND eligible.uncompressed_length = shadow.uncompressed_length
 				)
 			)
-			AND bm.object_key_main IS NOT NULL
-			AND bm.object_key_main <> ''
 			AND shadow.validated_at IS NOT NULL
 			AND shadow.consolidated_object_key_main IS NOT NULL
 			AND shadow.consolidated_object_key_main <> ''`
 
-	var objects, blocks uint64
-	if err := b.db.QueryRowContext(ctx, query, tag, startHeight, endHeight).Scan(&objects, &blocks); err != nil {
+	var objects, blocks, eligibleBlocks uint64
+	if err := b.db.QueryRowContext(ctx, query, tag, startHeight, endHeight).Scan(&objects, &blocks, &eligibleBlocks); err != nil {
 		return nil, xerrors.Errorf("failed to get consolidation shadow stats: %w", err)
 	}
 	return &internal.ConsolidationShadowStats{
-		Objects: objects,
-		Blocks:  blocks,
+		Objects:        objects,
+		Blocks:         blocks,
+		EligibleBlocks: eligibleBlocks,
 	}, nil
 }
 

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -646,6 +646,110 @@ func (b *blockStorageImpl) GetBlocksConsolidationShadow(ctx context.Context, blo
 	return shadows, nil
 }
 
+func (b *blockStorageImpl) GetBlockConsolidationLegacy(ctx context.Context, block *api.BlockMetadata) (*api.BlockMetadata, error) {
+	blocks, err := b.GetBlocksConsolidationLegacy(ctx, []*api.BlockMetadata{block})
+	if err != nil {
+		return nil, err
+	}
+	if len(blocks) == 0 || blocks[0] == nil {
+		return nil, xerrors.Errorf("consolidation legacy metadata not found: %w", errors.ErrItemNotFound)
+	}
+	return blocks[0], nil
+}
+
+func (b *blockStorageImpl) GetBlocksConsolidationLegacy(ctx context.Context, blocks []*api.BlockMetadata) ([]*api.BlockMetadata, error) {
+	legacyBlocks := make([]*api.BlockMetadata, len(blocks))
+	placeholders := make([]string, 0, len(blocks))
+	args := make([]interface{}, 0, len(blocks)*9)
+	nextArg := 1
+	for i, block := range blocks {
+		if block.GetSkipped() || block.GetObjectFormat() != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH {
+			continue
+		}
+		placeholders = append(placeholders, fmt.Sprintf(
+			"($%d::int, $%d::int, $%d::bigint, $%d::varchar, $%d::text, $%d::int, $%d::bigint, $%d::bigint, $%d::bigint)",
+			nextArg,
+			nextArg+1,
+			nextArg+2,
+			nextArg+3,
+			nextArg+4,
+			nextArg+5,
+			nextArg+6,
+			nextArg+7,
+			nextArg+8,
+		))
+		args = append(
+			args,
+			i,
+			block.GetTag(),
+			block.GetHeight(),
+			block.GetHash(),
+			block.GetObjectKeyMain(),
+			int32(block.GetObjectFormat()),
+			block.GetByteOffset(),
+			block.GetByteLength(),
+			block.GetUncompressedLength(),
+		)
+		nextArg += 9
+	}
+	if len(placeholders) == 0 {
+		return legacyBlocks, nil
+	}
+
+	query := fmt.Sprintf(`
+		WITH input(ord, tag, height, hash, consolidated_object_key_main, object_format, byte_offset, byte_length, uncompressed_length) AS (
+			VALUES %s
+		)
+		SELECT
+			input.ord,
+			shadow.legacy_object_key_main
+		FROM input
+		LEFT JOIN LATERAL (
+			SELECT legacy_object_key_main
+			FROM block_consolidation_shadow
+			WHERE tag = input.tag
+				AND height = input.height
+				AND hash = input.hash
+				AND consolidated_object_key_main = input.consolidated_object_key_main
+				AND object_format = input.object_format
+				AND byte_offset = input.byte_offset
+				AND byte_length = input.byte_length
+				AND uncompressed_length = input.uncompressed_length
+				AND validated_at IS NOT NULL
+				AND legacy_object_key_main IS NOT NULL
+				AND legacy_object_key_main <> ''
+			ORDER BY created_at DESC
+			LIMIT 1
+		) shadow ON true
+		ORDER BY input.ord ASC`, strings.Join(placeholders, ", "))
+	rows, err := b.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get consolidation legacy metadata: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	for rows.Next() {
+		var ord int
+		var legacyKey sql.NullString
+		if err := rows.Scan(&ord, &legacyKey); err != nil {
+			return nil, xerrors.Errorf("failed to scan consolidation legacy metadata: %w", err)
+		}
+		if !legacyKey.Valid {
+			continue
+		}
+		if ord < 0 || ord >= len(blocks) {
+			return nil, xerrors.Errorf("consolidation legacy input order out of range: %d", ord)
+		}
+		legacyBlocks[ord] = makeConsolidationLegacyBlockMetadata(blocks[ord], legacyKey.String)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate consolidation legacy metadata: %w", err)
+	}
+	return legacyBlocks, nil
+}
+
 func (b *blockStorageImpl) GetBlocksMissingConsolidationShadow(ctx context.Context, tag uint32, startHeight, endHeight uint64, limit uint64) ([]*internal.BlockMetadataRecord, error) {
 	if endHeight <= startHeight {
 		return nil, nil
@@ -1177,6 +1281,16 @@ func makeConsolidationShadowBlockMetadata(
 	shadow.ByteLength = byteLength
 	shadow.UncompressedLength = uncompressedLength
 	return shadow
+}
+
+func makeConsolidationLegacyBlockMetadata(block *api.BlockMetadata, objectKey string) *api.BlockMetadata {
+	legacy := proto.Clone(block).(*api.BlockMetadata)
+	legacy.ObjectKeyMain = objectKey
+	legacy.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
+	legacy.ByteOffset = 0
+	legacy.ByteLength = 0
+	legacy.UncompressedLength = 0
+	return legacy
 }
 
 func uint64Value(value sql.NullInt64) uint64 {

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -606,11 +606,34 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStats() {
 	require.NoError(err)
 	require.Equal(uint64(2), stats.Objects)
 	require.Equal(uint64(3), stats.Blocks)
+	require.Equal(uint64(8), stats.EligibleBlocks)
 
 	stats, err = s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight+1, startHeight+3)
 	require.NoError(err)
 	require.Equal(uint64(2), stats.Objects)
 	require.Equal(uint64(2), stats.Blocks)
+	require.Equal(uint64(2), stats.EligibleBlocks)
+}
+
+func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStatsExcludesSkippedBlocks() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 3, tag)
+	blocks[1].Skipped = true
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20, true, "")
+	s.insertConsolidationShadow(ctx, blocks[1], "consolidated/skipped.cscb.zstd", 30, 40, 40, true, "")
+	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/second.cscb.zstd", 50, 60, 60, true, "")
+
+	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+3)
+	require.NoError(err)
+	require.Equal(uint64(2), stats.Objects)
+	require.Equal(uint64(2), stats.Blocks)
+	require.Equal(uint64(2), stats.EligibleBlocks)
 }
 
 func (s *blockStorageTestSuite) TestPersistBlockConsolidationShadowsGuardsPrimaryIdentity() {
@@ -708,6 +731,7 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsPromotesVali
 	require.NoError(err)
 	require.Equal(uint64(2), stats.Objects)
 	require.Equal(uint64(2), stats.Blocks)
+	require.Equal(uint64(3), stats.EligibleBlocks)
 }
 
 func (s *blockStorageTestSuite) TestGetFirstPromotableBlockConsolidationShadowFiltersCandidates() {

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -620,7 +620,13 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStatsExcludesSkip
 	ctx := context.Background()
 	startHeight := s.config.Chain.BlockStartHeight
 	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 3, tag)
-	blocks[1].Skipped = true
+	blocks[1] = &api.BlockMetadata{
+		Tag:     tag,
+		Height:  startHeight + 1,
+		Skipped: true,
+	}
+	blocks[2].ParentHeight = blocks[0].Height
+	blocks[2].ParentHash = blocks[0].Hash
 
 	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
 	require.NoError(err)

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -642,6 +642,55 @@ func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStatsExcludesSkip
 	require.Equal(uint64(2), stats.EligibleBlocks)
 }
 
+func (s *blockStorageTestSuite) TestGetBlockConsolidationShadowStatsRequiresPromotionValidShadows() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 5, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/valid.cscb.zstd", 10, 20, 20, true, "")
+	s.insertInvalidConsolidationShadow(
+		ctx,
+		blocks[1],
+		"consolidated/wrong-format.cscb.zstd",
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK,
+		30,
+		40,
+		40,
+	)
+	s.insertInvalidConsolidationShadow(
+		ctx,
+		blocks[2],
+		"consolidated/zero-byte-length.cscb.zstd",
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		50,
+		0,
+		60,
+	)
+	s.insertInvalidConsolidationShadow(
+		ctx,
+		blocks[3],
+		"consolidated/zero-uncompressed-length.cscb.zstd",
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		70,
+		80,
+		0,
+	)
+	s.insertConsolidationShadow(ctx, blocks[4], "consolidated/promoted.cscb.zstd", 90, 100, 100, true, "")
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, blocks[4].GetHeight(), blocks[4].GetHeight()+1, 10, config.DefaultLegacyObjectRetention)
+	require.NoError(err)
+	require.Equal(uint64(1), result.Blocks)
+
+	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+5)
+	require.NoError(err)
+	require.Equal(uint64(2), stats.Objects)
+	require.Equal(uint64(2), stats.Blocks)
+	require.Equal(uint64(5), stats.EligibleBlocks)
+}
+
 func (s *blockStorageTestSuite) TestPersistBlockConsolidationShadowsGuardsPrimaryIdentity() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -326,6 +326,45 @@ func (s *blockStorageTestSuite) getBlockMetadataID(ctx context.Context, block *a
 	return blockMetadataID
 }
 
+type consolidationShadowAudit struct {
+	LegacyObjectKey       string
+	ConsolidatedObjectKey string
+	RetiredAt             *time.Time
+	RetireAfter           *time.Time
+}
+
+func (s *blockStorageTestSuite) getConsolidationShadowAudit(ctx context.Context, block *api.BlockMetadata) consolidationShadowAudit {
+	require := testutil.Require(s.T())
+	var legacyObjectKey, consolidatedObjectKey string
+	var retiredAt sql.NullTime
+	var retireAfter sql.NullTime
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT shadow.legacy_object_key_main, shadow.consolidated_object_key_main,
+			shadow.legacy_object_retired_at, shadow.legacy_object_retire_after
+		 FROM block_metadata bm
+		 JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+		 WHERE bm.tag = $1 AND bm.height = $2 AND bm.hash = $3`,
+		block.GetTag(),
+		block.GetHeight(),
+		block.GetHash(),
+	).Scan(&legacyObjectKey, &consolidatedObjectKey, &retiredAt, &retireAfter)
+	require.NoError(err)
+	audit := consolidationShadowAudit{
+		LegacyObjectKey:       legacyObjectKey,
+		ConsolidatedObjectKey: consolidatedObjectKey,
+	}
+	if retiredAt.Valid {
+		value := retiredAt.Time
+		audit.RetiredAt = &value
+	}
+	if retireAfter.Valid {
+		value := retireAfter.Time
+		audit.RetireAfter = &value
+	}
+	return audit
+}
+
 func (s *blockStorageTestSuite) insertConsolidationShadow(
 	ctx context.Context,
 	block *api.BlockMetadata,
@@ -640,7 +679,8 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsPromotesVali
 	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20, true, "")
 	s.insertConsolidationShadow(ctx, blocks[1], "consolidated/second.cscb.zstd", 30, 40, 40, true, "")
 
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+3, 10)
+	beforePromotion := time.Now().UTC()
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+3, 10, config.DefaultLegacyObjectRetention)
 	require.NoError(err)
 	require.Equal(uint64(2), result.Blocks)
 
@@ -655,6 +695,19 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsPromotesVali
 	primary, err = s.accessor.GetBlockByHeight(ctx, tag, blocks[2].GetHeight())
 	require.NoError(err)
 	s.equalProto(blocks[2], primary)
+
+	audit := s.getConsolidationShadowAudit(ctx, blocks[0])
+	require.Equal(blocks[0].GetObjectKeyMain(), audit.LegacyObjectKey)
+	require.Equal("consolidated/first.cscb.zstd", audit.ConsolidatedObjectKey)
+	require.NotNil(audit.RetiredAt)
+	require.NotNil(audit.RetireAfter)
+	require.WithinDuration(beforePromotion, *audit.RetiredAt, time.Minute)
+	require.WithinDuration(audit.RetiredAt.Add(config.DefaultLegacyObjectRetention), *audit.RetireAfter, time.Minute)
+
+	stats, err := s.accessor.GetBlockConsolidationShadowStats(ctx, tag, startHeight, startHeight+3)
+	require.NoError(err)
+	require.Equal(uint64(2), stats.Objects)
+	require.Equal(uint64(2), stats.Blocks)
 }
 
 func (s *blockStorageTestSuite) TestGetFirstPromotableBlockConsolidationShadowFiltersCandidates() {
@@ -686,7 +739,7 @@ func (s *blockStorageTestSuite) TestGetFirstPromotableBlockConsolidationShadowFi
 	require.NoError(err)
 	s.insertConsolidationShadow(ctx, blocks[2], "consolidated/unvalidated.cscb.zstd", 10, 20, 20, false, "")
 	s.insertConsolidationShadow(ctx, blocks[3], "consolidated/promoted.cscb.zstd", 10, 20, 20, true, "")
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, blocks[3].GetHeight(), blocks[3].GetHeight()+1, 10)
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, blocks[3].GetHeight(), blocks[3].GetHeight()+1, 10, config.DefaultLegacyObjectRetention)
 	require.NoError(err)
 	require.Equal(uint64(1), result.Blocks)
 	s.insertConsolidationShadow(ctx, blocks[4], "consolidated/first-promotable.cscb.zstd", 10, 20, 20, true, "")
@@ -716,7 +769,7 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsMissingShado
 	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
 	require.NoError(err)
 
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10, config.DefaultLegacyObjectRetention)
 	require.NoError(err)
 	require.Equal(uint64(0), result.Blocks)
 
@@ -743,7 +796,7 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsRejectsInval
 		20,
 	)
 
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10, config.DefaultLegacyObjectRetention)
 	require.Error(err)
 	require.Nil(result)
 	require.Contains(err.Error(), "invalid consolidation shadow metadata")
@@ -770,7 +823,7 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsSkipsStaleRe
 	err = s.accessor.PersistBlockMetas(ctx, true, []*api.BlockMetadata{reorgBlock}, blocks[2])
 	require.NoError(err)
 
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, reorgBlock.GetHeight(), reorgBlock.GetHeight()+1, 10)
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, reorgBlock.GetHeight(), reorgBlock.GetHeight()+1, 10, config.DefaultLegacyObjectRetention)
 	require.NoError(err)
 	require.Equal(uint64(0), result.Blocks)
 
@@ -789,11 +842,11 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsIdempotentRe
 	require.NoError(err)
 	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/first.cscb.zstd", 10, 20, 20, true, "")
 
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10, config.DefaultLegacyObjectRetention)
 	require.NoError(err)
 	require.Equal(uint64(1), result.Blocks)
 
-	result, err = s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10)
+	result, err = s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10, config.DefaultLegacyObjectRetention)
 	require.NoError(err)
 	require.Equal(uint64(0), result.Blocks)
 
@@ -821,7 +874,7 @@ func (s *blockStorageTestSuite) TestPromoteBlockConsolidationShadowsRollsBackOnI
 		40,
 	)
 
-	_, err = s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+2, 10)
+	_, err = s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+2, 10, config.DefaultLegacyObjectRetention)
 	require.Error(err)
 	require.Contains(err.Error(), "invalid consolidation shadow metadata")
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -479,6 +479,16 @@ func expectedConsolidationShadow(
 	return shadow
 }
 
+func expectedConsolidationLegacy(block *api.BlockMetadata, legacyObjectKey string) *api.BlockMetadata {
+	legacy := proto.Clone(block).(*api.BlockMetadata)
+	legacy.ObjectKeyMain = legacyObjectKey
+	legacy.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
+	legacy.ByteOffset = 0
+	legacy.ByteLength = 0
+	legacy.UncompressedLength = 0
+	return legacy
+}
+
 func (s *blockStorageTestSuite) TestGetConsolidationShadowPredicates() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()
@@ -513,6 +523,29 @@ func (s *blockStorageTestSuite) TestGetConsolidationShadowPredicates() {
 	_, err = s.accessor.GetBlockConsolidationShadow(ctx, skipped)
 	require.Error(err)
 	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+}
+
+func (s *blockStorageTestSuite) TestGetBlockConsolidationLegacyAfterPromotion() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	startHeight := s.config.Chain.BlockStartHeight
+	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 1, tag)
+
+	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
+	require.NoError(err)
+	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/promoted.cscb.zstd", 100, 200, 200, true, "")
+
+	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10, config.DefaultLegacyObjectRetention)
+	require.NoError(err)
+	require.Equal(uint64(1), result.Blocks)
+
+	promoted, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
+	require.NoError(err)
+	s.equalProto(expectedConsolidationShadow(blocks[0], "consolidated/promoted.cscb.zstd", 100, 200, 200), promoted)
+
+	legacy, err := s.accessor.GetBlockConsolidationLegacy(ctx, promoted)
+	require.NoError(err)
+	s.equalProto(expectedConsolidationLegacy(promoted, blocks[0].GetObjectKeyMain()), legacy)
 }
 
 func (s *blockStorageTestSuite) TestGetBlocksConsolidationShadowPreservesOrderAndMisses() {

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -479,16 +479,6 @@ func expectedConsolidationShadow(
 	return shadow
 }
 
-func expectedConsolidationLegacy(block *api.BlockMetadata, legacyObjectKey string) *api.BlockMetadata {
-	legacy := proto.Clone(block).(*api.BlockMetadata)
-	legacy.ObjectKeyMain = legacyObjectKey
-	legacy.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
-	legacy.ByteOffset = 0
-	legacy.ByteLength = 0
-	legacy.UncompressedLength = 0
-	return legacy
-}
-
 func (s *blockStorageTestSuite) TestGetConsolidationShadowPredicates() {
 	require := testutil.Require(s.T())
 	ctx := context.Background()
@@ -523,29 +513,6 @@ func (s *blockStorageTestSuite) TestGetConsolidationShadowPredicates() {
 	_, err = s.accessor.GetBlockConsolidationShadow(ctx, skipped)
 	require.Error(err)
 	require.True(xerrors.Is(err, errors.ErrItemNotFound))
-}
-
-func (s *blockStorageTestSuite) TestGetBlockConsolidationLegacyAfterPromotion() {
-	require := testutil.Require(s.T())
-	ctx := context.Background()
-	startHeight := s.config.Chain.BlockStartHeight
-	blocks := testutil.MakeBlockMetadatasFromStartHeight(startHeight, 1, tag)
-
-	err := s.accessor.PersistBlockMetas(ctx, true, blocks, nil)
-	require.NoError(err)
-	s.insertConsolidationShadow(ctx, blocks[0], "consolidated/promoted.cscb.zstd", 100, 200, 200, true, "")
-
-	result, err := s.accessor.PromoteBlockConsolidationShadows(ctx, tag, startHeight, startHeight+1, 10, config.DefaultLegacyObjectRetention)
-	require.NoError(err)
-	require.Equal(uint64(1), result.Blocks)
-
-	promoted, err := s.accessor.GetBlockByHeight(ctx, tag, blocks[0].GetHeight())
-	require.NoError(err)
-	s.equalProto(expectedConsolidationShadow(blocks[0], "consolidated/promoted.cscb.zstd", 100, 200, 200), promoted)
-
-	legacy, err := s.accessor.GetBlockConsolidationLegacy(ctx, promoted)
-	require.NoError(err)
-	s.equalProto(expectedConsolidationLegacy(promoted, blocks[0].GetObjectKeyMain()), legacy)
 }
 
 func (s *blockStorageTestSuite) TestGetBlocksConsolidationShadowPreservesOrderAndMisses() {

--- a/internal/storage/metastorage/postgres/db/migrations/20260703000001_add_consolidation_shadow_retirement.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260703000001_add_consolidation_shadow_retirement.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE block_consolidation_shadow
+    ADD COLUMN IF NOT EXISTS legacy_object_retired_at TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS legacy_object_retire_after TIMESTAMP;
+
+-- +goose Down
+ALTER TABLE block_consolidation_shadow
+    DROP COLUMN IF EXISTS legacy_object_retired_at,
+    DROP COLUMN IF EXISTS legacy_object_retire_after;

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -15,6 +15,8 @@ type Planner struct {
 	store ObjectStore
 }
 
+const defaultLegacyObjectRetention = 72 * time.Hour
+
 func NewPlanner(repo Repository, store ObjectStore) *Planner {
 	return &Planner{
 		repo:  repo,
@@ -30,7 +32,7 @@ func (p *Planner) Plan(ctx context.Context, req PlanRequest) (*Report, error) {
 		return nil, xerrors.New("bucket is required")
 	}
 	if req.GracePeriod == 0 {
-		req.GracePeriod = 7 * 24 * time.Hour
+		req.GracePeriod = defaultLegacyObjectRetention
 	}
 	if req.Now.IsZero() {
 		req.Now = time.Now().UTC()
@@ -119,10 +121,6 @@ func (p *Planner) planRow(
 		item.SkipReason = SkipSkippedBlock
 		return item
 	}
-	if row.PrimaryObjectFormat == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH || row.PrimaryByteLength > 0 {
-		item.SkipReason = SkipPrimaryNotLegacySingleBlock
-		return item
-	}
 	if row.LegacyObjectKey == "" {
 		item.SkipReason = SkipMissingLegacyKey
 		return item
@@ -134,12 +132,20 @@ func (p *Planner) planRow(
 	shadow := row.Shadow
 	item.ConsolidatedKey = shadow.ConsolidatedObjectKey
 	item.ValidatedAt = shadow.ValidatedAt
-	if shadow.ValidatedAt != nil {
+	item.RetiredAt = shadow.LegacyObjectRetiredAt
+	if shadow.LegacyObjectRetireAfter != nil {
+		eligibleAt := *shadow.LegacyObjectRetireAfter
+		item.EligibleAt = &eligibleAt
+	} else if shadow.ValidatedAt != nil {
 		eligibleAt := shadow.ValidatedAt.Add(req.GracePeriod)
 		item.EligibleAt = &eligibleAt
 	}
 	if shadow.ValidatedAt == nil {
 		item.SkipReason = SkipValidationNotPassed
+		return item
+	}
+	if !isPrimaryConsolidated(row) {
+		item.SkipReason = SkipActiveMetadataStillLegacy
 		return item
 	}
 	if !validShadowReference(row, shadow) {
@@ -231,6 +237,16 @@ func validShadowReference(row MetadataRow, shadow *ConsolidationShadow) bool {
 	if shadow.LegacyObjectKey != row.LegacyObjectKey {
 		return false
 	}
+	if !isPrimaryConsolidated(row) {
+		return false
+	}
+	if row.PrimaryObjectKey != shadow.ConsolidatedObjectKey ||
+		row.PrimaryObjectFormat != shadow.ObjectFormat ||
+		row.PrimaryByteOffset != shadow.ByteOffset ||
+		row.PrimaryByteLength != shadow.ByteLength ||
+		row.PrimaryUncompressedLength != shadow.UncompressedLength {
+		return false
+	}
 	if shadow.ConsolidatedObjectKey == "" {
 		return false
 	}
@@ -241,6 +257,12 @@ func validShadowReference(row MetadataRow, shadow *ConsolidationShadow) bool {
 		return false
 	}
 	return true
+}
+
+func isPrimaryConsolidated(row MetadataRow) bool {
+	return row.PrimaryObjectFormat == api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH &&
+		row.PrimaryObjectKey != "" &&
+		row.PrimaryByteLength > 0
 }
 
 func approvalMatches(req PlanRequest) bool {

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -15,8 +15,6 @@ type Planner struct {
 	store ObjectStore
 }
 
-const defaultLegacyObjectRetention = 72 * time.Hour
-
 func NewPlanner(repo Repository, store ObjectStore) *Planner {
 	return &Planner{
 		repo:  repo,
@@ -30,9 +28,6 @@ func (p *Planner) Plan(ctx context.Context, req PlanRequest) (*Report, error) {
 	}
 	if req.Bucket == "" {
 		return nil, xerrors.New("bucket is required")
-	}
-	if req.GracePeriod == 0 {
-		req.GracePeriod = defaultLegacyObjectRetention
 	}
 	if req.Now.IsZero() {
 		req.Now = time.Now().UTC()
@@ -53,7 +48,6 @@ func (p *Planner) Plan(ctx context.Context, req PlanRequest) (*Report, error) {
 		Tag:         req.Tag,
 		StartHeight: req.StartHeight,
 		EndHeight:   req.EndHeight,
-		GracePeriod: req.GracePeriod.String(),
 		Approval:    req.Approval,
 		SafetyGates: SafetyGates{
 			ClientMigrationApproved: req.ClientMigrationApproved,
@@ -136,9 +130,6 @@ func (p *Planner) planRow(
 	if shadow.LegacyObjectRetireAfter != nil {
 		eligibleAt := *shadow.LegacyObjectRetireAfter
 		item.EligibleAt = &eligibleAt
-	} else if shadow.ValidatedAt != nil {
-		eligibleAt := shadow.ValidatedAt.Add(req.GracePeriod)
-		item.EligibleAt = &eligibleAt
 	}
 	if shadow.ValidatedAt == nil {
 		item.SkipReason = SkipValidationNotPassed
@@ -152,8 +143,12 @@ func (p *Planner) planRow(
 		item.SkipReason = SkipInvalidMetadataReference
 		return item
 	}
+	if shadow.LegacyObjectRetiredAt == nil || shadow.LegacyObjectRetireAfter == nil {
+		item.SkipReason = SkipMissingRetirementMarker
+		return item
+	}
 	if item.EligibleAt != nil && req.Now.Before(*item.EligibleAt) {
-		item.SkipReason = SkipGracePeriodActive
+		item.SkipReason = SkipRetentionPeriodActive
 		return item
 	}
 	if !approvalMatches(req) {

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -60,7 +60,7 @@ func (s *fakeStore) DeleteObjectVersion(ctx context.Context, bucket string, key 
 	return nil
 }
 
-func TestPlannerPlan_NotEligibleGracePeriod(t *testing.T) {
+func TestPlannerPlan_NotEligibleRetentionPeriod(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	validatedAt := now.Add(-time.Hour)
@@ -72,7 +72,25 @@ func TestPlannerPlan_NotEligibleGracePeriod(t *testing.T) {
 	require.NoError(err)
 	require.Len(report.Items, 1)
 	require.Equal(ActionSkip, report.Items[0].Action)
-	require.Equal(SkipGracePeriodActive, report.Items[0].SkipReason)
+	require.Equal(SkipRetentionPeriodActive, report.Items[0].SkipReason)
+	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+	require.Zero(store.versionCalls[row.LegacyObjectKey])
+}
+
+func TestPlannerPlan_MissingRetirementMarkerIsNeverEligible(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-30 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	row.Shadow.LegacyObjectRetiredAt = nil
+	row.Shadow.LegacyObjectRetireAfter = nil
+	store := newFakeStore()
+
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipMissingRetirementMarker, report.Items[0].SkipReason)
 	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
 	require.Zero(store.versionCalls[row.LegacyObjectKey])
 }
@@ -370,7 +388,6 @@ func testRequest(now time.Time, execute bool) PlanRequest {
 		StartHeight:             428058000,
 		EndHeight:               428059000,
 		Now:                     now,
-		GracePeriod:             7 * 24 * time.Hour,
 		Execute:                 execute,
 		ClientMigrationApproved: true,
 		Approval: Approval{
@@ -382,6 +399,8 @@ func testRequest(now time.Time, execute bool) PlanRequest {
 }
 
 func testRow(height uint64, hash string, legacyKey string, cscbKey string, validatedAt time.Time) MetadataRow {
+	retiredAt := validatedAt
+	retireAfter := validatedAt.Add(72 * time.Hour)
 	return MetadataRow{
 		BlockMetadataID:           int64(height),
 		Tag:                       0,
@@ -394,17 +413,19 @@ func testRow(height uint64, hash string, legacyKey string, cscbKey string, valid
 		PrimaryByteLength:         200,
 		PrimaryUncompressedLength: 300,
 		Shadow: &ConsolidationShadow{
-			Tag:                   0,
-			Height:                height,
-			Hash:                  hash,
-			LegacyObjectKey:       legacyKey,
-			ConsolidatedObjectKey: cscbKey,
-			ObjectFormat:          api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-			ByteOffset:            100,
-			ByteLength:            200,
-			UncompressedLength:    300,
-			ValidatedAt:           &validatedAt,
-			FormatVersion:         1,
+			Tag:                     0,
+			Height:                  height,
+			Hash:                    hash,
+			LegacyObjectKey:         legacyKey,
+			ConsolidatedObjectKey:   cscbKey,
+			ObjectFormat:            api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:              100,
+			ByteLength:              200,
+			UncompressedLength:      300,
+			ValidatedAt:             &validatedAt,
+			LegacyObjectRetiredAt:   &retiredAt,
+			LegacyObjectRetireAfter: &retireAfter,
+			FormatVersion:           1,
 		},
 	}
 }

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -112,6 +112,24 @@ func TestPlannerPlan_InvalidMetadataReference(t *testing.T) {
 	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
 }
 
+func TestPlannerPlan_ActiveLegacyMetadataIsNeverRetired(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := activeLegacyTestRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	store := newFakeStore()
+	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
+	store.heads[row.Shadow.ConsolidatedObjectKey] = ObjectHead{Exists: true, Bytes: 1024}
+
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipActiveMetadataStillLegacy, report.Items[0].SkipReason)
+	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
+	require.Zero(store.versionCalls[row.LegacyObjectKey])
+}
+
 func TestPlannerPlan_ValidationAndApprovalGates(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
@@ -181,13 +199,40 @@ func TestPlannerPlan_SkippedReorgAndPromotedRows(t *testing.T) {
 	promoted := testRow(102, "hash-102", "consolidated/primary.cscb.zstd", "consolidated/canary.cscb.zstd", validatedAt)
 	promoted.PrimaryObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH
 	promoted.PrimaryByteLength = 123
+	promoted.PrimaryObjectKey = "consolidated/primary.cscb.zstd"
 
 	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{skipped, stale, promoted}}, newFakeStore()).Plan(context.Background(), testRequest(now, false))
 	require.NoError(err)
 	require.Len(report.Items, 3)
 	require.Equal(SkipSkippedBlock, report.Items[0].SkipReason)
 	require.Equal(SkipInvalidMetadataReference, report.Items[1].SkipReason)
-	require.Equal(SkipPrimaryNotLegacySingleBlock, report.Items[2].SkipReason)
+	require.Equal(SkipInvalidMetadataReference, report.Items[2].SkipReason)
+}
+
+func TestPlannerPlan_PromotedRowUsesShadowLegacyKeyAndRetireAfter(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-time.Hour)
+	retiredAt := now.Add(-2 * time.Minute)
+	retireAfter := now.Add(-time.Minute)
+	legacyKey := "legacy/102.zstd"
+	cscbKey := "consolidated/primary.cscb.zstd"
+	row := testRow(102, "hash-102", legacyKey, cscbKey, validatedAt)
+	row.Shadow.LegacyObjectRetiredAt = &retiredAt
+	row.Shadow.LegacyObjectRetireAfter = &retireAfter
+	store := newFakeStore()
+	store.versions[legacyKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
+	store.heads[cscbKey] = ObjectHead{Exists: true, Bytes: 1024}
+
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionReportOnly, report.Items[0].Action)
+	require.Equal(legacyKey, report.Items[0].Key)
+	require.Equal(cscbKey, report.Items[0].ConsolidatedKey)
+	require.Equal(retiredAt, *report.Items[0].RetiredAt)
+	require.Equal(retireAfter, *report.Items[0].EligibleAt)
+	require.Empty(report.Items[0].SkipReason)
 }
 
 func TestPlannerPlan_VersionedDeleteMarkerBehavior(t *testing.T) {
@@ -338,12 +383,16 @@ func testRequest(now time.Time, execute bool) PlanRequest {
 
 func testRow(height uint64, hash string, legacyKey string, cscbKey string, validatedAt time.Time) MetadataRow {
 	return MetadataRow{
-		BlockMetadataID:     int64(height),
-		Tag:                 0,
-		Height:              height,
-		Hash:                hash,
-		LegacyObjectKey:     legacyKey,
-		PrimaryObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK,
+		BlockMetadataID:           int64(height),
+		Tag:                       0,
+		Height:                    height,
+		Hash:                      hash,
+		PrimaryObjectKey:          cscbKey,
+		LegacyObjectKey:           legacyKey,
+		PrimaryObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		PrimaryByteOffset:         100,
+		PrimaryByteLength:         200,
+		PrimaryUncompressedLength: 300,
 		Shadow: &ConsolidationShadow{
 			Tag:                   0,
 			Height:                height,
@@ -358,4 +407,14 @@ func testRow(height uint64, hash string, legacyKey string, cscbKey string, valid
 			FormatVersion:         1,
 		},
 	}
+}
+
+func activeLegacyTestRow(height uint64, hash string, legacyKey string, cscbKey string, validatedAt time.Time) MetadataRow {
+	row := testRow(height, hash, legacyKey, cscbKey, validatedAt)
+	row.PrimaryObjectKey = legacyKey
+	row.PrimaryObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_LEGACY_SINGLE_BLOCK
+	row.PrimaryByteOffset = 0
+	row.PrimaryByteLength = 0
+	row.PrimaryUncompressedLength = 0
+	return row
 }

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -36,8 +36,11 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 			COALESCE(bm.hash, ''),
 			bm.skipped,
 			COALESCE(bm.object_key_main, ''),
+			COALESCE(shadow.legacy_object_key_main, bm.object_key_main, ''),
 			bm.object_format,
+			bm.byte_offset,
 			bm.byte_length,
+			bm.uncompressed_length,
 			shadow.tag,
 			shadow.height,
 			shadow.hash,
@@ -48,6 +51,8 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 			shadow.byte_length,
 			shadow.uncompressed_length,
 			shadow.validated_at,
+			shadow.legacy_object_retired_at,
+			shadow.legacy_object_retire_after,
 			shadow.format_version
 		FROM canonical_blocks cb
 		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
@@ -70,7 +75,9 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 	for rows.Next() {
 		var row MetadataRow
 		var primaryObjectFormat int64
+		var primaryByteOffset sql.NullInt64
 		var primaryByteLength sql.NullInt64
+		var primaryUncompressedLength sql.NullInt64
 		var shadowTag sql.NullInt64
 		var shadowHeight sql.NullInt64
 		var shadowHash sql.NullString
@@ -81,6 +88,8 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 		var shadowByteLength sql.NullInt64
 		var shadowUncompressedLength sql.NullInt64
 		var shadowValidatedAt sql.NullTime
+		var shadowLegacyObjectRetiredAt sql.NullTime
+		var shadowLegacyObjectRetireAfter sql.NullTime
 		var shadowFormatVersion sql.NullInt64
 		if err := rows.Scan(
 			&row.BlockMetadataID,
@@ -88,9 +97,12 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 			&row.Height,
 			&row.Hash,
 			&row.Skipped,
+			&row.PrimaryObjectKey,
 			&row.LegacyObjectKey,
 			&primaryObjectFormat,
+			&primaryByteOffset,
 			&primaryByteLength,
+			&primaryUncompressedLength,
 			&shadowTag,
 			&shadowHeight,
 			&shadowHash,
@@ -101,12 +113,16 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 			&shadowByteLength,
 			&shadowUncompressedLength,
 			&shadowValidatedAt,
+			&shadowLegacyObjectRetiredAt,
+			&shadowLegacyObjectRetireAfter,
 			&shadowFormatVersion,
 		); err != nil {
 			return nil, xerrors.Errorf("failed to scan retirement metadata row: %w", err)
 		}
 		row.PrimaryObjectFormat = api.BlockObjectFormat(primaryObjectFormat)
+		row.PrimaryByteOffset = nullableUint64(primaryByteOffset)
 		row.PrimaryByteLength = nullableUint64(primaryByteLength)
+		row.PrimaryUncompressedLength = nullableUint64(primaryUncompressedLength)
 		if shadowTag.Valid {
 			shadow := &ConsolidationShadow{
 				Tag:                   uint32(shadowTag.Int64),
@@ -123,6 +139,14 @@ func (r *PostgresRepository) ListMetadataRows(ctx context.Context, tag uint32, s
 			if shadowValidatedAt.Valid {
 				value := shadowValidatedAt.Time
 				shadow.ValidatedAt = &value
+			}
+			if shadowLegacyObjectRetiredAt.Valid {
+				value := shadowLegacyObjectRetiredAt.Time
+				shadow.LegacyObjectRetiredAt = &value
+			}
+			if shadowLegacyObjectRetireAfter.Valid {
+				value := shadowLegacyObjectRetireAfter.Time
+				shadow.LegacyObjectRetireAfter = &value
 			}
 			row.Shadow = shadow
 		}

--- a/internal/storage/retirement/types.go
+++ b/internal/storage/retirement/types.go
@@ -76,7 +76,6 @@ type (
 		EndHeight               uint64
 		Limit                   uint64
 		Now                     time.Time
-		GracePeriod             time.Duration
 		Execute                 bool
 		ClientMigrationApproved bool
 		FallbackErrorCount      uint64
@@ -100,7 +99,6 @@ type (
 		Tag         uint32      `json:"tag"`
 		StartHeight uint64      `json:"start_height"`
 		EndHeight   uint64      `json:"end_height"`
-		GracePeriod string      `json:"grace_period"`
 		Approval    Approval    `json:"approval"`
 		SafetyGates SafetyGates `json:"safety_gates"`
 		Summary     Summary     `json:"summary"`
@@ -150,8 +148,9 @@ const (
 	SkipMissingConsolidationShadow = "missing_consolidation_shadow"
 	SkipValidationNotPassed        = "validation_not_passed"
 	SkipActiveMetadataStillLegacy  = "active_metadata_still_legacy"
+	SkipMissingRetirementMarker    = "missing_retirement_marker"
 	SkipInvalidMetadataReference   = "invalid_metadata_reference"
-	SkipGracePeriodActive          = "grace_period_active"
+	SkipRetentionPeriodActive      = "retention_period_active"
 	SkipChainRangeNotApproved      = "chain_range_not_approved"
 	SkipActiveFallbackOrReadErrors = "active_fallback_or_read_errors"
 	SkipFileClientsNotApproved     = "file_clients_not_approved"

--- a/internal/storage/retirement/types.go
+++ b/internal/storage/retirement/types.go
@@ -19,29 +19,34 @@ type (
 	}
 
 	MetadataRow struct {
-		BlockMetadataID     int64
-		Tag                 uint32
-		Height              uint64
-		Hash                string
-		Skipped             bool
-		LegacyObjectKey     string
-		PrimaryObjectFormat api.BlockObjectFormat
-		PrimaryByteLength   uint64
-		Shadow              *ConsolidationShadow
+		BlockMetadataID           int64
+		Tag                       uint32
+		Height                    uint64
+		Hash                      string
+		Skipped                   bool
+		PrimaryObjectKey          string
+		LegacyObjectKey           string
+		PrimaryObjectFormat       api.BlockObjectFormat
+		PrimaryByteOffset         uint64
+		PrimaryByteLength         uint64
+		PrimaryUncompressedLength uint64
+		Shadow                    *ConsolidationShadow
 	}
 
 	ConsolidationShadow struct {
-		Tag                   uint32
-		Height                uint64
-		Hash                  string
-		LegacyObjectKey       string
-		ConsolidatedObjectKey string
-		ObjectFormat          api.BlockObjectFormat
-		ByteOffset            uint64
-		ByteLength            uint64
-		UncompressedLength    uint64
-		ValidatedAt           *time.Time
-		FormatVersion         int
+		Tag                     uint32
+		Height                  uint64
+		Hash                    string
+		LegacyObjectKey         string
+		ConsolidatedObjectKey   string
+		ObjectFormat            api.BlockObjectFormat
+		ByteOffset              uint64
+		ByteLength              uint64
+		UncompressedLength      uint64
+		ValidatedAt             *time.Time
+		LegacyObjectRetiredAt   *time.Time
+		LegacyObjectRetireAfter *time.Time
+		FormatVersion           int
 	}
 
 	ObjectHead struct {
@@ -127,6 +132,7 @@ type (
 		LegacyBytes     uint64     `json:"legacy_bytes"`
 		ConsolidatedKey string     `json:"consolidated_key"`
 		ValidatedAt     *time.Time `json:"validated_at"`
+		RetiredAt       *time.Time `json:"retired_at"`
 		EligibleAt      *time.Time `json:"eligible_at"`
 		Action          string     `json:"action"`
 		SkipReason      string     `json:"skip_reason"`
@@ -139,21 +145,21 @@ const (
 	ActionDeleteObjectVersion  = "delete_object_version"
 	ActionDeletedObjectVersion = "deleted_object_version"
 
-	SkipSkippedBlock                = "skipped_block"
-	SkipPrimaryNotLegacySingleBlock = "primary_not_legacy_single_block"
-	SkipMissingLegacyKey            = "missing_legacy_key"
-	SkipMissingConsolidationShadow  = "missing_consolidation_shadow"
-	SkipValidationNotPassed         = "validation_not_passed"
-	SkipInvalidMetadataReference    = "invalid_metadata_reference"
-	SkipGracePeriodActive           = "grace_period_active"
-	SkipChainRangeNotApproved       = "chain_range_not_approved"
-	SkipActiveFallbackOrReadErrors  = "active_fallback_or_read_errors"
-	SkipFileClientsNotApproved      = "file_clients_not_approved"
-	SkipMissingCSCBObject           = "missing_cscb_object"
-	SkipLegacyObjectMissing         = "legacy_object_missing"
-	SkipLegacyCurrentDeleteMarker   = "legacy_current_delete_marker"
-	SkipLegacyVersionIDUnavailable  = "legacy_version_id_unavailable"
-	SkipProductionDeletionDisabled  = "production_deletion_disabled"
-	SkipObjectInspectionFailed      = "object_inspection_failed"
-	SkipVersionedDeleteFailed       = "versioned_delete_failed"
+	SkipSkippedBlock               = "skipped_block"
+	SkipMissingLegacyKey           = "missing_legacy_key"
+	SkipMissingConsolidationShadow = "missing_consolidation_shadow"
+	SkipValidationNotPassed        = "validation_not_passed"
+	SkipActiveMetadataStillLegacy  = "active_metadata_still_legacy"
+	SkipInvalidMetadataReference   = "invalid_metadata_reference"
+	SkipGracePeriodActive          = "grace_period_active"
+	SkipChainRangeNotApproved      = "chain_range_not_approved"
+	SkipActiveFallbackOrReadErrors = "active_fallback_or_read_errors"
+	SkipFileClientsNotApproved     = "file_clients_not_approved"
+	SkipMissingCSCBObject          = "missing_cscb_object"
+	SkipLegacyObjectMissing        = "legacy_object_missing"
+	SkipLegacyCurrentDeleteMarker  = "legacy_current_delete_marker"
+	SkipLegacyVersionIDUnavailable = "legacy_version_id_unavailable"
+	SkipProductionDeletionDisabled = "production_deletion_disabled"
+	SkipObjectInspectionFailed     = "object_inspection_failed"
+	SkipVersionedDeleteFailed      = "versioned_delete_failed"
 )

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -55,6 +55,7 @@ type (
 		EndHeight          uint64
 		ScannedBlocks      uint64
 		ConsolidatedBlocks uint64
+		PromotedBlocks     uint64
 		ObjectKey          string
 	}
 
@@ -263,6 +264,14 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 
 	logger := a.getLogger(ctx).With(zap.Reflect("request", request))
 	totalStart := time.Now()
+	mode := request.Mode
+	if mode == "" {
+		mode = a.config.AWS.Storage.Consolidation.Mode
+	}
+	prePromotedBlocks, err := a.promoteConsolidatedBlocks(ctx, mode, request)
+	if err != nil {
+		return nil, err
+	}
 	scanStart := time.Now()
 	records, err := a.metaStorage.GetBlocksMissingConsolidationShadow(ctx, request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks)
 	if err != nil {
@@ -272,9 +281,19 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
 		return &BatchConsolidatorResponse{
-			StartHeight: request.StartHeight,
-			EndHeight:   request.EndHeight,
+			StartHeight:    request.StartHeight,
+			EndHeight:      request.EndHeight,
+			PromotedBlocks: prePromotedBlocks,
 		}, nil
+	}
+	if mode.IsAutoConsolidate() && !isFullContiguousConsolidationWindow(records, request.StartHeight, request.MaxBlocks) {
+		return nil, xerrors.Errorf(
+			"auto_consolidate requires a full contiguous consolidation window: start_height=%d end_height=%d max_blocks=%d records=%d",
+			request.StartHeight,
+			request.EndHeight,
+			request.MaxBlocks,
+			len(records),
+		)
 	}
 
 	buildStart := time.Now()
@@ -311,18 +330,25 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	persistDuration := time.Since(persistStart)
 	logger.Info("persisted consolidation shadow placements", zap.Int("placements", len(shadowPlacements)), zap.Duration("duration", persistDuration))
 	sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.shadows_persisted", objectKey, len(shadowPlacements))
+	postPromotedBlocks, err := a.promoteConsolidatedBlocks(ctx, mode, request)
+	if err != nil {
+		return nil, err
+	}
+	promotedBlocks := prePromotedBlocks + postPromotedBlocks
 
 	response := &BatchConsolidatorResponse{
 		StartHeight:        request.StartHeight,
 		EndHeight:          request.EndHeight,
 		ScannedBlocks:      uint64(len(records)),
 		ConsolidatedBlocks: uint64(len(shadowPlacements)),
+		PromotedBlocks:     promotedBlocks,
 		ObjectKey:          objectKey,
 	}
 	logger.Info(
 		"consolidated shadow blocks",
 		zap.Int("scanned_blocks", len(records)),
 		zap.Int("consolidated_blocks", len(shadowPlacements)),
+		zap.Uint64("promoted_blocks", promotedBlocks),
 		zap.String("object_key", objectKey),
 		zap.Uint64("raw_bytes", rawBytes),
 		zap.Duration("scan_duration", scanDuration),
@@ -356,6 +382,7 @@ func (a *BatchConsolidator) executePromoteFinalized(ctx context.Context, request
 		request.StartHeight,
 		plan.EndHeight,
 		request.MaxBlocks,
+		a.config.AWS.Storage.Consolidation.LegacyObjectRetention,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to promote consolidation shadows: %w", err)
@@ -375,7 +402,32 @@ func (a *BatchConsolidator) executePromoteFinalized(ctx context.Context, request
 		EndHeight:          plan.EndHeight,
 		ScannedBlocks:      promotedBlocks,
 		ConsolidatedBlocks: promotedBlocks,
+		PromotedBlocks:     promotedBlocks,
 	}, nil
+}
+
+func (a *BatchConsolidator) promoteConsolidatedBlocks(ctx context.Context, mode config.ConsolidationMode, request *BatchConsolidatorRequest) (uint64, error) {
+	if mode != config.ConsolidationModeAutoConsolidate && mode != config.ConsolidationModeHistoricalBackfill {
+		return 0, nil
+	}
+	result, err := a.metaStorage.PromoteBlockConsolidationShadows(
+		ctx,
+		request.Tag,
+		request.StartHeight,
+		request.EndHeight,
+		request.MaxBlocks,
+		a.config.AWS.Storage.Consolidation.LegacyObjectRetention,
+	)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to promote consolidated block metadata: %w", err)
+	}
+	if result == nil {
+		return 0, nil
+	}
+	if result.Blocks > 0 {
+		sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.metadata_promoted", result.Blocks)
+	}
+	return result.Blocks, nil
 }
 
 func (a *BatchConsolidator) planPromoteFinalized(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*BatchConsolidatorPlanResponse, error) {
@@ -469,6 +521,22 @@ func (a *BatchConsolidator) validateShadowWriteMode(mode config.ConsolidationMod
 
 func (a *BatchConsolidator) validateShadowStatsMode(mode config.ConsolidationMode) error {
 	return a.validateShadowWriteMode(mode)
+}
+
+func isFullContiguousConsolidationWindow(records []*metastorage.BlockMetadataRecord, startHeight uint64, maxBlocks uint64) bool {
+	if maxBlocks == 0 || uint64(len(records)) != maxBlocks {
+		return false
+	}
+	for i, record := range records {
+		if record == nil || record.Metadata == nil {
+			return false
+		}
+		expectedHeight := startHeight + uint64(i)
+		if expectedHeight < startHeight || record.Metadata.GetHeight() != expectedHeight {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *BatchConsolidator) validatePromoteFinalizedMode() error {

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -289,7 +289,7 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
 		if mode.IsAutoConsolidate() {
-			if err := a.validateFullAutoConsolidationCoverage(ctx, request); err != nil {
+			if err := a.validateFullAutoConsolidationWindow(ctx, request); err != nil {
 				return nil, err
 			}
 		}
@@ -299,14 +299,10 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 			PromotedBlocks: prePromotedBlocks,
 		}, nil
 	}
-	if mode.IsAutoConsolidate() && !isFullContiguousConsolidationWindow(records, request.StartHeight, request.MaxBlocks) {
-		return nil, xerrors.Errorf(
-			"auto_consolidate requires a full contiguous consolidation window: start_height=%d end_height=%d max_blocks=%d records=%d",
-			request.StartHeight,
-			request.EndHeight,
-			request.MaxBlocks,
-			len(records),
-		)
+	if mode.IsAutoConsolidate() {
+		if err := a.validateFullAutoConsolidationWindow(ctx, request); err != nil {
+			return nil, err
+		}
 	}
 
 	buildStart := time.Now()
@@ -443,23 +439,41 @@ func (a *BatchConsolidator) promoteConsolidatedBlocks(ctx context.Context, mode 
 	return result.Blocks, nil
 }
 
-func (a *BatchConsolidator) validateFullAutoConsolidationCoverage(ctx context.Context, request *BatchConsolidatorRequest) error {
-	stats, err := a.metaStorage.GetBlockConsolidationShadowStats(ctx, request.Tag, request.StartHeight, request.EndHeight)
+func (a *BatchConsolidator) validateFullAutoConsolidationWindow(ctx context.Context, request *BatchConsolidatorRequest) error {
+	blocks, err := a.metaStorage.GetBlocksByHeightRange(ctx, request.Tag, request.StartHeight, request.EndHeight)
 	if err != nil {
-		return xerrors.Errorf("failed to verify auto_consolidate coverage: %w", err)
+		return xerrors.Errorf("failed to verify auto_consolidate canonical window: %w", err)
 	}
-	if stats == nil || stats.Blocks != request.MaxBlocks {
-		actualBlocks := uint64(0)
-		if stats != nil {
-			actualBlocks = stats.Blocks
-		}
+	if request.MaxBlocks == 0 || uint64(len(blocks)) != request.MaxBlocks {
 		return xerrors.Errorf(
-			"auto_consolidate requires full validated consolidation coverage before empty success: start_height=%d end_height=%d max_blocks=%d covered_blocks=%d",
+			"auto_consolidate requires a full canonical consolidation window: start_height=%d end_height=%d max_blocks=%d canonical_blocks=%d",
 			request.StartHeight,
 			request.EndHeight,
 			request.MaxBlocks,
-			actualBlocks,
+			len(blocks),
 		)
+	}
+	for i, block := range blocks {
+		if block == nil {
+			return xerrors.Errorf(
+				"auto_consolidate requires a full canonical consolidation window: start_height=%d end_height=%d max_blocks=%d nil_index=%d",
+				request.StartHeight,
+				request.EndHeight,
+				request.MaxBlocks,
+				i,
+			)
+		}
+		expectedHeight := request.StartHeight + uint64(i)
+		if expectedHeight < request.StartHeight || block.GetHeight() != expectedHeight {
+			return xerrors.Errorf(
+				"auto_consolidate requires a full canonical consolidation window: start_height=%d end_height=%d max_blocks=%d expected_height=%d actual_height=%d",
+				request.StartHeight,
+				request.EndHeight,
+				request.MaxBlocks,
+				expectedHeight,
+				block.GetHeight(),
+			)
+		}
 	}
 	return nil
 }
@@ -562,22 +576,6 @@ func isFullAutoConsolidationRequest(request *BatchConsolidatorRequest) bool {
 		return false
 	}
 	return request.EndHeight-request.StartHeight == request.MaxBlocks
-}
-
-func isFullContiguousConsolidationWindow(records []*metastorage.BlockMetadataRecord, startHeight uint64, maxBlocks uint64) bool {
-	if maxBlocks == 0 || uint64(len(records)) != maxBlocks {
-		return false
-	}
-	for i, record := range records {
-		if record == nil || record.Metadata == nil {
-			return false
-		}
-		expectedHeight := startHeight + uint64(i)
-		if expectedHeight < startHeight || record.Metadata.GetHeight() != expectedHeight {
-			return false
-		}
-	}
-	return true
 }
 
 func (a *BatchConsolidator) validatePromoteFinalizedMode() error {

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -276,6 +276,11 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 			request.MaxBlocks,
 		)
 	}
+	if mode.IsAutoConsolidate() {
+		if err := a.validateFullAutoConsolidationWindow(ctx, request); err != nil {
+			return nil, err
+		}
+	}
 	prePromotedBlocks, err := a.promoteConsolidatedBlocks(ctx, mode, request)
 	if err != nil {
 		return nil, err
@@ -288,21 +293,11 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	scanDuration := time.Since(scanStart)
 	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
-		if mode.IsAutoConsolidate() {
-			if err := a.validateFullAutoConsolidationWindow(ctx, request); err != nil {
-				return nil, err
-			}
-		}
 		return &BatchConsolidatorResponse{
 			StartHeight:    request.StartHeight,
 			EndHeight:      request.EndHeight,
 			PromotedBlocks: prePromotedBlocks,
 		}, nil
-	}
-	if mode.IsAutoConsolidate() {
-		if err := a.validateFullAutoConsolidationWindow(ctx, request); err != nil {
-			return nil, err
-		}
 	}
 
 	buildStart := time.Now()

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -268,6 +268,14 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	if mode == "" {
 		mode = a.config.AWS.Storage.Consolidation.Mode
 	}
+	if mode.IsAutoConsolidate() && !isFullAutoConsolidationRequest(request) {
+		return nil, xerrors.Errorf(
+			"auto_consolidate requires exactly one full consolidation window: start_height=%d end_height=%d max_blocks=%d",
+			request.StartHeight,
+			request.EndHeight,
+			request.MaxBlocks,
+		)
+	}
 	prePromotedBlocks, err := a.promoteConsolidatedBlocks(ctx, mode, request)
 	if err != nil {
 		return nil, err
@@ -280,6 +288,11 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	scanDuration := time.Since(scanStart)
 	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
+		if mode.IsAutoConsolidate() {
+			if err := a.validateFullAutoConsolidationCoverage(ctx, request); err != nil {
+				return nil, err
+			}
+		}
 		return &BatchConsolidatorResponse{
 			StartHeight:    request.StartHeight,
 			EndHeight:      request.EndHeight,
@@ -430,6 +443,27 @@ func (a *BatchConsolidator) promoteConsolidatedBlocks(ctx context.Context, mode 
 	return result.Blocks, nil
 }
 
+func (a *BatchConsolidator) validateFullAutoConsolidationCoverage(ctx context.Context, request *BatchConsolidatorRequest) error {
+	stats, err := a.metaStorage.GetBlockConsolidationShadowStats(ctx, request.Tag, request.StartHeight, request.EndHeight)
+	if err != nil {
+		return xerrors.Errorf("failed to verify auto_consolidate coverage: %w", err)
+	}
+	if stats == nil || stats.Blocks != request.MaxBlocks {
+		actualBlocks := uint64(0)
+		if stats != nil {
+			actualBlocks = stats.Blocks
+		}
+		return xerrors.Errorf(
+			"auto_consolidate requires full validated consolidation coverage before empty success: start_height=%d end_height=%d max_blocks=%d covered_blocks=%d",
+			request.StartHeight,
+			request.EndHeight,
+			request.MaxBlocks,
+			actualBlocks,
+		)
+	}
+	return nil
+}
+
 func (a *BatchConsolidator) planPromoteFinalized(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*BatchConsolidatorPlanResponse, error) {
 	if err := a.validatePromoteFinalizedMode(); err != nil {
 		return nil, err
@@ -521,6 +555,13 @@ func (a *BatchConsolidator) validateShadowWriteMode(mode config.ConsolidationMod
 
 func (a *BatchConsolidator) validateShadowStatsMode(mode config.ConsolidationMode) error {
 	return a.validateShadowWriteMode(mode)
+}
+
+func isFullAutoConsolidationRequest(request *BatchConsolidatorRequest) bool {
+	if request == nil || request.MaxBlocks == 0 || request.EndHeight <= request.StartHeight {
+		return false
+	}
+	return request.EndHeight-request.StartHeight == request.MaxBlocks
 }
 
 func isFullContiguousConsolidationWindow(records []*metastorage.BlockMetadataRecord, startHeight uint64, maxBlocks uint64) bool {

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -109,6 +109,9 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanNoOpsWhenShadow
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
+	s.metaStorage.EXPECT().
+		GetBlockConsolidationShadowStats(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(&metastorage.ConsolidationShadowStats{Objects: 1, Blocks: 100}, nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
@@ -133,6 +136,9 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanPromotesExistin
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
+	s.metaStorage.EXPECT().
+		GetBlockConsolidationShadowStats(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(&metastorage.ConsolidationShadowStats{Objects: 1, Blocks: 100}, nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
@@ -141,6 +147,31 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanPromotesExistin
 		EndHeight:      request.EndHeight,
 		PromotedBlocks: 12,
 	}, response)
+}
+
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanRejectsMissingCoverage() {
+	require := testutil.Require(s.T())
+	request := &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   100,
+	}
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
+	s.metaStorage.EXPECT().
+		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
+		Return(nil, nil)
+	s.metaStorage.EXPECT().
+		GetBlockConsolidationShadowStats(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(&metastorage.ConsolidationShadowStats{Objects: 1, Blocks: 99}, nil)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.Error(err)
+	require.Equal(&BatchConsolidatorResponse{}, response)
+	require.Contains(err.Error(), "auto_consolidate requires full validated consolidation coverage")
 }
 
 func (s *BatchConsolidatorTestSuite) TestDeprecatedHistoricalBackfillAliasRemainsAccepted() {

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -104,6 +104,9 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanNoOpsWhenShadow
 		MaxBlocks:   100,
 	}
 	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
+	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
 
@@ -112,6 +115,31 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanNoOpsWhenShadow
 	require.Equal(&BatchConsolidatorResponse{
 		StartHeight: request.StartHeight,
 		EndHeight:   request.EndHeight,
+	}, response)
+}
+
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanPromotesExistingShadowsForRetryCleanup() {
+	require := testutil.Require(s.T())
+	request := &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   100,
+	}
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
+	s.metaStorage.EXPECT().
+		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
+		Return(nil, nil)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:    request.StartHeight,
+		EndHeight:      request.EndHeight,
+		PromotedBlocks: 12,
 	}, response)
 }
 
@@ -124,6 +152,9 @@ func (s *BatchConsolidatorTestSuite) TestDeprecatedHistoricalBackfillAliasRemain
 		EndHeight:   200,
 		MaxBlocks:   100,
 	}
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
@@ -197,6 +228,9 @@ func (s *BatchConsolidatorTestSuite) TestConsolidatesAndPersistsShadowPlacements
 	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
 
 	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
+	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
 	for i, record := range records {
@@ -208,6 +242,9 @@ func (s *BatchConsolidatorTestSuite) TestConsolidatesAndPersistsShadowPlacements
 	s.metaStorage.EXPECT().
 		PersistBlockConsolidationShadows(gomock.Any(), expectedShadows).
 		Return(nil)
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{Blocks: 2}, nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
@@ -216,6 +253,7 @@ func (s *BatchConsolidatorTestSuite) TestConsolidatesAndPersistsShadowPlacements
 		EndHeight:          request.EndHeight,
 		ScannedBlocks:      2,
 		ConsolidatedBlocks: 2,
+		PromotedBlocks:     2,
 		ObjectKey:          objectKey,
 	}, response)
 	require.Len(capturedPayloadPaths, len(records))
@@ -225,11 +263,10 @@ func (s *BatchConsolidatorTestSuite) TestConsolidatesAndPersistsShadowPlacements
 	}
 }
 
-func (s *BatchConsolidatorTestSuite) TestAutoConsolidateConsolidatesNonContiguousWindowRecords() {
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsPartialContiguousWindow() {
 	require := testutil.Require(s.T())
-	records, blocks := makeConsolidatorFixture(3, 1000)
-	records = []*metastorage.BlockMetadataRecord{records[0], records[2]}
-	blocks = []*api.Block{blocks[0], blocks[2]}
+	records, _ := makeConsolidatorFixture(3, 1000)
+	records = records[:2]
 	request := &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
 		Tag:         records[0].Metadata.GetTag(),
@@ -237,77 +274,43 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateConsolidatesNonContiguou
 		EndHeight:   1003,
 		MaxBlocks:   3,
 	}
-	objectKey := "consolidated/v=000000000001/shard=000000001000-000000001999/000000001000-000000001003-sha.zstd"
-	placements := []blobstorage.BlockPlacement{
-		{
-			MetadataID:         records[0].ID,
-			Height:             records[0].Metadata.GetHeight(),
-			Hash:               records[0].Metadata.GetHash(),
-			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-			ByteOffset:         0,
-			ByteLength:         100,
-			UncompressedLength: 100,
-		},
-		{
-			MetadataID:         records[1].ID,
-			Height:             records[1].Metadata.GetHeight(),
-			Hash:               records[1].Metadata.GetHash(),
-			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-			ByteOffset:         100,
-			ByteLength:         110,
-			UncompressedLength: 110,
-		},
-	}
-	expectedShadows := []*metastorage.ConsolidationShadowPlacement{
-		{
-			BlockMetadataID:           records[0].ID,
-			Tag:                       records[0].Metadata.GetTag(),
-			Height:                    records[0].Metadata.GetHeight(),
-			Hash:                      records[0].Metadata.GetHash(),
-			LegacyObjectKeyMain:       records[0].Metadata.GetObjectKeyMain(),
-			ConsolidatedObjectKeyMain: objectKey,
-			ObjectFormat:              api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-			ByteOffset:                0,
-			ByteLength:                100,
-			UncompressedLength:        100,
-		},
-		{
-			BlockMetadataID:           records[1].ID,
-			Tag:                       records[1].Metadata.GetTag(),
-			Height:                    records[1].Metadata.GetHeight(),
-			Hash:                      records[1].Metadata.GetHash(),
-			LegacyObjectKeyMain:       records[1].Metadata.GetObjectKeyMain(),
-			ConsolidatedObjectKeyMain: objectKey,
-			ObjectFormat:              api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-			ByteOffset:                100,
-			ByteLength:                110,
-			UncompressedLength:        110,
-		},
-	}
-	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
 
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
-	for i, record := range records {
-		s.blobStorage.EXPECT().Download(gomock.Any(), record.Metadata).Return(blocks[i], nil)
-	}
-	s.blobStorage.EXPECT().
-		UploadConsolidated(gomock.Any(), consolidatedPayloadsMatch(blocks, []int64{records[0].ID, records[1].ID})).
-		Return(objectKey, placements, nil)
-	s.metaStorage.EXPECT().
-		PersistBlockConsolidationShadows(gomock.Any(), expectedShadows).
-		Return(nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
-	require.NoError(err)
-	require.Equal(&BatchConsolidatorResponse{
-		StartHeight:        request.StartHeight,
-		EndHeight:          request.EndHeight,
-		ScannedBlocks:      2,
-		ConsolidatedBlocks: 2,
-		ObjectKey:          objectKey,
-	}, response)
+	require.Error(err)
+	require.Equal(&BatchConsolidatorResponse{}, response)
+	require.Contains(err.Error(), "auto_consolidate requires a full contiguous consolidation window")
+}
+
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsGappedWindow() {
+	require := testutil.Require(s.T())
+	records, _ := makeConsolidatorFixture(3, 1000)
+	records = []*metastorage.BlockMetadataRecord{records[0], records[2]}
+	request := &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         records[0].Metadata.GetTag(),
+		StartHeight: 1000,
+		EndHeight:   1003,
+		MaxBlocks:   3,
+	}
+
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
+	s.metaStorage.EXPECT().
+		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
+		Return(records, nil)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.Error(err)
+	require.Equal(&BatchConsolidatorResponse{}, response)
+	require.Contains(err.Error(), "auto_consolidate requires a full contiguous consolidation window")
 }
 
 func (s *BatchConsolidatorTestSuite) TestDownloadedBlockMetadataMismatchFailsBeforeUpload() {
@@ -341,6 +344,9 @@ func (s *BatchConsolidatorTestSuite) TestUploadFailureDoesNotPersistShadowPlacem
 		MaxBlocks:   1,
 	}
 
+	s.metaStorage.EXPECT().
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		Return(&metastorage.ConsolidationPromotionResult{}, nil)
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
@@ -438,7 +444,7 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPromotesShadows() {
 		GetLatestBlock(gomock.Any(), request.Tag).
 		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_300}, nil)
 	s.metaStorage.EXPECT().
-		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
 		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
@@ -448,6 +454,7 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedPromotesShadows() {
 		EndHeight:          request.EndHeight,
 		ScannedBlocks:      12,
 		ConsolidatedBlocks: 12,
+		PromotedBlocks:     12,
 	}, response)
 }
 
@@ -468,7 +475,7 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteCapsAtGateAndSaf
 		GetLatestBlock(gomock.Any(), request.Tag).
 		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_080}, nil)
 	s.metaStorage.EXPECT().
-		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, gateHeight, request.MaxBlocks).
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, gateHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
 		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
@@ -478,6 +485,7 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteCapsAtGateAndSaf
 		EndHeight:          gateHeight,
 		ScannedBlocks:      12,
 		ConsolidatedBlocks: 12,
+		PromotedBlocks:     12,
 	}, response)
 }
 
@@ -497,7 +505,7 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteAllowsMissingPro
 		GetLatestBlock(gomock.Any(), request.Tag).
 		Return(&api.BlockMetadata{Tag: request.Tag, Height: 1_080}, nil)
 	s.metaStorage.EXPECT().
-		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, uint64(1_071), request.MaxBlocks).
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, uint64(1_071), request.MaxBlocks, config.DefaultLegacyObjectRetention).
 		Return(&metastorage.ConsolidationPromotionResult{Blocks: 12}, nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
@@ -507,6 +515,7 @@ func (s *BatchConsolidatorTestSuite) TestPromoteFinalizedExecuteAllowsMissingPro
 		EndHeight:          1_071,
 		ScannedBlocks:      12,
 		ConsolidatedBlocks: 12,
+		PromotedBlocks:     12,
 	}, response)
 }
 

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -110,8 +110,8 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanNoOpsWhenShadow
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
 	s.metaStorage.EXPECT().
-		GetBlockConsolidationShadowStats(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
-		Return(&metastorage.ConsolidationShadowStats{Objects: 1, Blocks: 100}, nil)
+		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(makeCanonicalWindow(100, 100), nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
@@ -137,8 +137,8 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanPromotesExistin
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
 	s.metaStorage.EXPECT().
-		GetBlockConsolidationShadowStats(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
-		Return(&metastorage.ConsolidationShadowStats{Objects: 1, Blocks: 100}, nil)
+		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(makeCanonicalWindow(100, 100), nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
@@ -165,13 +165,13 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanRejectsMissingC
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(nil, nil)
 	s.metaStorage.EXPECT().
-		GetBlockConsolidationShadowStats(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
-		Return(&metastorage.ConsolidationShadowStats{Objects: 1, Blocks: 99}, nil)
+		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(makeCanonicalWindow(99, 100), nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.Error(err)
 	require.Equal(&BatchConsolidatorResponse{}, response)
-	require.Contains(err.Error(), "auto_consolidate requires full validated consolidation coverage")
+	require.Contains(err.Error(), "auto_consolidate requires a full canonical consolidation window")
 }
 
 func (s *BatchConsolidatorTestSuite) TestDeprecatedHistoricalBackfillAliasRemainsAccepted() {
@@ -294,10 +294,11 @@ func (s *BatchConsolidatorTestSuite) TestConsolidatesAndPersistsShadowPlacements
 	}
 }
 
-func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsPartialContiguousWindow() {
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateAllowsPartialRetryWindow() {
 	require := testutil.Require(s.T())
-	records, _ := makeConsolidatorFixture(3, 1000)
+	records, blocks := makeConsolidatorFixture(3, 1000)
 	records = records[:2]
+	blocks = blocks[:2]
 	request := &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
 		Tag:         records[0].Metadata.GetTag(),
@@ -307,22 +308,42 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsPartialContiguous
 	}
 
 	s.metaStorage.EXPECT().
-		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).Times(2).
 		Return(&metastorage.ConsolidationPromotionResult{}, nil)
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
+	s.metaStorage.EXPECT().
+		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(makeCanonicalWindow(3, 1000), nil)
+	for i := range records {
+		s.blobStorage.EXPECT().Download(gomock.Any(), records[i].Metadata).Return(blocks[i], nil)
+	}
+	s.blobStorage.EXPECT().
+		UploadConsolidated(gomock.Any(), consolidatedPayloadsMatch(blocks, []int64{records[0].ID, records[1].ID})).
+		Return("object-key", makeConsolidatorPlacements(records), nil)
+	s.metaStorage.EXPECT().
+		PersistBlockConsolidationShadows(gomock.Any(), gomock.Any()).
+		Return(nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
-	require.Error(err)
-	require.Equal(&BatchConsolidatorResponse{}, response)
-	require.Contains(err.Error(), "auto_consolidate requires a full contiguous consolidation window")
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:        request.StartHeight,
+		EndHeight:          request.EndHeight,
+		ScannedBlocks:      2,
+		ConsolidatedBlocks: 2,
+		ObjectKey:          "object-key",
+	}, response)
 }
 
-func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsGappedWindow() {
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateAllowsGappedMissingShadowScanWhenCanonicalWindowIsFull() {
 	require := testutil.Require(s.T())
-	records, _ := makeConsolidatorFixture(3, 1000)
-	records = []*metastorage.BlockMetadataRecord{records[0], records[2]}
+	allRecords, allBlocks := makeConsolidatorFixture(3, 1000)
+	records := []*metastorage.BlockMetadataRecord{allRecords[0], allRecords[2]}
+	blocks := []*api.Block{allBlocks[0], allBlocks[2]}
+	canonicalWindow := makeCanonicalWindow(3, 1000)
+	canonicalWindow[1].Skipped = true
 	request := &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
 		Tag:         records[0].Metadata.GetTag(),
@@ -332,16 +353,33 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsGappedWindow() {
 	}
 
 	s.metaStorage.EXPECT().
-		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
+		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).Times(2).
 		Return(&metastorage.ConsolidationPromotionResult{}, nil)
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
+	s.metaStorage.EXPECT().
+		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(canonicalWindow, nil)
+	for i := range records {
+		s.blobStorage.EXPECT().Download(gomock.Any(), records[i].Metadata).Return(blocks[i], nil)
+	}
+	s.blobStorage.EXPECT().
+		UploadConsolidated(gomock.Any(), consolidatedPayloadsMatch(blocks, []int64{records[0].ID, records[1].ID})).
+		Return("object-key", makeConsolidatorPlacements(records), nil)
+	s.metaStorage.EXPECT().
+		PersistBlockConsolidationShadows(gomock.Any(), gomock.Any()).
+		Return(nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
-	require.Error(err)
-	require.Equal(&BatchConsolidatorResponse{}, response)
-	require.Contains(err.Error(), "auto_consolidate requires a full contiguous consolidation window")
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:        request.StartHeight,
+		EndHeight:          request.EndHeight,
+		ScannedBlocks:      2,
+		ConsolidatedBlocks: 2,
+		ObjectKey:          "object-key",
+	}, response)
 }
 
 func (s *BatchConsolidatorTestSuite) TestDownloadedBlockMetadataMismatchFailsBeforeUpload() {
@@ -381,6 +419,9 @@ func (s *BatchConsolidatorTestSuite) TestUploadFailureDoesNotPersistShadowPlacem
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
 		Return(records, nil)
+	s.metaStorage.EXPECT().
+		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
+		Return(makeCanonicalWindow(1, 1000), nil)
 	s.blobStorage.EXPECT().Download(gomock.Any(), records[0].Metadata).Return(blocks[0], nil)
 	s.blobStorage.EXPECT().
 		UploadConsolidated(gomock.Any(), consolidatedPayloadsMatch(blocks, []int64{records[0].ID})).
@@ -722,4 +763,29 @@ func makeConsolidatorFixture(count int, startHeight uint64) ([]*metastorage.Bloc
 		}
 	}
 	return records, blocks
+}
+
+func makeCanonicalWindow(count int, startHeight uint64) []*api.BlockMetadata {
+	records, _ := makeConsolidatorFixture(count, startHeight)
+	blocks := make([]*api.BlockMetadata, len(records))
+	for i, record := range records {
+		blocks[i] = proto.Clone(record.Metadata).(*api.BlockMetadata)
+	}
+	return blocks
+}
+
+func makeConsolidatorPlacements(records []*metastorage.BlockMetadataRecord) []blobstorage.BlockPlacement {
+	placements := make([]blobstorage.BlockPlacement, len(records))
+	for i, record := range records {
+		placements[i] = blobstorage.BlockPlacement{
+			MetadataID:         record.ID,
+			Height:             record.Metadata.GetHeight(),
+			Hash:               record.Metadata.GetHash(),
+			ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:         uint64(i * 100),
+			ByteLength:         100,
+			UncompressedLength: 100,
+		}
+	}
+	return placements
 }

--- a/internal/workflow/activity/batch_consolidator_test.go
+++ b/internal/workflow/activity/batch_consolidator_test.go
@@ -149,7 +149,7 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanPromotesExistin
 	}, response)
 }
 
-func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanRejectsMissingCoverage() {
+func (s *BatchConsolidatorTestSuite) TestAutoConsolidateRejectsMissingCoverageBeforePromotion() {
 	require := testutil.Require(s.T())
 	request := &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeAutoConsolidate,
@@ -160,10 +160,10 @@ func (s *BatchConsolidatorTestSuite) TestAutoConsolidateEmptyScanRejectsMissingC
 	}
 	s.metaStorage.EXPECT().
 		PromoteBlockConsolidationShadows(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks, config.DefaultLegacyObjectRetention).
-		Return(&metastorage.ConsolidationPromotionResult{}, nil)
+		Times(0)
 	s.metaStorage.EXPECT().
 		GetBlocksMissingConsolidationShadow(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks).
-		Return(nil, nil)
+		Times(0)
 	s.metaStorage.EXPECT().
 		GetBlocksByHeightRange(gomock.Any(), request.Tag, request.StartHeight, request.EndHeight).
 		Return(makeCanonicalWindow(99, 100), nil)


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046/cscb-consolidation-retention

## Summary
- Preserve the legacy single-block S3 key in `block_consolidation_shadow` while promoting active metadata to validated CSCB metadata, so retirement remains auditable.
- Add `legacy_object_retired_at` / `legacy_object_retire_after` so retention eligibility is explicit and configurable.
- Harden the legacy-retirement planner so it never touches S3 while active metadata still points at the legacy object, and so it requires active CSCB metadata to match the validated shadow byte range.
- Keep read semantics explicit: legacy active metadata can try a validated CSCB shadow first and fall back to the active legacy metadata; promoted CSCB active metadata is authoritative and does not reconstruct a legacy fallback from `block_consolidation_shadow.legacy_object_key_main`.
- Promote validated shadows during `auto_consolidate` / `historical_backfill` retry cleanup.
- Fail closed when `auto_consolidate` activity input is not exactly one full configured window, and verify the full canonical window before any promotion/retirement metadata mutation.
- Require shadow stats coverage before treating an empty scan as success; coverage now compares promotion-valid covered shadow blocks to eligible non-skipped canonical blocks so skipped blocks do not block valid bootstrap.
- Require coverage verification before cron bootstraps the auto-consolidate cursor over a previously consolidated range.

## Safety notes
- Production deletion remains disabled in the retirement command.
- Non-prod execution still deletes only explicit S3 version IDs.
- The original legacy S3 path remains in `block_consolidation_shadow.legacy_object_key_main` after active metadata is promoted, but it is audit/retention state, not a serving fallback after promotion.
- If active metadata is legacy, reads can fall back to that active legacy metadata. If active metadata is CSCB, CSCB is the source of truth and CSCB read/presign failures are returned.
- If active block metadata is not found, the read path returns the metastorage not-found result; it does not reconstruct active metadata from shadow rows.
- Retirement eligibility requires the promotion-written `legacy_object_retired_at` and `legacy_object_retire_after` markers; old validated shadows without those markers are skipped as `missing_retirement_marker`.
- Auto residual-window waiting should happen before workflow start via cron/range selection; the activity now errors instead of silently completing an unsafe partial window that could advance the cursor.
- Empty auto-consolidate scans cannot advance the cursor unless stats prove every eligible non-skipped block in the full window is already covered.

## Review hardening
- Removed the `validated_at + grace` fallback from the retirement planner and admin command.
- Added explicit missing-retirement-marker and retention-period-active skip reasons.
- Added cron/activity coverage checks for already-consolidated empty windows.
- Moved auto-consolidate full-window validation before `PromoteBlockConsolidationShadows`, with a test proving failed coverage makes zero promotion and zero missing-shadow scan calls.
- Extended consolidation shadow stats with `EligibleBlocks`; cron bootstrap now accepts ranges with skipped canonical blocks when all eligible non-skipped blocks are covered.
- Tightened shadow stats coverage so legacy-primary rows count only when the shadow satisfies the same CSCB format/offset/length predicates used by promotion; already-promoted CSCB rows still count via exact placement equality.
- Added promoted-CSCB no-fallback tests for file URL, raw block, and raw range reads.

## Tests
- `go test ./internal/workflow/activity -run 'TestBatchConsolidatorTestSuite/(TestAutoConsolidateRejectsMissingCoverageBeforePromotion|TestAutoConsolidateEmptyScanNoOpsWhenShadowsAlreadyExist|TestAutoConsolidateEmptyScanPromotesExistingShadowsForRetryCleanup)' -count=1`
- `go test ./internal/cron -run 'TestBatchConsolidatorCron(BootstrapsCursorWhenNoMissingShadow|BootstrapsCursorWithSkippedBlocks|DoesNotBootstrapCursorWithoutFullCoverage)' -count=1`
- `go test ./internal/storage/metastorage/postgres -run 'TestIntegrationBlockStorageTestSuite/(TestGetBlockConsolidationShadowStats|TestGetBlockConsolidationShadowStatsExcludesSkippedBlocks|TestGetBlockConsolidationShadowStatsRequiresPromotionValidShadows|TestPromoteBlockConsolidationShadowsPromotesValidatedShadows)' -count=1`
- `go test ./internal/server -run 'TestHandlerSuite/(TestGetBlockFile_PromotedConsolidatedPresignErrorDoesNotFallbackToLegacy|TestGetRawBlock_PromotedConsolidatedDownloadErrorDoesNotFallbackToLegacy|TestGetRawBlocksByRange_PromotedConsolidatedDownloadErrorDoesNotFallbackToLegacy)' -count=1`
- `go test ./internal/server ./internal/storage/metastorage/postgres ./internal/storage/retirement ./internal/workflow/activity ./internal/workflow ./internal/cron ./cmd/admin -count=1`
- `go test ./internal/config -run 'TestConsolidationLegacyObjectRetention|TestConsolidationLegacyObjectRetentionMustBePositive' -count=1`
- `git diff --check`
