### PR TITLE
fix(INF-1046): remove auto consolidate range cap

### DIFF
--- a/config/chainstorage/solana/mainnet/production.yml
+++ b/config/chainstorage/solana/mainnet/production.yml
@@ -12,7 +12,7 @@ cadence:
 cron:
   batch_consolidator:
     spec: '@every 15m'
-    workflow_parallelism: 2
+    workflow_parallelism: 4
 server:
   bind_address: 0.0.0.0:9090
 storage_type:

--- a/config_templates/config/chainstorage/solana/mainnet/production.template.yml
+++ b/config_templates/config/chainstorage/solana/mainnet/production.template.yml
@@ -12,7 +12,7 @@ cadence:
 cron:
   batch_consolidator:
     spec: "@every 15m"
-    workflow_parallelism: 2
+    workflow_parallelism: 4
 workflows:
   backfiller:
     num_concurrent_extractors: 150

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -425,7 +425,6 @@ type (
 		WorkflowParallelism int           `mapstructure:"workflow_parallelism"`
 		DelayStartDuration  time.Duration `mapstructure:"delay_start_duration"`
 		StartHeight         uint64        `mapstructure:"start_height"`
-		MaxRangeBlocks      uint64        `mapstructure:"max_range_blocks"`
 	}
 
 	StorageConfig struct {
@@ -705,7 +704,6 @@ func New(opts ...ConfigOption) (*Config, error) {
 	v.SetDefault("cron.batch_consolidator.spec", "@every 30m")
 	v.SetDefault("cron.batch_consolidator.parallelism", 1)
 	v.SetDefault("cron.batch_consolidator.delay_start_duration", "1m")
-	v.SetDefault("cron.batch_consolidator.max_range_blocks", 10000)
 	v.SetDefault("aws.storage.consolidation.enabled", false)
 	v.SetDefault("aws.storage.consolidation.mode", string(ConsolidationModeLegacyOnly))
 	v.SetDefault("aws.storage.consolidation.codec", "ZSTD")

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -106,16 +106,6 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 	}
 
 	cronConfig := t.config.Cron.BatchConsolidator
-	if cronConfig.MaxRangeBlocks == 0 {
-		return xerrors.New("batch_consolidator cron max_range_blocks must be positive")
-	}
-	if cronConfig.MaxRangeBlocks < consolidation.MaxBlocks {
-		return xerrors.Errorf(
-			"batch_consolidator cron max_range_blocks(%d) must be at least consolidation max_blocks(%d)",
-			cronConfig.MaxRangeBlocks,
-			consolidation.MaxBlocks,
-		)
-	}
 	if cronConfig.WorkflowParallelism < 0 {
 		return xerrors.Errorf("batch_consolidator cron workflow_parallelism(%d) must be non-negative", cronConfig.WorkflowParallelism)
 	}
@@ -221,7 +211,6 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 			cursorEnd, cursorEndFound := batchConsolidatorCronRangeEnd(
 				cronConfig.StartHeight,
 				searchEnd,
-				cronConfig.MaxRangeBlocks,
 				consolidation.MaxBlocks,
 				consolidation.ShardSize,
 			)
@@ -233,7 +222,6 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 					zap.Uint64("safe_end_height", searchEnd),
 					zap.Uint64("latest_height", latest.GetHeight()),
 					zap.Uint64("safe_consolidation_height", safeHeight),
-					zap.Uint64("max_range_blocks", cronConfig.MaxRangeBlocks),
 					zap.Uint64("consolidation_max_blocks", consolidation.MaxBlocks),
 				)
 				return nil
@@ -282,7 +270,6 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 	endHeight, found := batchConsolidatorCronRangeEnd(
 		searchStart,
 		searchEnd,
-		cronConfig.MaxRangeBlocks,
 		consolidation.MaxBlocks,
 		consolidation.ShardSize,
 	)
@@ -297,7 +284,6 @@ func (t *batchConsolidatorTask) Run(ctx context.Context) error {
 			zap.Uint64("end_height", searchEnd),
 			zap.Uint64("latest_height", latest.GetHeight()),
 			zap.Uint64("safe_consolidation_height", safeHeight),
-			zap.Uint64("max_range_blocks", cronConfig.MaxRangeBlocks),
 			zap.Uint64("consolidation_max_blocks", consolidation.MaxBlocks),
 		)
 		return nil
