### PR TITLE
fix(INF-1046): include timestamp migrations in db dry run

### DIFF
--- a/cmd/admin/db_migrate.go
+++ b/cmd/admin/db_migrate.go
@@ -18,6 +18,8 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/log"
 )
 
+const maxMigrationVersion int64 = 1<<63 - 1
+
 func newDBMigrateCommand() *cobra.Command {
 	var (
 		masterUser     string
@@ -152,7 +154,7 @@ func runDBMigrate(masterUser, masterPassword, host string, port int, dbName, ssl
 
 		logger.Info("Current database version", zap.Int64("version", currentVersion))
 
-		migrations, err := goose.CollectMigrations("db/migrations", 0, 9999999)
+		migrations, err := collectDBMigrations()
 		if err != nil {
 			return xerrors.Errorf("failed to collect migrations: %w", err)
 		}
@@ -195,6 +197,10 @@ func runDBMigrate(masterUser, masterPassword, host string, port int, dbName, ssl
 	fmt.Printf("Current version: %d\n", currentVersion)
 
 	return nil
+}
+
+func collectDBMigrations() (goose.Migrations, error) {
+	return goose.CollectMigrations("db/migrations", 0, maxMigrationVersion)
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/cmd/admin/db_migrate_test.go
+++ b/cmd/admin/db_migrate_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coinbase/chainstorage/internal/storage/metastorage/postgres"
+)
+
+func TestCollectDBMigrationsIncludesTimestampMigrations(t *testing.T) {
+	goose.SetBaseFS(postgres.GetEmbeddedMigrations())
+	t.Cleanup(func() {
+		goose.SetBaseFS(nil)
+	})
+
+	migrations, err := collectDBMigrations()
+	require.NoError(t, err)
+
+	var hasRetirementMigration bool
+	for _, migration := range migrations {
+		if migration.Version == 20260703000001 {
+			hasRetirementMigration = true
+			break
+		}
+	}
+
+	require.True(t, hasRetirementMigration)
+}


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046/cscb-consolidation-retention

## Summary
- fix `admin db-migrate --dry-run` so it scans all timestamped goose migrations instead of stopping at `9999999`
- add a regression test proving the embedded migration collector includes the `20260703000001` CSCB retirement migration

## Context
Prod dry-run connected to Postgres and read `goose_db_version`, but failed with `no migration files found` because every timestamp migration version is larger than the hard-coded upper bound.

## Test
- `go test ./cmd/admin`