### PR TITLE
perf(INF-1113): raise CSCB backfill parallelism

### DIFF
--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -42,7 +42,7 @@ const (
 	autoConsolidateSuffix                   = "auto_consolidate"
 	batchConsolidatorOpenPageSize           = 1000
 	defaultBatchConsolidatorCronSpec        = "@every 30m"
-	maxBatchConsolidatorWorkflowParallelism = 10
+	maxBatchConsolidatorWorkflowParallelism = 20
 )
 
 func NewBatchConsolidator(params BatchConsolidatorTaskParams) (Task, error) {

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -106,7 +106,7 @@ func TestBatchConsolidatorCronPassesWorkflowParallelism(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.BatchConsolidator.StartHeight = 1_000
-	cfg.Cron.BatchConsolidator.WorkflowParallelism = 2
+	cfg.Cron.BatchConsolidator.WorkflowParallelism = 20
 
 	tag := cfg.GetEffectiveBlockTag(0)
 	metaStorage.EXPECT().
@@ -126,7 +126,7 @@ func TestBatchConsolidatorCronPassesWorkflowParallelism(t *testing.T) {
 		Tag:         tag,
 		StartHeight: 3_000,
 		EndHeight:   4_000,
-		Parallelism: 2,
+		Parallelism: 20,
 	}, runtime.executions[0].request)
 }
 
@@ -395,7 +395,7 @@ func TestBatchConsolidatorCronRejectsInvalidWorkflowParallelism(t *testing.T) {
 
 	err := task.Run(context.Background())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "workflow_parallelism(11) exceeds max(10)")
+	require.Contains(t, err.Error(), "workflow_parallelism(21) exceeds max(20)")
 	require.Empty(t, runtime.executions)
 }
 

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -66,7 +66,7 @@ const (
 	batchConsolidatorAutoCursorVersion             = 1
 	batchConsolidatorAutoParallelismChangeID       = "batch-consolidator-auto-parallelism"
 	batchConsolidatorAutoParallelismVersion        = 1
-	batchConsolidatorMaxParallelism                = 10
+	batchConsolidatorMaxParallelism                = 20
 	maxUint64                                      = ^uint64(0)
 )
 

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -66,6 +66,7 @@ const (
 	batchConsolidatorAutoCursorVersion             = 1
 	batchConsolidatorAutoParallelismChangeID       = "batch-consolidator-auto-parallelism"
 	batchConsolidatorAutoParallelismVersion        = 1
+	batchConsolidatorPreviousMaxParallelism        = 10
 	batchConsolidatorMaxParallelism                = 20
 	maxUint64                                      = ^uint64(0)
 )
@@ -266,6 +267,11 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			}
 
 			batchEnd := batchConsolidatorWindowEnd(batchStart, workflowEndHeight, batchSize, shardSize)
+			if mode == config.ConsolidationModeHistoricalBackfill && parallelism > batchConsolidatorPreviousMaxParallelism {
+				// Parallelism above the previous hard limit cannot exist in an old history.
+				// Queue work across shards while keeping each CSCB object shard-bounded below.
+				batchEnd = batchConsolidatorBatchEnd(batchStart, workflowEndHeight, batchSize)
+			}
 			if batchEnd <= batchStart {
 				return xerrors.Errorf("batch_consolidator made no height progress from %d to %d", batchStart, batchEnd)
 			}
@@ -281,6 +287,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 					batchStart,
 					batchEnd,
 					maxBlocks,
+					shardSize,
 					parallelism,
 					usePersistedShadowStats,
 				)
@@ -627,6 +634,7 @@ func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
 	batchStart uint64,
 	batchEnd uint64,
 	maxBlocks uint64,