@@ -420,14 +406,11 @@ func batchConsolidatorCronSafeEndHeight(latestHeight uint64, irreversibleDistanc
 	return safeHeight + 1, safeHeight, true
 }
 
-func batchConsolidatorCronRangeEnd(startHeight uint64, safeEndHeight uint64, maxRangeBlocks uint64, consolidationWindowBlocks uint64, shardSize uint64) (uint64, bool) {
-	if safeEndHeight <= startHeight || maxRangeBlocks == 0 || consolidationWindowBlocks == 0 || shardSize == 0 {
+func batchConsolidatorCronRangeEnd(startHeight uint64, safeEndHeight uint64, consolidationWindowBlocks uint64, shardSize uint64) (uint64, bool) {
+	if safeEndHeight <= startHeight || consolidationWindowBlocks == 0 || shardSize == 0 {
 		return 0, false
 	}
 	rangeLimit := safeEndHeight
-	if maxRangeBlocks < safeEndHeight-startHeight {
-		rangeLimit = startHeight + maxRangeBlocks
-	}
 	endHeight := startHeight
 	for {
 		nextEnd := endHeight + consolidationWindowBlocks

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -51,7 +51,6 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 2_500
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -76,11 +75,37 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 	}, runtime.executions[0].request)
 }
 
+func TestBatchConsolidatorCronRunsToNearestSafeFullWindow(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.BatchConsolidator.StartHeight = 7_000
+	cfg.Chain.IrreversibleDistance = 32
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 20_500}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(7_000), uint64(20_469)).
+		Return(uint64(7_000), true, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, &workflowpkg.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		Tag:         tag,
+		StartHeight: 7_000,
+		EndHeight:   20_000,
+	}, runtime.executions[0].request)
+}
+
 func TestBatchConsolidatorCronPassesWorkflowParallelism(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 2_500
 	cfg.Cron.BatchConsolidator.WorkflowParallelism = 2
 
 	tag := cfg.GetEffectiveBlockTag(0)
@@ -109,7 +134,6 @@ func TestBatchConsolidatorCronWaitsForFullConsolidationWindow(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -130,7 +154,6 @@ func TestBatchConsolidatorCronUsesPersistedCursor(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -157,7 +180,6 @@ func TestBatchConsolidatorCronNormalizesCursorShardTail(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -184,7 +206,6 @@ func TestBatchConsolidatorCronRepairsWithinCursorLookback(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -213,7 +234,6 @@ func TestBatchConsolidatorCronDoesNotCapAutoConsolidateAtPromotionGate(t *testin
 	gateHeight := uint64(1_600)
 	cfg.AWS.Storage.Consolidation.PromotionGateHeight = &gateHeight
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -387,7 +407,6 @@ func newBatchConsolidatorCronTask(t *testing.T) (*batchConsolidatorTask, *batchC
 	cfg.Chain.BlockTag.Latest = 2
 	cfg.Chain.IrreversibleDistance = 100
 	cfg.Cron.BatchConsolidator.Enabled = true
-	cfg.Cron.BatchConsolidator.MaxRangeBlocks = 10_000
 	cfg.AWS.Storage.Consolidation.Enabled = true
 	cfg.AWS.Storage.Consolidation.Mode = config.ConsolidationModeAutoConsolidate
 	cfg.AWS.Storage.Consolidation.MaxBlocks = 1_000


### PR DESCRIPTION
Linear: https://linear.app/cipherowl/issue/INF-1046/remove-auto-consolidate-range-cap

## Summary
- Remove `cron.batch_consolidator.max_range_blocks` from Chainstorage config.
- Make auto-consolidate select its end height from the latest safe exclusive end, rounded down to full consolidation windows.
- Add a regression test proving auto-consolidate runs to the nearest safe full window instead of stopping at the old 10k cap.

## Validation
- `go test ./internal/cron`
- `git diff --check`

## Deployment note
After this Chainstorage image is deployed, Solana auto-consolidate should no longer cap a run at `cursor + 10000`; it should process all safe full 1000-block windows available at cron start.