### PR TITLE
fix(INF-1046): stop runtime Postgres migrations

### DIFF
--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -71,6 +71,7 @@ func (s *blockStorageTestSuite) SetupTest() {
 	// Get database connection for cleanup
 	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
 	require.NoError(err)
+	require.NoError(runMigrations(context.Background(), db))
 	s.db = db
 }
 

--- a/internal/storage/metastorage/postgres/connection.go
+++ b/internal/storage/metastorage/postgres/connection.go
@@ -60,13 +60,8 @@ func newDBConnection(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, 
 		}
 	}
 
-	// Always run migrations - goose will check which migrations have been applied
-	// and only run new ones. This ensures incremental migrations work properly.
-	logger.Debug("Running database migrations")
-	if err := runMigrations(ctx, db); err != nil {
-		return nil, xerrors.Errorf("failed to run migrations: %w", err)
-	}
-	logger.Debug("Migrations completed successfully")
-
+	// Do not run schema migrations from runtime service connections.
+	// Server pods may connect through read replicas, and worker users may not own
+	// existing tables. Run migrations explicitly through admin db-init/db-migrate.
 	return db, nil
 }

--- a/internal/storage/metastorage/postgres/event_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/event_storage_integration_test.go
@@ -55,6 +55,7 @@ func (s *eventStorageTestSuite) SetupTest() {
 	// Get database connection for cleanup
 	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
 	require.NoError(err)
+	require.NoError(runMigrations(context.Background(), db))
 	s.db = db
 }
 


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046/fix-chainstorage-cscb-auto-consolidation-scheduler

## Summary
- Stop running Goose schema migrations from normal Postgres connection bootstrap.
- Keep migrations explicit through admin `db-init` / `db-migrate` paths.
- Update Postgres integration tests to run migrations explicitly in setup.

## Why
Runtime Chainstorage pods do not have a safe DDL execution context:
- server pods may connect through read replicas
- worker/batch-worker/cron users may not own existing tables

Migration files still track schema changes, but production DDL must be run manually by a human with owner/master credentials against the primary database before deploying schema-dependent code.

## Validation
- `git diff --check`
- `go test ./internal/storage/metastorage/postgres ./cmd/server ./cmd/worker ./cmd/cron ./cmd/admin`