### PR TITLE
fix(INF-1046): enable Solana consolidated reads

### DIFF
--- a/config/chainstorage/solana/mainnet/production.yml
+++ b/config/chainstorage/solana/mainnet/production.yml
@@ -2,6 +2,9 @@
 aws:
   aws_account: production
   bucket: example-chainstorage-solana-mainnet-prod
+  storage:
+    consolidation:
+      read_shadow_first: true
 cadence:
   address: temporal.example.com:7233
   keep_alive_time: 10s
@@ -12,6 +15,9 @@ cron:
     workflow_parallelism: 2
 server:
   bind_address: 0.0.0.0:9090
+storage_type:
+  blob: S3
+  meta: POSTGRES
 workflows:
   backfiller:
     num_concurrent_extractors: 150

--- a/config_templates/config/chainstorage/solana/mainnet/production.template.yml
+++ b/config_templates/config/chainstorage/solana/mainnet/production.template.yml
@@ -1,5 +1,11 @@
 aws:
   aws_account: production
+  storage:
+    consolidation:
+      read_shadow_first: true
+storage_type:
+  blob: S3
+  meta: POSTGRES
 cadence:
   keep_alive_time: 10s
   keep_alive_timeout: 30s

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -125,7 +125,7 @@ func TestValidateConfigs(t *testing.T) {
 
 		require.GreaterOrEqual(cfg.Chain.EventTag.Latest, cfg.Chain.EventTag.Stable)
 		require.Equal(api.Compression_GZIP, cfg.AWS.Storage.DataCompression)
-		require.Equal(defaultConsolidationConfig(), cfg.AWS.Storage.Consolidation)
+		require.Equal(expectedConsolidationConfig(cfg), cfg.AWS.Storage.Consolidation)
 		require.Equal(5*time.Minute, cfg.Workflows.BatchConsolidator.ActivityHeartbeatTimeout)
 
 		require.Equal(fmt.Sprintf("chainstorage-%v", normalizedConfigName), cfg.Cadence.Domain)
@@ -223,13 +223,19 @@ func TestDerivedConfigValues(t *testing.T) {
 			// Skip AWS account verification
 			AWSAccount: cfg.AWS.AWSAccount,
 		}
-		if cfg.Env() == config.EnvProduction &&
-			cfg.Chain.Blockchain == common.Blockchain_BLOCKCHAIN_SOLANA &&
-			cfg.Chain.Network == common.Network_NETWORK_SOLANA_MAINNET {
-			expectedAWS.Storage.Consolidation.ReadShadowFirst = true
-		}
+		expectedAWS.Storage.Consolidation = expectedConsolidationConfig(cfg)
 		require.Equal(expectedAWS, cfg.AWS)
 	})
+}
+
+func expectedConsolidationConfig(cfg *config.Config) config.ConsolidationConfig {
+	consolidation := defaultConsolidationConfig()
+	if cfg.Env() == config.EnvProduction &&
+		cfg.Chain.Blockchain == common.Blockchain_BLOCKCHAIN_SOLANA &&
+		cfg.Chain.Network == common.Network_NETWORK_SOLANA_MAINNET {
+		consolidation.ReadShadowFirst = true
+	}
+	return consolidation
 }
 
 func TestAWSAccountEnvParsing(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -154,6 +154,9 @@ func TestSolanaProductionCadenceKeepAliveConfig(t *testing.T) {
 	require.NoError(err)
 	require.Equal(10*time.Second, cfg.Cadence.KeepAliveTime)
 	require.Equal(30*time.Second, cfg.Cadence.KeepAliveTimeout)
+	require.True(cfg.AWS.Storage.Consolidation.ReadShadowFirst)
+	require.Equal(config.BlobStorageType_S3, cfg.StorageType.BlobStorageType)
+	require.Equal(config.MetaStorageType_POSTGRES, cfg.StorageType.MetaStorageType)
 }
 
 func TestDerivedConfigValues(t *testing.T) {
@@ -219,6 +222,11 @@ func TestDerivedConfigValues(t *testing.T) {
 			},
 			// Skip AWS account verification
 			AWSAccount: cfg.AWS.AWSAccount,
+		}
+		if cfg.Env() == config.EnvProduction &&
+			cfg.Chain.Blockchain == common.Blockchain_BLOCKCHAIN_SOLANA &&
+			cfg.Chain.Network == common.Network_NETWORK_SOLANA_MAINNET {
+			expectedAWS.Storage.Consolidation.ReadShadowFirst = true
 		}
 		require.Equal(expectedAWS, cfg.AWS)
 	})

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -423,7 +423,7 @@ func (s *Server) GetBlockFile(ctx context.Context, req *api.GetBlockFileRequest)
 		return nil, xerrors.Errorf("failed to get block from meta storage: %w", err)
 	}
 
