### PR TITLE
feat: add rps_count_batch endpoint option to charge rate limit per batched call

### DIFF
--- a/internal/blockchain/endpoints/client.go
+++ b/internal/blockchain/endpoints/client.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,13 +11,40 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/ratelimiter"
 )
 
+type requestWeightContextKey struct{}
+
+// WithRequestWeight annotates ctx with the number of provider-side requests
+// the enclosed HTTP request represents, e.g. the number of calls inside a
+// JSON-RPC batch request. The weight is only consumed by endpoints configured
+// with rps_count_batch; all other endpoints keep charging one token per HTTP
+// request.
+func WithRequestWeight(ctx context.Context, weight int) context.Context {
+	return context.WithValue(ctx, requestWeightContextKey{}, weight)
+}
+
+// RequestWeightFromContext returns the weight set by WithRequestWeight.
+// It returns 1 when the weight is unset or non-positive, since every HTTP
+// request costs at least one provider-side request.
+func RequestWeightFromContext(ctx context.Context) int {
+	weight, ok := ctx.Value(requestWeightContextKey{}).(int)
+	if !ok || weight <= 0 {
+		return 1
+	}
+
+	return weight
+}
+
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(rt.headers) > 0 {
 		for key, val := range rt.headers {
 			req.Header.Set(key, val)
 		}
 	}
-	err := rt.rateLimiter.WaitN(req.Context(), 1)
+	weight := 1
+	if rt.countBatch {
+		weight = RequestWeightFromContext(req.Context())
+	}
+	err := rt.rateLimiter.WaitWeight(req.Context(), weight)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to wait for rate limiting: %w", err)
 	}
@@ -24,7 +52,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return res, err
 }
 
