### PR TITLE
feat: make EVM client receipt batch size configurable via tx_batch_size

### DIFF
--- a/internal/blockchain/client/ethereum/ethereum.go
+++ b/internal/blockchain/client/ethereum/ethereum.go
@@ -719,8 +719,13 @@ func (c *EthereumClient) getBlockTransactionReceipts(ctx context.Context, block 
 	numTransactions := len(block.Transactions)
 	responses := make([]*jsonrpc.Response, numTransactions)
 
-	for batchStart := 0; batchStart < numTransactions; batchStart += ethBlockTransactionReceiptBatchSize {
-		batchEnd := batchStart + ethBlockTransactionReceiptBatchSize
+	receiptBatchSize := c.config.Chain.Client.TxBatchSize
+	if receiptBatchSize <= 0 {
+		receiptBatchSize = ethBlockTransactionReceiptBatchSize
+	}
+
+	for batchStart := 0; batchStart < numTransactions; batchStart += receiptBatchSize {
+		batchEnd := batchStart + receiptBatchSize
 		if batchEnd > numTransactions {
 			batchEnd = numTransactions
 		}

--- a/internal/blockchain/client/ethereum/ethereum_test.go
+++ b/internal/blockchain/client/ethereum/ethereum_test.go
@@ -21,6 +21,7 @@ import (
 	jsonrpcmocks "github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks"
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/blockchain/restapi"
+	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/dlq"
 	"github.com/coinbase/chainstorage/internal/utils/fixtures"
 	"github.com/coinbase/chainstorage/internal/utils/retry"
@@ -287,6 +288,67 @@ func TestEthereumClient_GetBlockByHeight(t *testing.T) {
 	require.Equal(2, len(blobdata.TransactionReceipts))
 	require.NotNil(blobdata.TransactionTraces)
 	require.Nil(blobdata.Uncles)
+}
+
+func TestEthereumClient_GetBlockByHeight_WithTxBatchSize(t *testing.T) {
+	require := testutil.Require(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rpcClient := jsonrpcmocks.NewMockClient(ctrl)
+
+	blockResponse := &jsonrpc.Response{
+		Result: json.RawMessage(fixtureBlock),
+	}
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethGetBlockByNumberMethod, jsonrpc.Params{
+			"0xacc290",
+			true,
+		},
+	).Return(blockResponse, nil)
+
+	// The fixture block has 2 transactions. With tx_batch_size set to 1,
+	// the receipts must be fetched via 2 batch calls of 1 receipt each.
+	rpcClient.EXPECT().BatchCall(
+		gomock.Any(), ethGetTransactionReceiptMethod, gomock.Any(),
+	).DoAndReturn(func(ctx context.Context, method *jsonrpc.RequestMethod, batchParams []jsonrpc.Params, opts ...jsonrpc.Option) ([]*jsonrpc.Response, error) {
+		require.Equal(1, len(batchParams))
+		return []*jsonrpc.Response{
+			{Result: json.RawMessage(fixtureReceipt)},
+		}, nil
+	}).Times(2)
+
+	traceResponse := &jsonrpc.Response{
+		Result: json.RawMessage(fixtureBlockTrace),
+	}
+	rpcClient.EXPECT().Call(
+		gomock.Any(), ethTraceBlockByHashMethod, gomock.Any(),
+	).Return(traceResponse, nil)
+
+	cfg, err := config.New()
+	require.NoError(err)
+	cfg.Chain.Client.TxBatchSize = 1
+
+	var result internal.ClientParams
+	app := testapp.New(
+		t,
+		Module,
+		testModule(rpcClient),
+		testapp.WithConfig(cfg),
+		fx.Populate(&result),
+	)
+	defer app.Close()
+
+	client := result.Master
+	require.NotNil(client)
+
+	block, err := client.GetBlockByHeight(context.Background(), tag, ethereumHeight)
+	require.NoError(err)
+
+	blobdata := block.GetEthereum()
+	require.NotNil(blobdata)
+	require.Equal(2, len(blobdata.TransactionReceipts))
 }
 
 func TestEthereumClient_GetBlockByHeightWithoutTransactions(t *testing.T) {


### PR DESCRIPTION
The ethereum client (shared by robinhood and other EVM chains) hardcoded eth_getTransactionReceipt batching at 100 per JSON-RPC batch call. Wire the existing chain.client.tx_batch_size config (previously only read by the bitcoin client) into the receipt batching loop, falling back to the current default of 100 when unset, so per-chain configs can tune batch size to provider limits.

### What changed? Why?
<!-- Please describe the change and why you made it. -->
 
### How did you test the change?
<!-- Please describe how the change was tested. -->
- [ ] unit test
- [ ] integration test
- [ ] functional test
- [ ] adhoc test (described below)
