### PR TITLE
fix(INF-1046): tune auto consolidate workflow parallelism

### DIFF
--- a/config/chainstorage/solana/mainnet/production.yml
+++ b/config/chainstorage/solana/mainnet/production.yml
@@ -6,6 +6,9 @@ cadence:
   address: temporal.example.com:7233
   keep_alive_time: 10s
   keep_alive_timeout: 30s
+cron:
+  batch_consolidator:
+    workflow_parallelism: 2
 server:
   bind_address: 0.0.0.0:9090
 workflows:

--- a/config/chainstorage/solana/mainnet/production.yml
+++ b/config/chainstorage/solana/mainnet/production.yml
@@ -8,6 +8,7 @@ cadence:
   keep_alive_timeout: 30s
 cron:
   batch_consolidator:
+    spec: '@every 15m'
     workflow_parallelism: 2
 server:
   bind_address: 0.0.0.0:9090

--- a/config_templates/config/chainstorage/solana/mainnet/production.template.yml
+++ b/config_templates/config/chainstorage/solana/mainnet/production.template.yml
@@ -5,6 +5,7 @@ cadence:
   keep_alive_timeout: 30s
 cron:
   batch_consolidator:
+    spec: "@every 15m"
     workflow_parallelism: 2
 workflows:
   backfiller:

--- a/config_templates/config/chainstorage/solana/mainnet/production.template.yml
+++ b/config_templates/config/chainstorage/solana/mainnet/production.template.yml
@@ -3,6 +3,9 @@ aws:
 cadence:
   keep_alive_time: 10s
   keep_alive_timeout: 30s
+cron:
+  batch_consolidator:
+    workflow_parallelism: 2
 workflows:
   backfiller:
     num_concurrent_extractors: 150

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -419,12 +419,13 @@ type (
 	}
 
 	BatchConsolidatorCronConfig struct {
-		Enabled            bool          `mapstructure:"enabled"`
-		Spec               string        `mapstructure:"spec"`
-		Parallelism        int64         `mapstructure:"parallelism"`
-		DelayStartDuration time.Duration `mapstructure:"delay_start_duration"`
-		StartHeight        uint64        `mapstructure:"start_height"`
-		MaxRangeBlocks     uint64        `mapstructure:"max_range_blocks"`
+		Enabled             bool          `mapstructure:"enabled"`
+		Spec                string        `mapstructure:"spec"`
+		Parallelism         int64         `mapstructure:"parallelism"`
+		WorkflowParallelism int           `mapstructure:"workflow_parallelism"`
+		DelayStartDuration  time.Duration `mapstructure:"delay_start_duration"`
+		StartHeight         uint64        `mapstructure:"start_height"`
+		MaxRangeBlocks      uint64        `mapstructure:"max_range_blocks"`
 	}
 
 	StorageConfig struct {

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -39,9 +39,10 @@ type (
 )
 
 const (
-	autoConsolidateSuffix            = "auto_consolidate"
-	batchConsolidatorOpenPageSize    = 1000
-	defaultBatchConsolidatorCronSpec = "@every 30m"
+	autoConsolidateSuffix                   = "auto_consolidate"
+	batchConsolidatorOpenPageSize           = 1000
+	defaultBatchConsolidatorCronSpec        = "@every 30m"
+	maxBatchConsolidatorWorkflowParallelism = 10
 )
 
 func NewBatchConsolidator(params BatchConsolidatorTaskParams) (Task, error) {
@@ -113,6 +114,16 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 			"batch_consolidator cron max_range_blocks(%d) must be at least consolidation max_blocks(%d)",
 			cronConfig.MaxRangeBlocks,
 			consolidation.MaxBlocks,
+		)
+	}
+	if cronConfig.WorkflowParallelism < 0 {
+		return xerrors.Errorf("batch_consolidator cron workflow_parallelism(%d) must be non-negative", cronConfig.WorkflowParallelism)
+	}
+	if cronConfig.WorkflowParallelism > maxBatchConsolidatorWorkflowParallelism {
+		return xerrors.Errorf(
+			"batch_consolidator cron workflow_parallelism(%d) exceeds max(%d)",
+			cronConfig.WorkflowParallelism,
+			maxBatchConsolidatorWorkflowParallelism,
 		)
 	}
 
@@ -298,6 +309,9 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		StartHeight: startHeight,
 		EndHeight:   endHeight,
 	}