+	shardSize uint64,
 	parallelism int,
 	usePersistedShadowStats bool,
 ) (uint64, uint64, error) {
@@ -651,7 +659,7 @@ func (w *BatchConsolidator) processHistoricalBackfillBatchParallel(
 	for windowStart := batchStart; windowStart < batchEnd; {
 		pending := make([]batchConsolidatorPendingActivity, 0, parallelism)
 		for len(pending) < parallelism && windowStart < batchEnd {
-			windowEnd := batchConsolidatorObjectWindowEnd(windowStart, batchEnd, maxBlocks)
+			windowEnd := batchConsolidatorWindowEnd(windowStart, batchEnd, maxBlocks, shardSize)
 			if windowEnd <= windowStart {
 				return 0, 0, xerrors.Errorf("batch_consolidator made no parallel window progress from %d to %d", windowStart, windowEnd)
 			}
@@ -975,13 +983,18 @@ func (w *BatchConsolidator) getCursorActivityRetryPolicy(cfg *config.RetryPolicy
 }
 
 func batchConsolidatorWindowEnd(startHeight uint64, requestedEndHeight uint64, batchSize uint64, shardSize uint64) uint64 {
-	batchEnd := startHeight + batchSize
-	if batchEnd < startHeight || batchEnd > requestedEndHeight {
-		batchEnd = requestedEndHeight
-	}
+	batchEnd := batchConsolidatorBatchEnd(startHeight, requestedEndHeight, batchSize)
 	shardEnd := batchConsolidatorShardEnd(startHeight, shardSize)
 	if shardEnd < batchEnd {
 		return shardEnd
+	}
+	return batchEnd
+}
+
+func batchConsolidatorBatchEnd(startHeight uint64, requestedEndHeight uint64, batchSize uint64) uint64 {
+	batchEnd := startHeight + batchSize
+	if batchEnd < startHeight || batchEnd > requestedEndHeight {
+		batchEnd = requestedEndHeight
 	}
 	return batchEnd
 }

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -308,6 +308,7 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParalle
 
 	s.cfg.Workflows.BatchConsolidator.BatchSize = 500
 	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 1000
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
 	var requests []*activity.BatchConsolidatorRequest
 	var requestsMu sync.Mutex
 	s.mockAutoConsolidateLatestHeight(620)

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -306,12 +306,15 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRejectsExcessiveParall
 func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParallelism() {
 	require := testutil.Require(s.T())
 
-	s.cfg.Workflows.BatchConsolidator.BatchSize = 500
-	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 1000
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 10000
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 100000
+	s.cfg.Workflows.BatchConsolidator.MaxBlocks = 1000
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.cfg.Workflows.BatchConsolidator.Storage.Consolidation.MaxBlocks = 1000
+	s.cfg.Workflows.BatchConsolidator.Storage.Consolidation.ShardSize = 10000
 	var requests []*activity.BatchConsolidatorRequest
 	var requestsMu sync.Mutex
-	s.mockAutoConsolidateLatestHeight(620)
+	s.mockAutoConsolidateLatestHeight(120010)
 	s.mockEmptyShadowStats()
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
@@ -330,9 +333,10 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParalle
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
-		StartHeight: 100,
-		EndHeight:   600,
-		MaxBlocks:   25,
+		StartHeight: 100000,
+		EndHeight:   120000,
+		BatchSize:   20000,
+		MaxBlocks:   1000,
 		Parallelism: 20,
 	})
 	require.NoError(err)
@@ -341,13 +345,13 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParalle
 		return requests[i].StartHeight < requests[j].StartHeight
 	})
 	for i, request := range requests {
-		startHeight := uint64(100 + i*25)
+		startHeight := uint64(100000 + i*1000)
 		require.Equal(&activity.BatchConsolidatorRequest{
 			Mode:        config.ConsolidationModeHistoricalBackfill,
 			Tag:         2,
 			StartHeight: startHeight,
-			EndHeight:   startHeight + 25,
-			MaxBlocks:   25,
+			EndHeight:   startHeight + 1000,
+			MaxBlocks:   1000,
 		}, request)
 	}
 }
@@ -542,11 +546,14 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillProcessesObjectWindow
 	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
 	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
 	var requests []*activity.BatchConsolidatorRequest
+	var requestsMu sync.Mutex
 	s.mockAutoConsolidateLatestHeight(220)
 	s.mockEmptyShadowStats()
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requestsMu.Lock()
 			requests = append(requests, request)