-func WrapHTTPClient(client *http.Client, headers map[string]string, rps int) *http.Client {
+func WrapHTTPClient(client *http.Client, headers map[string]string, rps int, rpsCountBatch bool) *http.Client {
 	transport := client.Transport
 	if transport == nil {
 		transport = http.DefaultTransport
@@ -34,6 +62,7 @@ func WrapHTTPClient(client *http.Client, headers map[string]string, rps int) *ht
 		base:        transport,
 		headers:     headers,
 		rateLimiter: ratelimiter.New(rps),
+		countBatch:  rpsCountBatch,
 	}
 
 	return client

--- a/internal/blockchain/endpoints/client_test.go
+++ b/internal/blockchain/endpoints/client_test.go
@@ -1,10 +1,78 @@
 package endpoints
 
 import (
+	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
 )
+
+type stubRoundTripper struct {
+	calls int
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func TestRequestWeightFromContext(t *testing.T) {
+	require := testutil.Require(t)
+
+	// Unset and non-positive weights are clamped to 1.
+	require.Equal(1, RequestWeightFromContext(context.Background()))
+	require.Equal(1, RequestWeightFromContext(WithRequestWeight(context.Background(), 0)))
+	require.Equal(1, RequestWeightFromContext(WithRequestWeight(context.Background(), -3)))
+	require.Equal(7, RequestWeightFromContext(WithRequestWeight(context.Background(), 7)))
+}
+
+func TestRoundTripperRequestWeight(t *testing.T) {
+	require := testutil.Require(t)
+
+	newRequest := func(weight int) *http.Request {
+		ctx := WithRequestWeight(context.Background(), weight)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost", nil)
+		require.NoError(err)
+		return req
+	}
+
+	// countBatch disabled: a weighted request charges a single token, so it
+	// passes instantly even though the weight exceeds the burst.
+	stub := &stubRoundTripper{}
+	client := WrapHTTPClient(&http.Client{Transport: stub}, nil, 20, false)
+	start := time.Now()
+	resp, err := client.Transport.RoundTrip(newRequest(25))
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.True(time.Since(start) < 200*time.Millisecond, "elapsed=%v", time.Since(start))
+	require.Equal(1, stub.calls)
+
+	// countBatch enabled: the same request charges 25 tokens against a bucket
+	// of 20, so at least 5 tokens must be waited for at 20 rps (>= 250ms).
+	stub = &stubRoundTripper{}
+	client = WrapHTTPClient(&http.Client{Transport: stub}, nil, 20, true)
+	start = time.Now()
+	resp, err = client.Transport.RoundTrip(newRequest(25))
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.True(time.Since(start) >= 200*time.Millisecond, "elapsed=%v", time.Since(start))
+	require.Equal(1, stub.calls)
+
+	// countBatch enabled without a weight in the context: defaults to 1.
+	stub = &stubRoundTripper{}
+	client = WrapHTTPClient(&http.Client{Transport: stub}, nil, 20, true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://localhost", nil)
+	require.NoError(err)
+	start = time.Now()
+	_, err = client.Transport.RoundTrip(req)
+	require.NoError(err)
+	require.True(time.Since(start) < 200*time.Millisecond, "elapsed=%v", time.Since(start))
+}
 
 func TestGetCookieNames(t *testing.T) {
 	tests := []struct {

--- a/internal/blockchain/endpoints/endpoint_provider.go
+++ b/internal/blockchain/endpoints/endpoint_provider.go
@@ -281,6 +281,10 @@ func newEndpoint(
 		opts = append(opts, withRPS(endpoint.RPS))
 	}
 
+	if endpoint.RPSCountBatch {
+		opts = append(opts, withRPSCountBatch(true))
+	}
+
 	client, err := newHTTPClient(opts...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create http client for %v: %w", endpoint.Name, err)

--- a/internal/blockchain/endpoints/http.go
+++ b/internal/blockchain/endpoints/http.go
@@ -27,6 +27,7 @@ type (
 		headers             map[string]string
 		rootCAs             *x509.CertPool
 		rps                 int
+		rpsCountBatch       bool
 	}
 
 	// stickySessionJar implements passive cookie affinity.
@@ -49,6 +50,7 @@ type (
 		logger      *zap.Logger
 		headers     map[string]string
 		rateLimiter *ratelimiter.RateLimiter
+		countBatch  bool
 	}
 )
 
@@ -98,7 +100,7 @@ func newDefaultClient(options *clientOptions) (*http.Client, error) {
 		Timeout:   options.timeout,
 		Transport: transport,
 	}
-	wrapClient := WrapHTTPClient(client, options.headers, options.rps)
+	wrapClient := WrapHTTPClient(client, options.headers, options.rps, options.rpsCountBatch)
 	return wrapClient, nil
 }
 
@@ -129,7 +131,7 @@ func newStickyClient(options *clientOptions) (*http.Client, error) {
 		headers[key] = val
 	}
 
-	wrapClient := WrapHTTPClient(client, headers, options.rps)
+	wrapClient := WrapHTTPClient(client, headers, options.rps, options.rpsCountBatch)
 	return wrapClient, nil
 }
 
@@ -202,5 +204,15 @@ func withRootCAs(roots *x509.CertPool) ClientOption {
 func withRPS(rps int) ClientOption {
 	return func(opts *clientOptions) {
 		opts.rps = rps
+	}
+}
+
+// withRPSCountBatch makes the endpoint's rate limiter charge one token per
+// call inside a JSON-RPC batch request (see WithRequestWeight). It has no
+// effect unless withRPS is also set, since no rate limiter is created
+// otherwise.
+func withRPSCountBatch(countBatch bool) ClientOption {
+	return func(opts *clientOptions) {
+		opts.rpsCountBatch = countBatch
 	}
 }

--- a/internal/blockchain/jsonrpc/client.go
+++ b/internal/blockchain/jsonrpc/client.go
@@ -230,6 +230,11 @@ func (c *clientImpl) BatchCall(ctx context.Context, method *RequestMethod, batch
 		opt(&options)
 	}
 
+	// Annotate the context before entering the retry wrapper so that every
+	// attempt's HTTP request carries the batch size, allowing endpoints with
+	// rps_count_batch to charge one rate-limit token per batched call.
+	ctx = endpoints.WithRequestWeight(ctx, len(batchParams))
+
 	endpoint, err := c.endpointProvider.GetEndpoint(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get endpoint for request: %w", err)

--- a/internal/blockchain/jsonrpc/client_test.go
+++ b/internal/blockchain/jsonrpc/client_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"github.com/coinbase/chainstorage/internal/blockchain/endpoints"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
 	jsonrpcmocks "github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -673,6 +674,111 @@ func TestBatchCall_DuplicateID(t *testing.T) {
 		batchParams)
 	require.Error(err)
 	require.Contains(err.Error(), "missing response")
+}
+
+func TestBatchCall_RequestWeight(t *testing.T) {
+	require := testutil.Require(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	httpClient := jsonrpcmocks.NewMockHTTPClient(ctrl)
+
+	// Capture the request weight seen by the transport on every attempt,
+	// including the first one and the retry.
+	var weights []int
+	attempts := 0
+	httpClient.EXPECT().Do(gomock.Any()).Times(2).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			weights = append(weights, endpoints.RequestWeightFromContext(req.Context()))
+			attempts += 1
+			body := `
+			[
+				{"jsonrpc":"2.0","id":0,"result":{"hash": "0xabcd"}},
+				{"jsonrpc":"2.0","id":1,"result":{"hash": "0xabce"}},
+				{"jsonrpc":"2.0","id":2,"result":{"hash": "0xabcf"}}
+			]`
+			if attempts == 1 {
+				// Return a null response to trigger a retry.
+				body = `
+				[
+					{"jsonrpc":"2.0","id":0,"result":{"hash": "0xabcd"}},
+					{"jsonrpc":"2.0","id":1,"result":{"hash": "0xabce"}},
+					{"jsonrpc":"2.0","id":2,"result":null}
+				]`
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader(body)),
+			}, nil
+		})
+
+	var params clientParams
+	app := testapp.New(
+		t,
+		withDummyEndpoints(),
+		fx.Provide(jsonrpc.New),
+		fx.Provide(func() jsonrpc.HTTPClient {
+			return httpClient
+		}),
+		fx.Populate(&params),
+	)
+	defer app.Close()
+
+	client := params.Master
+	require.NotNil(client)
+	batchParams := []jsonrpc.Params{
+		{"0x1234"},
+		{"0x1235"},
+		{"0x1236"},
+	}
+	_, err := client.BatchCall(context.Background(),
+		&jsonrpc.RequestMethod{Name: "hello", Timeout: time.Duration(5)},
+		batchParams)
+	require.NoError(err)
+	require.Equal([]int{3, 3}, weights)
+}
+
+func TestCall_RequestWeightDefault(t *testing.T) {
+	require := testutil.Require(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	httpClient := jsonrpcmocks.NewMockHTTPClient(ctrl)
+
+	// A single call must not carry a batch weight: the transport sees the
+	// default weight of 1.
+	var weight int
+	httpClient.EXPECT().Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			weight = endpoints.RequestWeightFromContext(req.Context())
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader(`{"jsonrpc":"2.0","id":0,"result":{"hash": "0xabcd"}}`)),
+			}, nil
+		})
+
+	var params clientParams
+	app := testapp.New(
+		t,
+		withDummyEndpoints(),
+		fx.Provide(jsonrpc.New),
+		fx.Provide(func() jsonrpc.HTTPClient {
+			return httpClient
+		}),
+		fx.Populate(&params),
+	)
+	defer app.Close()
+
+	client := params.Master
+	require.NotNil(client)
+	_, err := client.Call(context.Background(),
+		&jsonrpc.RequestMethod{Name: "hello", Timeout: time.Duration(5)},
+		jsonrpc.Params{"0x1234"})
+	require.NoError(err)
+	require.Equal(1, weight)
 }
 
 func TestBatchCall_RetryNullResponse(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -367,6 +367,10 @@ type (
 		Weight     uint8             `json:"weight"`
 		ExtraUrls  map[string]string `json:"extra_urls"`
 		RPS        int               `json:"rps"`
+		// RPSCountBatch makes the rate limiter charge one token per call inside
+		// a JSON-RPC batch request, for providers whose rate limit counts each
+		// batched call individually. Has no effect unless RPS is set.
+		RPSCountBatch bool `json:"rps_count_batch"`
 	}
 
 	EndpointConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -632,6 +632,45 @@ func TestEndpointGroupWithExtraUrls(t *testing.T) {
 	require.Equal(expectedEndpointGroup, endpointGroup)
 }
 
+func TestEndpointGroupWithRPSCountBatch(t *testing.T) {
+	require := testutil.Require(t)
+
+	text := `
+	{
+		"endpoints": [
+			{
+				"name": "quicknode",
+				"url": "testUrl",
+				"weight": 1,
+				"rps": 300,
+				"rps_count_batch": true
+			}
+		]
+	}`
+
+	var endpointGroup config.EndpointGroup
+	require.NoError(endpointGroup.UnmarshalText([]byte(text)))
+	require.Equal(300, endpointGroup.Endpoints[0].RPS)
+	require.True(endpointGroup.Endpoints[0].RPSCountBatch)
+
+	// Defaults to false when unset.
+	text = `
+	{
+		"endpoints": [
+			{
+				"name": "quicknode",
+				"url": "testUrl",
+				"weight": 1,
+				"rps": 300
+			}
+		]
+	}`
+
+	var endpointGroupDefault config.EndpointGroup
+	require.NoError(endpointGroupDefault.UnmarshalText([]byte(text)))
+	require.False(endpointGroupDefault.Endpoints[0].RPSCountBatch)
+}
+
 func TestEndpointGroup(t *testing.T) {
 	tests := []struct {
 		fixture  string

--- a/internal/utils/ratelimiter/rate_limiter.go
+++ b/internal/utils/ratelimiter/rate_limiter.go
@@ -55,6 +55,35 @@ func (l *RateLimiter) WaitN(ctx context.Context, n int) (err error) {
 	return l.limiter.WaitN(ctx, n)
 }
 
+// WaitWeight blocks until it permits n events to happen. Unlike WaitN, n may
+// exceed the limiter's burst size: the wait is split into burst-sized chunks
+// so that the total number of tokens consumed is still n. A non-positive n is
+// treated as 1.
+func (l *RateLimiter) WaitWeight(ctx context.Context, n int) error {
+	if l == nil {
+		return nil
+	}
+
+	if n <= 0 {
+		n = 1
+	}
+
+	burst := l.limiter.Burst()
+	for n > 0 {
+		chunk := n
+		if chunk > burst {
+			chunk = burst
+		}
+
+		if err := l.limiter.WaitN(ctx, chunk); err != nil {
+			return err
+		}
+		n -= chunk
+	}
+
+	return nil
+}
+
 // Limit returns the maximum overall event rate.
 // Zero is returned when there is no limit specified.
 func (l *RateLimiter) Limit() int {

--- a/internal/utils/ratelimiter/rate_limiter_test.go
+++ b/internal/utils/ratelimiter/rate_limiter_test.go
@@ -69,6 +69,38 @@ func TestWait(t *testing.T) {
 	require.True(duration <= 1.11)
 }
 
+func TestWaitWeight(t *testing.T) {
+	require := testutil.Require(t)
+
+	// nil limiter is unlimited.
+	var nilLimiter *RateLimiter
+	require.NoError(nilLimiter.WaitWeight(context.Background(), 100))
+
+	// WaitN fails when n exceeds the burst, while WaitWeight waits in chunks.
+	limiter := New(20)
+	require.Error(limiter.WaitN(context.Background(), 25))
+
+	start := time.Now()
+	require.NoError(limiter.WaitWeight(context.Background(), 25))
+	// 25 tokens at 20 rps with burst 20: at least 5 tokens must be waited for.
+	require.True(time.Since(start) >= 200*time.Millisecond, "expected chunked wait, elapsed=%v", time.Since(start))
+}
+
+func TestWaitWeightClampsNonPositive(t *testing.T) {
+	require := testutil.Require(t)
+
+	for _, n := range []int{0, -5} {
+		limiter := New(1)
+		start := time.Now()
+		// A non-positive weight consumes a single token from the full bucket,
+		// so it must return immediately without error.
+		require.NoError(limiter.WaitWeight(context.Background(), n))
+		require.True(time.Since(start) < 500*time.Millisecond)
+		// The single token is spent: the next request is not allowed.
+		require.False(limiter.Allow())
+	}
+}
+
 func tryLimiter(limiter *RateLimiter) bool {
 	for i := 0; i < 100; i++ {
 		if !limiter.Allow() {


### PR DESCRIPTION
## Summary

The per-endpoint `rps` limiter charges one token per HTTP request, but some providers (e.g. QuickNode, 300 req/s) count **each call inside a JSON-RPC batch** against their rate limit individually. Operators currently have to budget `rps × batch size` manually, which is very conservative (a 100-receipt batch forces `rps` down to 3).

This PR adds a per-endpoint `rps_count_batch` option. When enabled, a batch request charges one rate-limit token per batched call, so `rps` maps 1:1 to the provider's limit:

```yaml
endpoints:
  - name: quicknode
    url: https://...
    rps: 300
    rps_count_batch: true
```

## Changes

- **config**: new `rps_count_batch` field on `Endpoint` (defaults to false; no effect unless `rps` is set)
- **jsonrpc**: `BatchCall` annotates the request context with the batch size before entering the retry wrapper, so every attempt carries it; single `Call` keeps the default weight of 1
- **endpoints**: the rate-limiting round tripper charges the context weight when the option is enabled; weights are clamped to a minimum of 1
- **ratelimiter**: new `WaitWeight` waits in burst-sized chunks, so a batch larger than the burst no longer errors (`WaitN` fails outright when n > burst)

Backward compatible: the option defaults to off and existing endpoints keep the one-token-per-HTTP-request behavior.

## Testing

- `WaitWeight` chunking (n > burst) and non-positive clamp
- `RequestWeightFromContext` clamp (unset / 0 / negative → 1)
- round tripper behavior with the option on/off
- `rps_count_batch` parsing via `EndpointGroup.UnmarshalText` + default-false assertion
- `BatchCall` carries the weight on the first attempt **and** on retries (asserted `[3, 3]` across a null-response retry); single `Call` sees weight 1
- `go build ./...`, full `internal/blockchain/...` regression, `go vet ./internal/...` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)