+	if cronConfig.WorkflowParallelism > 0 {
+		request.Parallelism = cronConfig.WorkflowParallelism
+	}
 	workflowCtx := workflow.WithWorkflowID(ctx, workflowID)
 	run, err := t.batchConsolidator.Execute(workflowCtx, request)
 	if err != nil {
@@ -319,6 +333,7 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 		zap.Uint64("cursor_height", cursorHeight),
 		zap.Uint64("latest_height", latest.GetHeight()),
 		zap.Uint64("safe_consolidation_height", safeHeight),
+		zap.Int("workflow_parallelism", request.Parallelism),
 	)
 	return nil
 }

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -76,6 +76,35 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 	}, runtime.executions[0].request)
 }
 
+func TestBatchConsolidatorCronPassesWorkflowParallelism(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 2_500
+	cfg.Cron.BatchConsolidator.WorkflowParallelism = 2
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 5_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(4_901)).
+		Return(uint64(3_500), true, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         tag,
+		StartHeight: 3_000,
+		EndHeight:   4_000,
+		Parallelism: 2,
+	}, runtime.executions[0].request)
+}
+
 func TestBatchConsolidatorCronWaitsForFullConsolidationWindow(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
@@ -332,6 +361,21 @@ func TestBatchConsolidatorCronRequiresAutoConsolidateMode(t *testing.T) {
 	err := task.Run(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `batch_consolidator cron requires consolidation mode "auto_consolidate", got "promote_finalized"`)
+	require.Empty(t, runtime.executions)
+}
+
+func TestBatchConsolidatorCronRejectsInvalidWorkflowParallelism(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.WorkflowParallelism = maxBatchConsolidatorWorkflowParallelism + 1
+
+	metaStorage.EXPECT().GetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	err := task.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "workflow_parallelism(11) exceeds max(10)")
 	require.Empty(t, runtime.executions)
 }
 

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -64,6 +64,8 @@ const (
 	batchConsolidatorAutoSerialVersion             = 1
 	batchConsolidatorAutoCursorChangeID            = "batch-consolidator-auto-cursor"
 	batchConsolidatorAutoCursorVersion             = 1
+	batchConsolidatorAutoParallelismChangeID       = "batch-consolidator-auto-parallelism"
+	batchConsolidatorAutoParallelismVersion        = 1
 	batchConsolidatorMaxParallelism                = 10
 	maxUint64                                      = ^uint64(0)
 )
@@ -194,6 +196,15 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				batchConsolidatorAutoCursorVersion,
 			)
 		}