+			requestsMu.Unlock()
 			return &activity.BatchConsolidatorResponse{
 				StartHeight:        request.StartHeight,
 				EndHeight:          request.EndHeight,
@@ -719,6 +726,7 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesP
 	s.cfg.Workflows.BatchConsolidator.BatchSize = 100
 	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 500
 	var requests []*activity.BatchConsolidatorRequest
+	var requestsMu sync.Mutex
 	s.mockAutoConsolidateLatestHeight(220)
 	s.mockEmptyShadowStats()
 	s.env.OnGetVersion(
@@ -738,7 +746,9 @@ func (s *batchConsolidatorTestSuite) TestAutoConsolidateDefaultVersionPreservesP
 	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requestsMu.Lock()
 			requests = append(requests, request)
+			requestsMu.Unlock()
 			return &activity.BatchConsolidatorResponse{
 				StartHeight:        request.StartHeight,
 				EndHeight:          request.EndHeight,

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -299,7 +300,55 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRejectsExcessiveParall
 		Parallelism: batchConsolidatorMaxParallelism + 1,
 	})
 	require.Error(err)
-	require.Contains(err.Error(), "parallelism(11) exceeds max(10)")
+	require.Contains(err.Error(), "parallelism(21) exceeds max(20)")
+}
+
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParallelism() {
+	require := testutil.Require(s.T())
+
+	s.cfg.Workflows.BatchConsolidator.BatchSize = 500
+	s.cfg.Workflows.BatchConsolidator.CheckpointSize = 1000
+	var requests []*activity.BatchConsolidatorRequest
+	var requestsMu sync.Mutex
+	s.mockAutoConsolidateLatestHeight(620)
+	s.mockEmptyShadowStats()
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requestsMu.Lock()
+			requests = append(requests, request)
+			requestsMu.Unlock()
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				ScannedBlocks:      request.EndHeight - request.StartHeight,
+				ConsolidatedBlocks: request.EndHeight - request.StartHeight,
+				ObjectKey:          "consolidated/object.zstd",
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   600,
+		MaxBlocks:   25,
+		Parallelism: 20,
+	})
+	require.NoError(err)
+	require.Len(requests, 20)
+	sort.Slice(requests, func(i, j int) bool {
+		return requests[i].StartHeight < requests[j].StartHeight
+	})
+	for i, request := range requests {
+		startHeight := uint64(100 + i*25)
+		require.Equal(&activity.BatchConsolidatorRequest{
+			Mode:        config.ConsolidationModeHistoricalBackfill,
+			Tag:         2,
+			StartHeight: startHeight,
+			EndHeight:   startHeight + 25,
+			MaxBlocks:   25,
+		}, request)
+	}
 }
 
 func (s *batchConsolidatorTestSuite) TestAutoConsolidateValidatesFinalizedRange() {


### PR DESCRIPTION
## Summary

- raise historical-backfill and cron workflow parallelism limits from 10 to 20
- let newly valid p11-p20 historical requests queue work across scheduling shards while keeping every CSCB object inside its existing 10,000-block S3 shard
- add production-ratio coverage proving p20 creates twenty exact 1,000-block activities across two shards
- keep normal auto-consolidation and existing p10 workflow batching unchanged

## Replay and operational safety

Cross-shard scheduling is enabled only when historical-backfill parallelism exceeds the previous hard limit of 10. Such histories could not have succeeded on the previous code, so existing p10-or-lower histories retain their deterministic shard batching. Object windows remain shard-bounded and the on-disk key layout is unchanged.

A p20 canary must set `BatchSize: 20000`; the current 10,000-block default creates only ten 1,000-block activities. With ten batch-worker pods and one activity slot per pod, p20 yields ten active and ten queued activities.

## Validation

- `make test`
- `TEST_TYPE=unit go test ./internal/workflow ./internal/cron -run TestBatchConsolidator -count=1`
- `TEST_TYPE=unit go test -race ./internal/workflow -run TestBatchConsolidator -count=1`

Linear: https://linear.app/cipherowl/issue/INF-1113/cscb-scale-solana-historical-backfill-workers-and-parallelism