### PR TITLE
fix: fall back to transaction traces for robinhood top-level calls error

### DIFF
--- a/internal/blockchain/client/ethereum/ethereum.go
+++ b/internal/blockchain/client/ethereum/ethereum.go
@@ -54,6 +54,7 @@ type (
 	ethereumClientMetrics struct {
 		traceBlockSuccessCounter          tally.Counter
 		traceBlockServerErrorCounter      tally.Counter
+		traceBlockFallbackCounter         tally.Counter
 		traceBlockExecutionTimeoutCounter tally.Counter
 		traceBlockFakeCounter             tally.Counter
 		traceTransactionFakeCounter       tally.Counter
@@ -111,6 +112,13 @@ const (
 	optimismWhitelistError    = "TypeError: cannot read property 'toString' of undefined    in server-side tracer function 'result'"
 	optimismFakeTraceError    = "Creating fake trace for failed transaction."
 	unfinalizedDataError      = "cannot query unfinalized data"
+
+	// On Arbitrum Nitro based chains, a transaction terminated by ArbOS before EVM execution
+	// (e.g. included by the sequencer but failed pre-checks) produces zero call frames, while
+	// go-ethereum's callTracer requires exactly one top-level frame per transaction.
+	// See https://github.com/OffchainLabs/go-ethereum/blob/master/eth/tracers/native/call.go
+	incorrectTopLevelCallsError = "incorrect number of top-level calls"
+	robinhoodFakeTraceError     = "Creating fake trace for transaction terminated by ArbOS before EVM execution."
 )
 
 var ethBlacklistedRanges = map[common.Network][]types.BlockRange{
@@ -319,6 +327,9 @@ func newEthereumClientMetrics(scope tally.Scope) *ethereumClientMetrics {
 	traceBlockFakeCounter := scope.
 		Tagged(map[string]string{resultType: "fake_trace"}).
 		Counter(traceBlockCounter)
+	traceBlockFallbackCounter := scope.
+		Tagged(map[string]string{resultType: "fallback"}).
+		Counter(traceBlockCounter)
 
 	traceTransactionSuccessCounter := scope.
 		Tagged(map[string]string{resultType: "success"}).
@@ -339,6 +350,7 @@ func newEthereumClientMetrics(scope tally.Scope) *ethereumClientMetrics {
 		traceTransactionSuccessCounter:    traceTransactionSuccessCounter,
 		traceTransactionIgnoredCounter:    traceTransactionIgnoredCounter,
 		traceBlockFakeCounter:             traceBlockFakeCounter,
+		traceBlockFallbackCounter:         traceBlockFallbackCounter,
 		traceTransactionFakeCounter:       traceTransactionFakeCounter,
 		transactionReceiptFakeCounter:     transactionReceiptFakeCounter,
 	}
@@ -879,6 +891,20 @@ func (c *EthereumClient) getBlockTraces(ctx context.Context, tag uint32, block *
 			return response, nil
 		})
 		if err != nil {
+			if c.config.Blockchain() == common.Blockchain_BLOCKCHAIN_ROBINHOOD && isIncorrectTopLevelCallsError(err) {
+				// A transaction terminated by ArbOS before EVM execution produces zero call
+				// frames, which fails the whole block-level callTracer request. Fall back to
+				// per-transaction tracing so the poisoned transaction gets a fake trace via
+				// processFailedTransactionTrace while the rest keep their real traces.
+				c.logger.Warn(
+					"block trace failed with incorrect number of top-level calls; falling back to transaction traces",
+					zap.Uint64("height", height),
+					zap.String("hash", hash),
+				)
+				c.metrics.traceBlockFallbackCounter.Inc(1)
+				return c.getTransactionTraces(ctx, tag, block)
+			}
+
 			c.metrics.traceBlockServerErrorCounter.Inc(1)
 			return nil, err
 		}
@@ -1378,8 +1404,27 @@ func (c *EthereumClient) isServerError(err error) bool {
 	return false
 }
 
+// isIncorrectTopLevelCallsError matches the deterministic go-ethereum callTracer error
+// returned when a transaction yields a number of top-level call frames other than one.
+func isIncorrectTopLevelCallsError(err error) bool {
+	var rpcErr *jsonrpc.RPCError
+	return xerrors.As(err, &rpcErr) && rpcErr.Code == -32000 && rpcErr.Message == incorrectTopLevelCallsError
+}
+
 func (c *EthereumClient) processFailedTransactionTrace(err error) ([]byte, bool, error) {
 	processed := false
+	if c.config.Blockchain() == common.Blockchain_BLOCKCHAIN_ROBINHOOD && isIncorrectTopLevelCallsError(err) {
+		// The transaction was terminated by ArbOS before EVM execution (e.g. included by the
+		// sequencer but failed pre-checks), so no call frames exist. Substitute a fake trace;
+		// the receipt already records the failed status.
+		byteTrace, processErr := json.Marshal(ethereum.EthereumTransactionTrace{Error: robinhoodFakeTraceError})
+		processed = true
+		if processErr != nil {
+			return nil, processed, xerrors.Errorf("failed to marshal fake trace for robinhood transaction: %w", processErr)
+		}
+		c.metrics.traceTransactionFakeCounter.Inc(1)
+		return byteTrace, processed, nil
+	}
 	if c.config.Blockchain() == common.Blockchain_BLOCKCHAIN_OPTIMISM {
 		// If an Optimism transaction is failed with the following error: "Fail with error
 		// 'deployer address not whitelisted:'", we need to create a fake trace

--- a/internal/blockchain/client/ethereum/robinhood_test.go
+++ b/internal/blockchain/client/ethereum/robinhood_test.go
@@ -1,0 +1,177 @@
+package ethereum
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/mock/gomock"
+
+	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
+	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
+	jsonrpcmocks "github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks"
+	"github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum"
+	"github.com/coinbase/chainstorage/internal/utils/testapp"
+	"github.com/coinbase/chainstorage/internal/utils/testutil"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
+)
+
+const (
+	// Transaction hashes embedded in fixtureBlock.
+	robinhoodTestTxHash0 = "0xbaa42c87b7c764c548fa37e61e9764415fd4a79d7e073d4f92a456698002016b"
+	robinhoodTestTxHash1 = "0xf5365847bff6e48d0c6bc23eee276343d2987efd9876c3c1bf597225e3d69991"
+)
+
+func newRobinhoodTestClient(t *testing.T, rpcClient *jsonrpcmocks.MockClient) (internal.Client, func()) {
+	var result internal.ClientParams
+	app := testapp.New(
+		t,
+		Module,
+		testModule(rpcClient),
+		testapp.WithBlockchainNetwork(common.Blockchain_BLOCKCHAIN_ROBINHOOD, common.Network_NETWORK_ROBINHOOD_MAINNET),
+		fx.Populate(&result),
+	)
+	return result.Master, app.Close
+}
+
+// A block containing a transaction terminated by ArbOS before EVM execution cannot be traced
+// at the block level ("incorrect number of top-level calls"). The client should fall back to
+// per-transaction tracing and substitute a fake trace for the poisoned transaction.
+func TestRobinhoodClient_GetBlockByHeight_TopLevelCallsFallback(t *testing.T) {
+	require := testutil.Require(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rpcClient := jsonrpcmocks.NewMockClient(ctrl)
+
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethGetBlockByNumberMethod, jsonrpc.Params{"0xacc290", true},
+	).Return(&jsonrpc.Response{Result: json.RawMessage(fixtureBlock)}, nil)
+
+	rpcClient.EXPECT().BatchCall(
+		gomock.Any(), ethGetTransactionReceiptMethod, gomock.Any(),
+	).Return([]*jsonrpc.Response{
+		{Result: json.RawMessage(fixtureReceipt)},
+		{Result: json.RawMessage(fixtureReceipt)},
+	}, nil)
+
+	rpcErr := &jsonrpc.RPCError{Code: -32000, Message: incorrectTopLevelCallsError}
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethTraceBlockByHashMethod, gomock.Any(),
+	).Return(nil, rpcErr)
+
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethTraceTransactionMethod, gomock.Any(),
+	).Times(2).DoAndReturn(func(ctx context.Context, method *jsonrpc.RequestMethod, params jsonrpc.Params, opts ...jsonrpc.Option) (*jsonrpc.Response, error) {
+		txHash, ok := params[0].(string)
+		require.True(ok)
+		switch txHash {
+		case robinhoodTestTxHash0:
+			return &jsonrpc.Response{Result: json.RawMessage(fixtureTransactionTrace)}, nil
+		case robinhoodTestTxHash1:
+			return nil, rpcErr
+		default:
+			t.Fatalf("unexpected transaction hash: %v", txHash)
+			return nil, nil
+		}
+	})
+
+	client, closeApp := newRobinhoodTestClient(t, rpcClient)
+	defer closeApp()
+
+	block, err := client.GetBlockByHeight(context.Background(), tag, ethereumHeight)
+	require.NoError(err)
+	require.NotNil(block)
+
+	blobdata := block.GetEthereum()
+	require.NotNil(blobdata)
+	require.Equal(2, len(blobdata.TransactionTraces))
+
+	// The healthy transaction keeps its real trace.
+	require.Equal(json.RawMessage(fixtureTransactionTrace), json.RawMessage(blobdata.TransactionTraces[0]))
+
+	// The poisoned transaction gets the fake trace, and its wire format is exactly
+	// {"error": robinhoodFakeTraceError} so the parser sees a failed trace.
+	expectedStub, err := json.Marshal(ethereum.EthereumTransactionTrace{Error: robinhoodFakeTraceError})
+	require.NoError(err)
+	require.Equal(expectedStub, blobdata.TransactionTraces[1])
+
+	var stub map[string]any
+	require.NoError(json.Unmarshal(blobdata.TransactionTraces[1], &stub))
+	require.Equal(robinhoodFakeTraceError, stub["error"])
+}
+
+// Other block-level trace errors must still fail: the fallback only applies to the exact
+// "incorrect number of top-level calls" error.
+func TestRobinhoodClient_GetBlockByHeight_OtherTraceError_NoFallback(t *testing.T) {
+	require := testutil.Require(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rpcClient := jsonrpcmocks.NewMockClient(ctrl)
+
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethGetBlockByNumberMethod, jsonrpc.Params{"0xacc290", true},
+	).Return(&jsonrpc.Response{Result: json.RawMessage(fixtureBlock)}, nil)
+
+	rpcClient.EXPECT().BatchCall(
+		gomock.Any(), ethGetTransactionReceiptMethod, gomock.Any(),
+	).Return([]*jsonrpc.Response{
+		{Result: json.RawMessage(fixtureReceipt)},
+		{Result: json.RawMessage(fixtureReceipt)},
+	}, nil).AnyTimes()
+
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethTraceBlockByHashMethod, gomock.Any(),
+	).Return(nil, &jsonrpc.RPCError{Code: -32000, Message: "some other error"})
+
+	client, closeApp := newRobinhoodTestClient(t, rpcClient)
+	defer closeApp()
+
+	_, err := client.GetBlockByHeight(context.Background(), tag, ethereumHeight)
+	require.Error(err)
+	require.Contains(err.Error(), "some other error")
+}
+
+// Non-Robinhood chains must not fall back: the same error on Ethereum still fails the block,
+// and no per-transaction tracing is attempted.
+func TestEthereumClient_GetBlockByHeight_TopLevelCallsError_NoFallback(t *testing.T) {
+	require := testutil.Require(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rpcClient := jsonrpcmocks.NewMockClient(ctrl)
+
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethGetBlockByNumberMethod, jsonrpc.Params{"0xacc290", true},
+	).Return(&jsonrpc.Response{Result: json.RawMessage(fixtureBlock)}, nil)
+
+	rpcClient.EXPECT().BatchCall(
+		gomock.Any(), ethGetTransactionReceiptMethod, gomock.Any(),
+	).Return([]*jsonrpc.Response{
+		{Result: json.RawMessage(fixtureReceipt)},
+		{Result: json.RawMessage(fixtureReceipt)},
+	}, nil).AnyTimes()
+
+	// No expectation for ethTraceTransactionMethod: any per-transaction call would fail the test.
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethTraceBlockByHashMethod, gomock.Any(),
+	).Return(nil, &jsonrpc.RPCError{Code: -32000, Message: incorrectTopLevelCallsError})
+
+	var result internal.ClientParams
+	app := testapp.New(
+		t,
+		Module,
+		testModule(rpcClient),
+		fx.Populate(&result),
+	)
+	defer app.Close()
+
+	_, err := result.Master.GetBlockByHeight(context.Background(), tag, ethereumHeight)
+	require.Error(err)
+	require.Contains(err.Error(), incorrectTopLevelCallsError)
+}