+		autoConsolidateParallelismVersion := workflow.DefaultVersion
+		if mode.IsAutoConsolidate() {
+			autoConsolidateParallelismVersion = workflow.GetVersion(
+				ctx,
+				batchConsolidatorAutoParallelismChangeID,
+				workflow.DefaultVersion,
+				batchConsolidatorAutoParallelismVersion,
+			)
+		}
 
 		if historicalBackfillVersion != workflow.DefaultVersion {
 			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
@@ -291,7 +302,8 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			if mode.IsAutoConsolidate() &&
 				(autoConsolidateCursorVersion != workflow.DefaultVersion || autoConsolidateVersion == workflow.DefaultVersion) {
 				autoConsolidateParallelism := 1
-				if autoConsolidateCursorVersion == workflow.DefaultVersion {
+				if autoConsolidateCursorVersion == workflow.DefaultVersion ||
+					autoConsolidateParallelismVersion != workflow.DefaultVersion {
 					autoConsolidateParallelism = parallelism
 				}
 				objectsInBatch, blocksInBatch, err := w.processAutoConsolidateBatchParallel(

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -604,6 +604,21 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 	s.mockAutoConsolidateLatestHeight(220)
 	s.mockEmptyShadowStats()
 	s.mockAutoConsolidateCursorUpdate(200)
+	s.env.OnGetVersion(
+		batchConsolidatorAutoSerialChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoSerialVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorAutoSerialVersion))
+	s.env.OnGetVersion(
+		batchConsolidatorAutoCursorChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoCursorVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorAutoCursorVersion))
+	s.env.OnGetVersion(
+		batchConsolidatorAutoParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoParallelismVersion,
+	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
@@ -653,6 +668,11 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesP
 		batchConsolidatorAutoCursorChangeID,
 		temporalworkflow.DefaultVersion,
 		batchConsolidatorAutoCursorVersion,
+	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnGetVersion(
+		batchConsolidatorAutoParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoParallelismVersion,
 	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
@@ -728,6 +748,11 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateSerialVersionWithoutCurs
 		temporalworkflow.DefaultVersion,
 		batchConsolidatorAutoCursorVersion,
 	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnGetVersion(
+		batchConsolidatorAutoParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoParallelismVersion,
+	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
@@ -759,6 +784,67 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateSerialVersionWithoutCurs
 		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 200, MaxBlocks: 25},
 		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 200, MaxBlocks: 25},
 	}, requests)
+}
+
+func (s *batchConsolidatorTestSuite) TestAutoConsolidateParallelismVersionRunsObjectWindowsConcurrently() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
+	var inFlight int64
+	var maxInFlight int64
+	s.mockAutoConsolidateLatestHeight(220)
+	s.mockEmptyShadowStats()
+	s.mockAutoConsolidateCursorUpdate(200)
+	s.env.OnGetVersion(
+		batchConsolidatorAutoSerialChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoSerialVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorAutoSerialVersion))
+	s.env.OnGetVersion(
+		batchConsolidatorAutoCursorChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoCursorVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorAutoCursorVersion))
+	s.env.OnGetVersion(
+		batchConsolidatorAutoParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorAutoParallelismVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorAutoParallelismVersion))
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			current := atomic.AddInt64(&inFlight, 1)
+			for {
+				maxSeen := atomic.LoadInt64(&maxInFlight)
+				if current <= maxSeen || atomic.CompareAndSwapInt64(&maxInFlight, maxSeen, current) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&inFlight, -1)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+		Parallelism: 2,
+	})
+	require.NoError(err)
+	observedMaxInFlight := atomic.LoadInt64(&maxInFlight)
+	s.T().Logf("max in-flight auto_consolidate activities: %d", observedMaxInFlight)
+	require.Greater(observedMaxInFlight, int64(1))
+	require.LessOrEqual(observedMaxInFlight, int64(2))
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateResumeAfterLostActivityCompletion() {

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -600,6 +600,8 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
 	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
 	var requests []*activity.BatchConsolidatorRequest
+	var inFlight int64
+	var maxInFlight int64
 	normalCalls := 0
 	s.mockAutoConsolidateLatestHeight(220)
 	s.mockEmptyShadowStats()
@@ -621,6 +623,15 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			current := atomic.AddInt64(&inFlight, 1)
+			for {
+				maxSeen := atomic.LoadInt64(&maxInFlight)
+				if current <= maxSeen || atomic.CompareAndSwapInt64(&maxInFlight, maxSeen, current) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&inFlight, -1)
 			requests = append(requests, request)
 			normalCalls++
 			return &activity.BatchConsolidatorResponse{
@@ -642,6 +653,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateIgnoresParallelism() {
 	})
 	require.NoError(err)
 	require.Equal(4, normalCalls)
+	require.Equal(int64(1), atomic.LoadInt64(&maxInFlight))
 	require.Equal([]*activity.BatchConsolidatorRequest{
 		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 100, EndHeight: 125, MaxBlocks: 25},
 		{Mode: config.ConsolidationModeAutoConsolidate, Tag: 2, StartHeight: 125, EndHeight: 150, MaxBlocks: 25},


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046/fix-chainstorage-cscb-auto-consolidation-scheduler

## Summary
- add explicit `cron.batch_consolidator.workflow_parallelism` separate from the cron task semaphore
- pass configured auto workflow parallelism into `BatchConsolidatorRequest.Parallelism` and fail closed on invalid values
- add a new Temporal version marker so existing auto_consolidate histories replay serially while new histories can fan out
- set Solana mainnet production auto workflow parallelism to `2`
- run Solana mainnet production auto_consolidate every 15 minutes

## Validation
- `go test -count=1 ./internal/cron ./internal/workflow`
- `git diff --check`

## Rollout notes
- This only changes Solana production auto_consolidate cadence and fan-out after deployment.
- Existing Temporal histories without `batch-consolidator-auto-parallelism` replay with serial auto_consolidate behavior.
- 15 minutes is intentional for the next step; it is less aggressive than 10 minutes while one or two parallel auto workflow activities are being observed.
- Watch one or two auto_consolidate runs before considering any higher value.
