### PR TITLE
fix(INF-1114): validate retirement against logical CSCB size

### DIFF
--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -2,12 +2,21 @@ package retirement
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
 
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+const (
+	cscbFormatMetadataKey             = "chainstorage-format"
+	cscbCompressionScopeMetadataKey   = "chainstorage-compression-scope"
+	cscbUncompressedLengthMetadataKey = "chainstorage-uncompressed-length"
+	cscbFormatMetadataValue           = "cscb"
+	cscbCompressionScopeMetadataValue = "batch-chunked"
 )
 
 type Planner struct {
@@ -203,7 +212,9 @@ func (p *Planner) planRow(
 		item.SkipReason = SkipMissingCSCBObject
 		return item
 	}
-	if shadow.ByteOffset > head.Bytes || shadow.ByteLength > head.Bytes-shadow.ByteOffset {
+	// CSCB placements address the logical payload, not the compressed S3 object.
+	logicalBytes, ok := cscbLogicalPayloadBytes(head)
+	if head.Bytes == 0 || !ok || shadow.ByteOffset > logicalBytes || shadow.ByteLength > logicalBytes-shadow.ByteOffset {
 		item.SkipReason = SkipInvalidMetadataReference
 		return item
 	}
@@ -252,6 +263,40 @@ func validShadowReference(row MetadataRow, shadow *ConsolidationShadow) bool {
 		return false
 	}
 	return true
+}
+
+func cscbLogicalPayloadBytes(head ObjectHead) (uint64, bool) {
+	format, ok := objectMetadataValue(head.Metadata, cscbFormatMetadataKey)
+	if !ok || !strings.EqualFold(strings.TrimSpace(format), cscbFormatMetadataValue) {
+		return 0, false
+	}
+	scope, ok := objectMetadataValue(head.Metadata, cscbCompressionScopeMetadataKey)
+	if !ok || !strings.EqualFold(strings.TrimSpace(scope), cscbCompressionScopeMetadataValue) {
+		return 0, false
+	}
+	value, ok := objectMetadataValue(head.Metadata, cscbUncompressedLengthMetadataKey)
+	if !ok {
+		return 0, false
+	}
+
+	logicalBytes, err := strconv.ParseUint(strings.TrimSpace(value), 10, 64)
+	if err != nil || logicalBytes == 0 {
+		return 0, false
+	}
+	return logicalBytes, true
+}
+
+func objectMetadataValue(metadata map[string]string, name string) (string, bool) {
+	value, ok := metadata[name]
+	if ok {
+		return value, true
+	}
+	for key, candidate := range metadata {
+		if strings.EqualFold(key, name) {
+			return candidate, true
+		}
+	}
+	return "", false
 }
 
 func isPrimaryConsolidated(row MetadataRow) bool {

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -137,7 +137,7 @@ func TestPlannerPlan_ActiveLegacyMetadataIsNeverRetired(t *testing.T) {
 	row := activeLegacyTestRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
 	store := newFakeStore()
 	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
-	store.heads[row.Shadow.ConsolidatedObjectKey] = ObjectHead{Exists: true, Bytes: 1024}
+	store.heads[row.Shadow.ConsolidatedObjectKey] = cscbObjectHead(1024, 1024)
 
 	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
 	require.NoError(err)
@@ -240,7 +240,7 @@ func TestPlannerPlan_PromotedRowUsesShadowLegacyKeyAndRetireAfter(t *testing.T) 
 	row.Shadow.LegacyObjectRetireAfter = &retireAfter
 	store := newFakeStore()
 	store.versions[legacyKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
-	store.heads[cscbKey] = ObjectHead{Exists: true, Bytes: 1024}
+	store.heads[cscbKey] = cscbObjectHead(1024, 1024)
 
 	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
 	require.NoError(err)
@@ -276,7 +276,7 @@ func TestPlannerPlan_DryRunOutput(t *testing.T) {
 	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
 	store := newFakeStore()
 	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
-	store.heads[row.Shadow.ConsolidatedObjectKey] = ObjectHead{Exists: true, Bytes: 1024}
+	store.heads[row.Shadow.ConsolidatedObjectKey] = cscbObjectHead(1024, 1024)
 	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
 	require.NoError(err)
 
@@ -310,7 +310,7 @@ func TestPlannerPlan_ExactSolanaCanaryReportShape(t *testing.T) {
 
 	rows := make([]MetadataRow, 0, endHeight-startHeight)
 	store := newFakeStore()
-	store.heads[cscbKey] = ObjectHead{Exists: true, Bytes: 2 << 20}
+	store.heads[cscbKey] = cscbObjectHead(512<<10, 2<<20)
 	for height := startHeight; height < endHeight; height++ {
 		hash := fmt.Sprintf("solana-hash-%d", height)
 		key := fmt.Sprintf("BLOCKCHAIN_SOLANA/NETWORK_SOLANA_MAINNET/0/%d/%s.zstd", height, hash)
@@ -378,6 +378,58 @@ func TestPlannerApply_ProductionDisabledAndNonProdDeletesVersionIDOnly(t *testin
 	require.Equal(ActionDeletedObjectVersion, report.Items[0].Action)
 }
 
+func TestPlannerPlan_UsesCSCBUncompressedLengthForPlacementBounds(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+	row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	row.PrimaryByteOffset = 900
+	row.PrimaryByteLength = 100
+	row.Shadow.ByteOffset = 900
+	row.Shadow.ByteLength = 100
+	store := newFakeStore()
+	store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
+	store.heads[row.Shadow.ConsolidatedObjectKey] = cscbObjectHead(100, 1000)
+
+	report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Equal(ActionReportOnly, report.Items[0].Action)
+	require.Empty(report.Items[0].SkipReason)
+}
+
+func TestPlannerPlan_InvalidCSCBUncompressedLengthFailsClosed(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	validatedAt := now.Add(-8 * 24 * time.Hour)
+
+	for _, test := range []struct {
+		name     string
+		metadata map[string]string
+	}{
+		{name: "missing", metadata: nil},
+		{name: "wrong format", metadata: cscbObjectMetadata("100", "not-cscb", cscbCompressionScopeMetadataValue)},
+		{name: "wrong compression scope", metadata: cscbObjectMetadata("100", cscbFormatMetadataValue, "whole-object")},
+		{name: "malformed length", metadata: cscbObjectMetadata("invalid", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
+		{name: "zero length", metadata: cscbObjectMetadata("0", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			row := testRow(100, "hash-100", "legacy/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+			store := newFakeStore()
+			store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
+			store.heads[row.Shadow.ConsolidatedObjectKey] = ObjectHead{
+				Exists:   true,
+				Bytes:    1024,
+				Metadata: test.metadata,
+			}
+
+			report, err := NewPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+			require.NoError(err)
+			require.Equal(ActionSkip, report.Items[0].Action)
+			require.Equal(SkipInvalidMetadataReference, report.Items[0].SkipReason)
+		})
+	}
+}
+
 func testRequest(now time.Time, execute bool) PlanRequest {
 	return PlanRequest{
 		Environment:             "production",
@@ -427,6 +479,26 @@ func testRow(height uint64, hash string, legacyKey string, cscbKey string, valid
 			LegacyObjectRetireAfter: &retireAfter,
 			FormatVersion:           1,
 		},
+	}
+}
+
+func cscbObjectHead(compressedBytes uint64, uncompressedBytes uint64) ObjectHead {
+	return ObjectHead{
+		Exists: true,
+		Bytes:  compressedBytes,
+		Metadata: cscbObjectMetadata(
+			fmt.Sprintf("%d", uncompressedBytes),
+			cscbFormatMetadataValue,
+			cscbCompressionScopeMetadataValue,
+		),
+	}
+}
+
+func cscbObjectMetadata(uncompressedLength string, format string, compressionScope string) map[string]string {
+	return map[string]string{
+		cscbFormatMetadataKey:             format,
+		cscbCompressionScopeMetadataKey:   compressionScope,
+		cscbUncompressedLengthMetadataKey: uncompressedLength,
 	}
 }
 

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -402,14 +402,16 @@ func TestPlannerPlan_InvalidCSCBUncompressedLengthFailsClosed(t *testing.T) {
 	validatedAt := now.Add(-8 * 24 * time.Hour)
 
 	for _, test := range []struct {
-		name     string
-		metadata map[string]string
+		name            string
+		compressedBytes uint64
+		metadata        map[string]string
 	}{
-		{name: "missing", metadata: nil},
-		{name: "wrong format", metadata: cscbObjectMetadata("100", "not-cscb", cscbCompressionScopeMetadataValue)},
-		{name: "wrong compression scope", metadata: cscbObjectMetadata("100", cscbFormatMetadataValue, "whole-object")},
-		{name: "malformed length", metadata: cscbObjectMetadata("invalid", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
-		{name: "zero length", metadata: cscbObjectMetadata("0", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
+		{name: "missing", compressedBytes: 1024, metadata: nil},
+		{name: "zero compressed bytes", compressedBytes: 0, metadata: cscbObjectMetadata("100", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
+		{name: "wrong format", compressedBytes: 1024, metadata: cscbObjectMetadata("100", "not-cscb", cscbCompressionScopeMetadataValue)},
+		{name: "wrong compression scope", compressedBytes: 1024, metadata: cscbObjectMetadata("100", cscbFormatMetadataValue, "whole-object")},
+		{name: "malformed length", compressedBytes: 1024, metadata: cscbObjectMetadata("invalid", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
+		{name: "zero length", compressedBytes: 1024, metadata: cscbObjectMetadata("0", cscbFormatMetadataValue, cscbCompressionScopeMetadataValue)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
@@ -418,7 +420,7 @@ func TestPlannerPlan_InvalidCSCBUncompressedLengthFailsClosed(t *testing.T) {
 			store.versions[row.LegacyObjectKey] = ObjectVersion{Exists: true, VersionID: "legacy-v1", Bytes: 42}
 			store.heads[row.Shadow.ConsolidatedObjectKey] = ObjectHead{
 				Exists:   true,
-				Bytes:    1024,
+				Bytes:    test.compressedBytes,
 				Metadata: test.metadata,
 			}
 


### PR DESCRIPTION
## Summary

- validate retirement placements against CSCB logical payload size instead of compressed S3 object size
- require the S3 object metadata to identify `cscb` / `batch-chunked` content and provide a valid positive `chainstorage-uncompressed-length`
- keep missing or malformed object metadata fail-closed
- add regression coverage for compressed-vs-logical bounds and invalid metadata

## Production evidence

After the `ListBucketVersions` IAM fix deployed, the dry-run canary over `[429600000,429601000)` reported 52 eligible rows and 948 `invalid_metadata_reference` rows. The referenced CSCB object has:

- compressed S3 `ContentLength`: `572,479,570`
- `chainstorage-uncompressed-length`: `10,138,241,386`
- logical placement for height `429600052`: offset `565,392,561`, length `13,350,598`

Placements are offsets into the uncompressed CSCB payload, so comparing them with compressed `ContentLength` rejected valid rows after the first 52.

## Safety boundary

This PR does not enable production deletion, add `DeleteObjectVersion`, change S3 lifecycle rules, mutate metadata, or add a database migration. Production remains report-only until this fix deploys and the full canary passes.

## Validation

- `go test -count=1 ./internal/storage/retirement`
- `go test -count=1 ./internal/storage/blobstorage/cscb ./internal/storage/blobstorage/s3 ./internal/storage/retirement`
- `go vet ./internal/storage/retirement`
- repository-wide tests were attempted locally but unrelated link steps exhausted the workstation disk (`no space left on device`); CI is the full-suite gate

Linear: https://linear.app/cipherowl/issue/INF-1114/cscb-unblock-guarded-solana-legacy-object-retirement