-	if shouldReadFromConsolidated(req.GetReadSource(), false) {
+	if shouldReadFromConsolidated(req.GetReadSource(), s.config.AWS.Storage.Consolidation.ReadShadowFirst) {
 		if consolidated, ok := s.getConsolidatedBlockMetadata(ctx, block); ok {
 			blockFile, err := s.newBlockFile(consolidated)
 			if err == nil {
@@ -470,7 +470,7 @@ func (s *Server) GetBlockFilesByRange(ctx context.Context, req *api.GetBlockFile
 
 	selectedBlocks := blocks
 	shadowCount := 0
-	if shouldReadFromConsolidated(req.GetReadSource(), false) {
+	if shouldReadFromConsolidated(req.GetReadSource(), s.config.AWS.Storage.Consolidation.ReadShadowFirst) {
 		selectedBlocks, shadowCount, _, _ = s.selectShadowBlockMetadata(ctx, blocks)
 	}
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -338,7 +338,54 @@ func (s *handlerTestSuite) TestGetBlockFile() {
 	require.Equal(expected, resp.File)
 }
 
-func (s *handlerTestSuite) TestGetBlockFile_DefaultIgnoresReadShadowFirst() {
+func (s *handlerTestSuite) TestGetBlockFile_DefaultUsesReadShadowFirst() {
+	const (
+		height        uint64 = 13193825
+		hash                 = "0xda5a0439434adf072394e0b94f78e56032c5409a2c58668995f306b171ff4ace"
+		parentHash           = "0xba6a6c85739b50384625e10718524fb2c1fcf88858eabf6db9bd851902b53546"
+		objectKeyMain        = "foo/bar"
+	)
+
+	require := testutil.Require(s.T())
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+	tag := s.app.Config().Chain.BlockTag.Stable
+	blockMetadata := &api.BlockMetadata{
+		Tag:           tag,
+		Hash:          hash,
+		ParentHash:    parentHash,
+		Height:        height,
+		ObjectKeyMain: objectKeyMain,
+	}
+	shadowMetadata := makeShadowBlockMetadata(blockMetadata)
+	expected := &api.BlockFile{
+		Tag:                tag,
+		Hash:               hash,
+		ParentHash:         parentHash,
+		Height:             height,
+		FileUrl:            "http://endpoint/consolidated",
+		Compression:        api.Compression_ZSTD,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		ByteOffset:         shadowMetadata.GetByteOffset(),
+		ByteLength:         shadowMetadata.GetByteLength(),
+		UncompressedLength: shadowMetadata.GetUncompressedLength(),
+	}
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlockByHash(gomock.Any(), tag, height, hash).Times(1).Return(blockMetadata, nil),
+		s.metaStorage.EXPECT().GetBlockConsolidationShadow(gomock.Any(), blockMetadata).Times(1).Return(shadowMetadata, nil),
+		s.blobStorage.EXPECT().PreSign(gomock.Any(), shadowMetadata.GetObjectKeyMain()).Times(1).Return("http://endpoint/consolidated", nil),
+	)
+
+	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
+		Height: height,
+		Hash:   hash,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Equal(expected, resp.File)
+}
+
+func (s *handlerTestSuite) TestGetBlockFile_ReadSourceLegacyIgnoresReadShadowFirst() {
 	const (
 		height        uint64 = 13193825
 		hash                 = "0xda5a0439434adf072394e0b94f78e56032c5409a2c58668995f306b171ff4ace"
@@ -369,8 +416,9 @@ func (s *handlerTestSuite) TestGetBlockFile_DefaultIgnoresReadShadowFirst() {
 	)
 
 	resp, err := s.server.GetBlockFile(context.Background(), &api.GetBlockFileRequest{
-		Height: height,
-		Hash:   hash,
+		Height:     height,
+		Hash:       hash,
+		ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
 	})
 	require.NoError(err)
 	require.NotNil(resp)
@@ -835,6 +883,48 @@ func (s *handlerTestSuite) TestGetBlockFilesByRange_ReadSourceConsolidatedUsesSh
 		StartHeight: startHeight,
 		EndHeight:   endHeight,
 		ReadSource:  api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED,
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.Len(resp.GetFiles(), len(blockMetadatas))
+	require.Equal("http://endpoint/consolidated", resp.GetFiles()[0].GetFileUrl())
+	require.Equal(resp.GetFiles()[0].GetFileUrl(), resp.GetFiles()[1].GetFileUrl())
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, resp.GetFiles()[0].GetObjectFormat())
+	require.Equal(uint64(100), resp.GetFiles()[1].GetByteOffset())
+	require.Equal(uint64(100), resp.GetFiles()[1].GetByteLength())
+	require.Equal(uint64(200), resp.GetFiles()[1].GetUncompressedLength())
+}
+
+func (s *handlerTestSuite) TestGetBlockFilesByRange_DefaultUsesReadShadowFirst() {
+	require := testutil.Require(s.T())
+	s.server.config.AWS.Storage.Consolidation.ReadShadowFirst = true
+	stableTag := s.app.Config().Chain.BlockTag.Stable
+	const (
+		startHeight uint64 = 9000
+		endHeight   uint64 = 9002
+		objectKey          = "consolidated/v=1/shard=000000000000-000000010000/000000009000-000000009002-deadbeef.cscb.zstd"
+	)
+
+	blockMetadatas := testutil.MakeBlockMetadatasFromStartHeight(startHeight, int(endHeight-startHeight), stableTag)
+	shadowMetadatas := make([]*api.BlockMetadata, len(blockMetadatas))
+	for i, blockMetadata := range blockMetadatas {
+		shadowMetadatas[i] = makeShadowBlockMetadata(blockMetadata)
+		shadowMetadatas[i].ObjectKeyMain = objectKey
+		shadowMetadatas[i].ByteOffset = uint64(i * 100)
+		shadowMetadatas[i].ByteLength = 100
+		shadowMetadatas[i].UncompressedLength = 200
+	}
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().GetBlocksByHeightRange(gomock.Any(), stableTag, startHeight, endHeight).Times(1).Return(blockMetadatas, nil),
+		s.metaStorage.EXPECT().GetLatestBlock(gomock.Any(), stableTag).Times(1).Return(testutil.MakeBlockMetadata(10000, stableTag), nil),
+		s.metaStorage.EXPECT().GetBlocksConsolidationShadow(gomock.Any(), blockMetadatas).Times(1).Return(shadowMetadatas, nil),
+		s.blobStorage.EXPECT().PreSign(gomock.Any(), objectKey).Times(1).Return("http://endpoint/consolidated", nil),
+	)
+
+	resp, err := s.server.GetBlockFilesByRange(context.Background(), &api.GetBlockFilesByRangeRequest{
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
 	})
 	require.NoError(err)
 	require.NotNil(resp)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -240,15 +240,16 @@ func (c *clientImpl) GetBlockWithTag(ctx context.Context, tag uint32, height uin
 
 func (c *clientImpl) GetBlockWithTagAndReadSource(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*api.Block, error) {
 	block, err := c.downloadBlock(ctx, tag, height, hash, readSource)
-	if err == nil || readSource != api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED {
+	if err == nil || !shouldRetryLegacyRead(readSource) {
 		return block, err
 	}
 
 	c.logger.Warn(
-		"consolidated block download failed; retrying legacy",
+		"preferred block download failed; retrying legacy",
 		zap.Uint32("tag", tag),
 		zap.Uint64("height", height),
 		zap.String("hash", hash),
+		zap.String("read_source", readSource.String()),
 		zap.Error(err),
 	)
 	block, fallbackErr := c.downloadBlock(ctx, tag, height, hash, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
@@ -268,15 +269,16 @@ func (c *clientImpl) GetBlocksByRangeWithTagAndReadSource(ctx context.Context, t
 	}
 
 	blocks, err := c.downloadBlocksByRange(ctx, tag, startHeight, endHeight, readSource)
-	if err == nil || readSource != api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED {
+	if err == nil || !shouldRetryLegacyRead(readSource) {
 		return blocks, err
 	}
 
 	c.logger.Warn(
-		"consolidated block range download failed; retrying legacy",
+		"preferred block range download failed; retrying legacy",
 		zap.Uint32("tag", tag),
 		zap.Uint64("start_height", startHeight),
 		zap.Uint64("end_height", endHeight),
+		zap.String("read_source", readSource.String()),
 		zap.Error(err),
 	)
 	blocks, fallbackErr := c.downloadBlocksByRange(ctx, tag, startHeight, endHeight, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
@@ -346,15 +348,16 @@ func (c *clientImpl) OpenRawBlockPayloadWithTag(ctx context.Context, tag uint32,
 
 func (c *clientImpl) OpenRawBlockPayloadWithTagAndReadSource(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*RawBlockPayload, error) {
 	payload, err := c.openRawBlockPayload(ctx, tag, height, hash, readSource)
-	if err == nil || readSource != api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED {
+	if err == nil || !shouldRetryLegacyRead(readSource) {
 		return payload, err
 	}
 
 	c.logger.Warn(
-		"consolidated raw block payload open failed; retrying legacy",
+		"preferred raw block payload open failed; retrying legacy",
 		zap.Uint32("tag", tag),
 		zap.Uint64("height", height),
 		zap.String("hash", hash),
+		zap.String("read_source", readSource.String()),
 		zap.Error(err),
 	)
 	payload, fallbackErr := c.openRawBlockPayload(ctx, tag, height, hash, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
@@ -396,15 +399,16 @@ func (c *clientImpl) OpenRawBlockPayloadsByRangeWithTagAndReadSource(ctx context
 	}
 
 	iter, err := c.openRawBlockPayloadsByRange(ctx, tag, startHeight, endHeight, readSource)
-	if err == nil || readSource != api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED {
+	if err == nil || !shouldRetryLegacyRead(readSource) {
 		return iter, err
 	}
 
 	c.logger.Warn(
-		"consolidated raw block payload range open failed; retrying legacy",
+		"preferred raw block payload range open failed; retrying legacy",
 		zap.Uint32("tag", tag),
 		zap.Uint64("start_height", startHeight),
 		zap.Uint64("end_height", endHeight),
+		zap.String("read_source", readSource.String()),
 		zap.Error(err),
 	)
 	iter, fallbackErr := c.openRawBlockPayloadsByRange(ctx, tag, startHeight, endHeight, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
@@ -434,6 +438,16 @@ func (c *clientImpl) openRawBlockPayloadsByRange(ctx context.Context, tag uint32
 		return nil, xerrors.Errorf("failed to open raw block payload iterator: %w", err)
 	}
 	return &rawBlockPayloadIterator{inner: iter}, nil
+}
+
+func shouldRetryLegacyRead(readSource api.BlockReadSource) bool {
+	switch readSource {
+	case api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *clientImpl) StreamChainEvents(ctx context.Context, cfg StreamingConfiguration) (<-chan *ChainEventResult, error) {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -546,7 +546,7 @@ func (c *clientImpl) streamBlocks(
 		if !cfg.EventOnly {
 			var err error
 			blockID := event.GetBlock()
-			block, err = c.downloadBlock(ctx, blockID.GetTag(), blockID.GetHeight(), blockID.GetHash(), api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
+			block, err = c.GetBlockWithTagAndReadSource(ctx, blockID.GetTag(), blockID.GetHeight(), blockID.GetHash(), api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
 			if err != nil {
 				c.sendBlockResult(ctx, ch, &ChainEventResult{
 					Error: xerrors.Errorf("failed to download block (cfg={%+v}, request={%+v}, event={%+v}): %w", cfg, request, event, err),
@@ -675,7 +675,7 @@ func (c *clientImpl) GetBlockByTransaction(ctx context.Context, tag uint32, tran
 	// because a transaction belongs to a single block in most cases.
 	blocks := make([]*api.Block, len(blockIds))
 	for i, blockId := range blockIds {
-		block, err := c.downloadBlock(ctx, blockId.Tag, blockId.Height, blockId.Hash, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
+		block, err := c.GetBlockWithTagAndReadSource(ctx, blockId.Tag, blockId.Height, blockId.Hash, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to download block data: %w", err)
 		}
@@ -696,7 +696,7 @@ func (c *clientImpl) GetBlockByTimestamp(ctx context.Context, tag uint32, timest
 	}
 
 	// Download the block data using the metadata from the response
-	block, err := c.downloadBlock(ctx, resp.Tag, resp.Height, resp.Hash, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
+	block, err := c.GetBlockWithTagAndReadSource(ctx, resp.Tag, resp.Height, resp.Hash, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to download block data: %w", err)
 	}
@@ -718,18 +718,20 @@ func (c *clientImpl) StreamNativeBlock(
 	tag uint32, height uint64, hash string,
 	opts ...ParseOption,
 ) (NativeStreamedBlock, error) {
-	blockFileResp, err := c.client.GetBlockFile(ctx, &api.GetBlockFileRequest{
-		Tag:    tag,
-		Height: height,
-		Hash:   hash,
-	})
+	spooled, err := c.downloadBlockStream(ctx, tag, height, hash, api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to query block file (tag=%v, height=%v, hash=%v): %w", tag, height, hash, err)
-	}
-
-	spooled, err := c.blockDownloader.DownloadStream(ctx, blockFileResp.GetFile())
-	if err != nil {
-		return nil, err
+		c.logger.Warn(
+			"preferred native block stream download failed; retrying legacy",
+			zap.Uint32("tag", tag),
+			zap.Uint64("height", height),
+			zap.String("hash", hash),
+			zap.Error(err),
+		)
+		var fallbackErr error
+		spooled, fallbackErr = c.downloadBlockStream(ctx, tag, height, hash, api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY)
+		if fallbackErr != nil {
+			return nil, xerrors.Errorf("failed to download preferred native block stream and legacy fallback failed (originalErr=%v): %w", err, fallbackErr)
+		}
 	}
 
 	sp, ok := c.parser.(streamingParser)
@@ -743,6 +745,24 @@ func (c *clientImpl) StreamNativeBlock(
 		return nil, xerrors.Errorf("failed to create native stream: %w", err)
 	}
 	return stream, nil
+}
+
+func (c *clientImpl) downloadBlockStream(ctx context.Context, tag uint32, height uint64, hash string, readSource api.BlockReadSource) (*downloader.SpooledBlock, error) {
+	blockFileResp, err := c.client.GetBlockFile(ctx, &api.GetBlockFileRequest{
+		Tag:        tag,
+		Height:     height,
+		Hash:       hash,
+		ReadSource: readSource,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query block file (tag=%v, height=%v, hash=%v): %w", tag, height, hash, err)
+	}
+
+	spooled, err := c.blockDownloader.DownloadStream(ctx, blockFileResp.GetFile())
+	if err != nil {
+		return nil, err
+	}
+	return spooled, nil
 }
 
 func (c *clientImpl) validateBlock(ctx context.Context, rawBlock *api.Block) error {

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -195,6 +195,52 @@ func (s *clientTestSuite) TestGetBlockWithTagAndReadSource_FallsBackToLegacyOnDo
 	s.require.Equal(block, fetchedBlock)
 }
 
+func (s *clientTestSuite) TestGetBlockWithTag_DefaultFallsBackToLegacyOnDownloadError() {
+	const (
+		tag    = uint32(2)
+		height = uint64(12345)
+		hash   = "0xabcde"
+	)
+
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+	consolidatedBlockFile := &api.BlockFile{
+		Tag:          block.Metadata.Tag,
+		Height:       block.Metadata.Height,
+		Hash:         block.Metadata.Hash,
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	}
+	legacyBlockFile := &api.BlockFile{
+		Tag:    block.Metadata.Tag,
+		Height: block.Metadata.Height,
+		Hash:   block.Metadata.Hash,
+	}
+
+	gomock.InOrder(
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFileResponse{
+			File: consolidatedBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), consolidatedBlockFile).Return(nil, xerrors.New("consolidated download failed")),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFileResponse{
+			File: legacyBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), legacyBlockFile).Return(block, nil),
+	)
+
+	fetchedBlock, err := s.client.GetBlockWithTag(context.Background(), tag, height, hash)
+	s.require.NoError(err)
+	s.require.Equal(block, fetchedBlock)
+}
+
 func (s *clientTestSuite) TestGetBlocksByRange() {
 	const (
 		tag         = uint32(0)
@@ -346,6 +392,59 @@ func (s *clientTestSuite) TestGetBlocksByRangeWithTagAndReadSource_FallsBackToLe
 	readSourceClient, ok := s.client.(ReadSourceClient)
 	s.require.True(ok)
 	fetchedBlocks, err := readSourceClient.GetBlocksByRangeWithTagAndReadSource(context.Background(), tag, startHeight, endHeight, api.BlockReadSource_BLOCK_READ_SOURCE_CONSOLIDATED)
+	s.require.NoError(err)
+	s.require.Equal(numBlocks, len(fetchedBlocks))
+	s.require.Equal(blocks, fetchedBlocks)
+}
+
+func (s *clientTestSuite) TestGetBlocksByRangeWithTag_DefaultFallsBackToLegacyOnDownloadError() {
+	const (
+		tag         = uint32(2)
+		startHeight = uint64(12345)
+		endHeight   = uint64(12350)
+		numBlocks   = int(endHeight - startHeight)
+	)
+
+	blocks := testutil.MakeBlocksFromStartHeight(startHeight, numBlocks, tag)
+	consolidatedBlockFiles := make([]*api.BlockFile, numBlocks)
+	legacyBlockFiles := make([]*api.BlockFile, numBlocks)
+	for i := range blocks {
+		metadata := blocks[i].Metadata
+		consolidatedBlockFiles[i] = &api.BlockFile{
+			Tag:          metadata.Tag,
+			Height:       metadata.Height,
+			Hash:         metadata.Hash,
+			ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		}
+		legacyBlockFiles[i] = &api.BlockFile{
+			Tag:    metadata.Tag,
+			Height: metadata.Height,
+			Hash:   metadata.Hash,
+		}
+	}
+
+	gomock.InOrder(
+		s.gatewayClient.EXPECT().GetBlockFilesByRange(gomock.Any(), &api.GetBlockFilesByRangeRequest{
+			Tag:         tag,
+			StartHeight: startHeight,
+			EndHeight:   endHeight,
+			ReadSource:  api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFilesByRangeResponse{
+			Files: consolidatedBlockFiles,
+		}, nil),
+		s.downloaderClient.EXPECT().DownloadMany(gomock.Any(), consolidatedBlockFiles).Return(nil, xerrors.New("consolidated download failed")),
+		s.gatewayClient.EXPECT().GetBlockFilesByRange(gomock.Any(), &api.GetBlockFilesByRangeRequest{
+			Tag:         tag,
+			StartHeight: startHeight,
+			EndHeight:   endHeight,
+			ReadSource:  api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFilesByRangeResponse{
+			Files: legacyBlockFiles,
+		}, nil),
+		s.downloaderClient.EXPECT().DownloadMany(gomock.Any(), legacyBlockFiles).Return(blocks, nil),
+	)
+
+	fetchedBlocks, err := s.client.GetBlocksByRangeWithTag(context.Background(), tag, startHeight, endHeight)
 	s.require.NoError(err)
 	s.require.Equal(numBlocks, len(fetchedBlocks))
 	s.require.Equal(blocks, fetchedBlocks)

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -553,6 +553,69 @@ func (s *clientTestSuite) TestStreamBlocks() {
 	s.require.Equal(numberOfEvents, count)
 }
 
+func (s *clientTestSuite) TestStreamBlocks_DefaultFallsBackToLegacyOnDownloadError() {
+	const (
+		tag    = uint32(2)
+		height = uint64(12345)
+		hash   = "0xabcde"
+	)
+
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+	event := &api.BlockchainEvent{
+		Block: &api.BlockIdentifier{
+			Tag:    tag,
+			Height: height,
+			Hash:   hash,
+		},
+	}
+	consolidatedBlockFile := &api.BlockFile{
+		Tag:          block.Metadata.Tag,
+		Height:       block.Metadata.Height,
+		Hash:         block.Metadata.Hash,
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	}
+	legacyBlockFile := &api.BlockFile{
+		Tag:    block.Metadata.Tag,
+		Height: block.Metadata.Height,
+		Hash:   block.Metadata.Hash,
+	}
+
+	s.gatewayClient.EXPECT().StreamChainEvents(gomock.Any(), gomock.Any()).Return(s.streamClient, nil)
+	gomock.InOrder(
+		s.streamClient.EXPECT().Recv().Return(&api.ChainEventsResponse{Event: event}, nil),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFileResponse{
+			File: consolidatedBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), consolidatedBlockFile).Return(nil, xerrors.New("consolidated download failed")),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFileResponse{
+			File: legacyBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), legacyBlockFile).Return(block, nil),
+	)
+
+	ch, err := s.client.StreamChainEvents(context.Background(), StreamingConfiguration{
+		ChainEventsRequest: &api.ChainEventsRequest{},
+		NumberOfEvents:     1,
+	})
+	s.require.NoError(err)
+
+	result := <-ch
+	s.require.NotNil(result)
+	s.require.NoError(result.Error)
+	s.require.Equal(block, result.Block)
+	s.require.Equal(event, result.BlockchainEvent)
+}
+
 func (s *clientTestSuite) TestStreamBlocks_EventOnly() {
 	s.gatewayClient.EXPECT().StreamChainEvents(gomock.Any(), gomock.Any()).Return(s.streamClient, nil)
 
@@ -691,20 +754,86 @@ func (s *clientTestSuite) TestStreamNativeBlock_EthereumReturnsNilAccessors() {
 	s.require.Nil(native.GetEthereum(), "no ethereum streaming walker exists yet")
 }
 
+func (s *clientTestSuite) TestStreamNativeBlock_DefaultFallsBackToLegacyOnDownloadError() {
+	const (
+		tag    = uint32(2)
+		height = uint64(12345)
+		hash   = "0xabcde"
+	)
+	consolidatedBlockFile := &api.BlockFile{
+		Tag:          tag,
+		Height:       height,
+		Hash:         hash,
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	}
+	legacyBlockFile := &api.BlockFile{Tag: tag, Height: height, Hash: hash}
+	spooled := &downloader.SpooledBlock{
+		BlockFile: legacyBlockFile,
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(nil)), nil
+		},
+	}
+
+	gomock.InOrder(
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFileResponse{File: consolidatedBlockFile}, nil),
+		s.downloaderClient.EXPECT().DownloadStream(gomock.Any(), consolidatedBlockFile).Return(nil, xerrors.New("consolidated stream download failed")),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFileResponse{File: legacyBlockFile}, nil),
+		s.downloaderClient.EXPECT().DownloadStream(gomock.Any(), legacyBlockFile).Return(spooled, nil),
+	)
+
+	native, err := s.client.StreamNativeBlock(context.Background(), tag, height, hash)
+	s.require.NoError(err)
+	defer native.Close()
+	s.require.Nil(native.GetBitcoin(), "ethereum config must not populate GetBitcoin()")
+	s.require.Nil(native.GetEthereum(), "no ethereum streaming walker exists yet")
+}
+
 func (s *clientTestSuite) TestStreamNativeBlock_DownloadError() {
 	const (
 		tag    = uint32(2)
 		height = uint64(12345)
 		hash   = "0xabcde"
 	)
-	bf := &api.BlockFile{Tag: tag, Height: height, Hash: hash}
+	consolidatedBlockFile := &api.BlockFile{
+		Tag:          tag,
+		Height:       height,
+		Hash:         hash,
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	}
+	legacyBlockFile := &api.BlockFile{Tag: tag, Height: height, Hash: hash}
 
-	s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), gomock.Any()).Return(&api.GetBlockFileResponse{File: bf}, nil)
 	sentinel := xerrors.New("download exploded")
-	s.downloaderClient.EXPECT().DownloadStream(gomock.Any(), bf).Return(nil, sentinel)
+	fallbackSentinel := xerrors.New("legacy download exploded")
+	gomock.InOrder(
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFileResponse{File: consolidatedBlockFile}, nil),
+		s.downloaderClient.EXPECT().DownloadStream(gomock.Any(), consolidatedBlockFile).Return(nil, sentinel),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFileResponse{File: legacyBlockFile}, nil),
+		s.downloaderClient.EXPECT().DownloadStream(gomock.Any(), legacyBlockFile).Return(nil, fallbackSentinel),
+	)
 
 	view, err := s.client.StreamNativeBlock(context.Background(), tag, height, hash)
-	s.require.ErrorIs(err, sentinel)
+	s.require.ErrorIs(err, fallbackSentinel)
+	s.require.Contains(err.Error(), sentinel.Error())
 	s.require.Nil(view)
 }
 
@@ -972,4 +1101,112 @@ func (s *clientTestSuite) TestGetStaticChainMetadata() {
 	s.require.Equal(uint64(100), resp.BlockStartHeight)
 	s.require.Equal(uint64(10), resp.IrreversibleDistance)
 	s.require.Equal("3s", resp.BlockTime)
+}
+
+func (s *clientTestSuite) TestGetBlockByTransaction_DefaultFallsBackToLegacyOnDownloadError() {
+	const (
+		tag             = uint32(2)
+		height          = uint64(12345)
+		hash            = "0xabcde"
+		transactionHash = "0xtx"
+	)
+
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+	consolidatedBlockFile := &api.BlockFile{
+		Tag:          block.Metadata.Tag,
+		Height:       block.Metadata.Height,
+		Hash:         block.Metadata.Hash,
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	}
+	legacyBlockFile := &api.BlockFile{
+		Tag:    block.Metadata.Tag,
+		Height: block.Metadata.Height,
+		Hash:   block.Metadata.Hash,
+	}
+
+	gomock.InOrder(
+		s.gatewayClient.EXPECT().GetBlockByTransaction(gomock.Any(), &api.GetBlockByTransactionRequest{
+			Tag:             tag,
+			TransactionHash: transactionHash,
+		}).Return(&api.GetBlockByTransactionResponse{
+			Blocks: []*api.BlockIdentifier{{Tag: tag, Height: height, Hash: hash}},
+		}, nil),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFileResponse{
+			File: consolidatedBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), consolidatedBlockFile).Return(nil, xerrors.New("consolidated download failed")),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFileResponse{
+			File: legacyBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), legacyBlockFile).Return(block, nil),
+	)
+
+	blocks, err := s.client.GetBlockByTransaction(context.Background(), tag, transactionHash)
+	s.require.NoError(err)
+	s.require.Equal([]*api.Block{block}, blocks)
+}
+
+func (s *clientTestSuite) TestGetBlockByTimestamp_DefaultFallsBackToLegacyOnDownloadError() {
+	const (
+		tag       = uint32(2)
+		height    = uint64(12345)
+		hash      = "0xabcde"
+		timestamp = uint64(123456789)
+	)
+
+	block := testutil.MakeBlocksFromStartHeight(height, 1, tag)[0]
+	consolidatedBlockFile := &api.BlockFile{
+		Tag:          block.Metadata.Tag,
+		Height:       block.Metadata.Height,
+		Hash:         block.Metadata.Hash,
+		ObjectFormat: api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	}
+	legacyBlockFile := &api.BlockFile{
+		Tag:    block.Metadata.Tag,
+		Height: block.Metadata.Height,
+		Hash:   block.Metadata.Hash,
+	}
+
+	gomock.InOrder(
+		s.gatewayClient.EXPECT().GetBlockByTimestamp(gomock.Any(), &api.GetBlockByTimestampRequest{
+			Tag:       tag,
+			Timestamp: timestamp,
+		}).Return(&api.GetBlockByTimestampResponse{
+			Tag:    tag,
+			Height: height,
+			Hash:   hash,
+		}, nil),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_DEFAULT,
+		}).Return(&api.GetBlockFileResponse{
+			File: consolidatedBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), consolidatedBlockFile).Return(nil, xerrors.New("consolidated download failed")),
+		s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), &api.GetBlockFileRequest{
+			Tag:        tag,
+			Height:     height,
+			Hash:       hash,
+			ReadSource: api.BlockReadSource_BLOCK_READ_SOURCE_LEGACY,
+		}).Return(&api.GetBlockFileResponse{
+			File: legacyBlockFile,
+		}, nil),
+		s.downloaderClient.EXPECT().Download(gomock.Any(), legacyBlockFile).Return(block, nil),
+	)
+
+	got, err := s.client.GetBlockByTimestamp(context.Background(), tag, timestamp)
+	s.require.NoError(err)
+	s.require.Equal(block, got)
 }


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046/fix-chainstorage-cscb-auto-consolidation-scheduler

## Summary
- enable `aws.storage.consolidation.read_shadow_first` for Solana mainnet production
- make the Solana prod config explicitly declare S3 blob storage and Postgres metadata storage for the consolidated read path
- make default file reads (`GetBlockFile` / `GetBlockFilesByRange`) honor `read_shadow_first`, matching raw-block reads
- make normal SDK default reads retry explicit legacy if the preferred CSCB/default object read fails, including block/range reads, stream event reads, transaction/timestamp lookups, raw payload opens, and native block streaming
- update config, handler, and SDK tests for the Solana prod override and default read fallback behavior

## Behavior
- default Solana prod reads try validated CSCB shadow metadata first across raw-block and file-read APIs
- explicit `LEGACY` read source still forces the legacy single-block metadata/object path
- if the shadow is missing or invalid, the server falls back to the legacy single-block metadata/object path
- if a default SDK read receives a CSCB file but download/open fails, the SDK retries once with explicit `LEGACY`
- already promoted CSCB primary metadata continues to read directly from CSCB without server-side legacy fallback

## Validation
- `make config`
- `TEST_TYPE=unit go test -count=1 ./internal/config`
- `TEST_TYPE=unit go test -count=1 ./internal/config -run 'TestSolanaProductionCadenceKeepAliveConfig|TestDerivedConfigValues/chainstorage/solana-mainnet/production|TestValidateConfigs/chainstorage/solana-mainnet/production'`
- `TEST_TYPE=unit go test -count=1 ./internal/server -run 'TestHandlerSuite/TestGet(BlockFile_DefaultUsesReadShadowFirst|BlockFile_ReadSourceLegacyIgnoresReadShadowFirst|BlockFile_ReadSourceConsolidatedUsesShadowMetadata|BlockFilesByRange_DefaultUsesReadShadowFirst|BlockFilesByRange_ReadSourceConsolidatedUsesShadowMetadata|RawBlock_DefaultUsesReadShadowFirst|RawBlocksByRange_DefaultUsesReadShadowFirstWithMiss)$'`
- `TEST_TYPE=unit go test -count=1 ./sdk -run 'TestClientTestSuite/Test(StreamBlocks_DefaultFallsBackToLegacyOnDownloadError|StreamNativeBlock_DefaultFallsBackToLegacyOnDownloadError|StreamNativeBlock_DownloadError|GetBlockByTransaction_DefaultFallsBackToLegacyOnDownloadError|GetBlockByTimestamp_DefaultFallsBackToLegacyOnDownloadError|GetBlockWithTag_DefaultFallsBackToLegacyOnDownloadError|GetBlocksByRangeWithTag_DefaultFallsBackToLegacyOnDownloadError)$'`
- `TEST_TYPE=unit go test -count=1 ./sdk ./internal/server ./internal/config ./tools/config_gen`
- `git diff --check`