### PR DESCRIPTION
## Problem

Robinhood mainnet block 604227 cannot be ingested: `debug_traceBlockByHash` (callTracer) fails deterministically with `RPCError -32000: incorrect number of top-level calls`.

Root cause (verified against the live chain and Nitro sources): the block contains a transaction terminated by ArbOS **before EVM execution** (included by the sequencer but failed pre-checks — receipt `status 0`, entire gas limit burned, `gasUsedForL1 = 0`, plain transfer to an EOA, empty structLogs). Nitro's `endTxNow` path never calls the tracer's `OnEnter`, so the transaction yields **zero** call frames, while go-ethereum's `callTracer.GetResult()` requires **exactly one** top-level frame per transaction. Both the block-level and the per-transaction callTracer calls fail; this is unfixed in the latest Nitro, so a client-side fallback is required. Such transactions are user-generated and will recur.

## Fix (Robinhood-gated; no behavior change for any other chain)

Two insertions in `internal/blockchain/client/ethereum/ethereum.go`, both behind `Blockchain == BLOCKCHAIN_ROBINHOOD` plus an exact error-code/message match via a shared `isIncorrectTopLevelCallsError` helper:

1. **Block-level fallback** in `getBlockTraces` (GETH branch): on this exact error, fall back to the existing `getTransactionTraces` per-transaction path (same dispatch precedent as best-effort/blacklist), recorded under a new `trace_block` `result_type=fallback` metric instead of `server_error`.
2. **Per-transaction stub** in `processFailedTransactionTrace`: the poisoned transaction's own `debug_traceTransaction` fails with the same error; substitute `{"error": "Creating fake trace for transaction terminated by ArbOS before EVM execution."}` — the same mechanism as the Optimism whitelist fake trace. Trace/tx counts stay aligned, so the parser needs no changes (the stub parses as a failed trace, matching the receipt status). No DLQ noise.

## Testing

- TDD: new `robinhood_test.go` written first and observed failing for the right reason, then made green:
  - fallback happy path (tx0 keeps its real trace; poisoned tx1's stub is byte-exact `{"error": ...}`, locking the client→parser contract)
  - other `-32000` errors on robinhood still fail (no over-catching)
  - control: the same error on Ethereum still fails and never attempts per-transaction tracing
- Full `internal/blockchain/client/...` + `internal/blockchain/parser/...` suites pass; `go build ./...`, `go vet`, `gofmt` clean.
- Live verification against robinhood mainnet (QuickNode): block 604227 now ingests — fallback warn fires once, poisoned tx `0xd164...8ff3b` gets exactly one stub flattened trace, healthy internal tx keeps its 3 real traces; neighbor block 604226 regression-checked (no fallback triggered, unchanged path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)