### PR TITLE
feat(INF-1133): repair pre-normalization CSCBs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -631,6 +631,7 @@ const (
 	// auto_consolidate, which is the normal serial cron mode.
 	ConsolidationModeHistoricalBackfill        ConsolidationMode = "historical_backfill"
 	ConsolidationModePromoteFinalized          ConsolidationMode = "promote_finalized"
+	ConsolidationModeRepairExistingCSCB        ConsolidationMode = "repair_existing_cscb"
 	ConsolidationModeSyncerConsolidatedPrimary ConsolidationMode = "syncer_consolidated_primary"
 	DefaultSingleBlockObjectRetention                            = 72 * time.Hour
 
@@ -655,6 +656,10 @@ func (m ConsolidationMode) IsShadowWrite() bool {
 	return m == ConsolidationModeShadowDualWrite ||
 		m == ConsolidationModeAutoConsolidate ||
 		m == ConsolidationModeHistoricalBackfill
+}
+
+func (m ConsolidationMode) IsRepairExistingCSCB() bool {
+	return m == ConsolidationModeRepairExistingCSCB
 }
 
 func New(opts ...ConfigOption) (*Config, error) {

--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -1,0 +1,359 @@
+package cscbrepair_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	awss3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/coinbase/chainstorage/internal/config"
+	chains3 "github.com/coinbase/chainstorage/internal/s3"
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage"
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepair"
+	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	metapostgres "github.com/coinbase/chainstorage/internal/storage/metastorage/postgres"
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
+	storageutils "github.com/coinbase/chainstorage/internal/storage/utils"
+	"github.com/coinbase/chainstorage/internal/utils/testapp"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
+	if os.Getenv("TEST_TYPE") != "integration" {
+		t.Skip("integration test")
+	}
+	require := require.New(t)
+	ctx := context.Background()
+	unique := time.Now().UTC().UnixNano()
+	tag := uint32(1_700_000_000 + unique%100_000_000)
+	height := uint64(9_500_000_000 + unique%100_000_000)
+	bucket := fmt.Sprintf("chainstorage-cscb-repair-%d", unique)
+
+	cfg, err := config.New(
+		config.WithEnvironment(config.EnvLocal),
+		config.WithBlockchain(common.Blockchain_BLOCKCHAIN_SOLANA),
+		config.WithNetwork(common.Network_NETWORK_SOLANA_MAINNET),
+	)
+	require.NoError(err)
+	if cfg.AWS.Postgres == nil {
+		t.Skip("Postgres is not configured")
+	}
+	cfg.StorageType.BlobStorageType = config.BlobStorageType_S3
+	cfg.StorageType.MetaStorageType = config.MetaStorageType_POSTGRES
+	cfg.AWS.Bucket = bucket
+	cfg.AWS.IsLocalStack = true
+	cfg.AWS.IsResetLocal = true
+	// Pin the Docker test credentials so shell-level environment overrides cannot
+	// silently redirect or skip this destructive lifecycle test.
+	cfg.AWS.Postgres.Host = "localhost"
+	cfg.AWS.Postgres.Port = 5433
+	cfg.AWS.Postgres.Database = "chainstorage_solana_mainnet"
+	cfg.AWS.Postgres.User = "cs_solana_mainnet_worker"
+	cfg.AWS.Postgres.Password = "worker_password"
+	cfg.AWS.Postgres.SSLMode = "require"
+	cfg.Chain.BlockStartHeight = height
+	cfg.AWS.Storage.Consolidation.Enabled = true
+	cfg.AWS.Storage.Consolidation.Mode = config.ConsolidationModeHistoricalBackfill
+
+	db, err := openRepairDB(ctx, cfg.AWS.Postgres)
+	require.NoError(err)
+	defer func() { _ = db.Close() }()
+	goose.SetBaseFS(metapostgres.GetEmbeddedMigrations())
+	require.NoError(goose.SetDialect("postgres"))
+	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+
+	var (
+		meta                metastorage.MetaStorage
+		blob                blobstorage.BlobStorage
+		singleBlockUploader blobstorage.SingleBlockUploader
+		s3Session           *chains3.S3
+	)
+	app := testapp.New(
+		t,
+		testapp.WithIntegration(),
+		testapp.WithConfig(cfg),
+		chains3.Module,
+		metastorage.Module,
+		blobstorage.Module,
+		fx.Replace(newRepairLocalStackConfig(ctx)),
+		fx.Populate(&meta, &blob, &singleBlockUploader, &s3Session),
+	)
+	defer app.Close()
+	require.NotNil(meta)
+	require.NotNil(blob)
+	require.NotNil(singleBlockUploader)
+	require.NotNil(s3Session)
+
+	rawS3 := awss3.NewFromConfig(s3Session.Config)
+	_, err = rawS3.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket: aws.String(bucket),
+		VersioningConfiguration: &awss3types.VersioningConfiguration{
+			Status: awss3types.BucketVersioningStatusEnabled,
+		},
+	})
+	require.NoError(err)
+	defer cleanupRepairBucket(t, rawS3, bucket)
+
+	block := &api.Block{
+		Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+		Network:    common.Network_NETWORK_SOLANA_MAINNET,
+		Metadata: &api.BlockMetadata{
+			Tag:          tag,
+			Height:       height,
+			Hash:         fmt.Sprintf("repair-hash-%d", unique),
+			ParentHash:   fmt.Sprintf("repair-parent-%d", unique),
+			ParentHeight: height - 1,
+			Timestamp:    timestamppb.New(time.Now().UTC().Truncate(time.Second)),
+		},
+		Blobdata: &api.Block_Solana{
+			Solana: &api.SolanaBlobdata{Header: []byte(`{"slot":9500000000,"transactions":["repair"]}`)},
+		},
+	}
+	singleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
+	require.NoError(err)
+	block.Metadata.ObjectKeyMain = singleBlockKey
+	require.NoError(meta.PersistBlockMetas(ctx, true, []*api.BlockMetadata{block.Metadata}, nil))
+
+	records, err := meta.GetBlocksMissingConsolidationShadow(ctx, tag, height, height+1, 1)
+	require.NoError(err)
+	require.Len(records, 1)
+	blockMetadataID := records[0].ID
+	var repairID int64
+	defer cleanupRepairMetadata(t, db, blockMetadataID, &repairID)
+
+	downloaded, err := blob.Download(ctx, records[0].Metadata)
+	require.NoError(err)
+	dirtyBlock := proto.Clone(downloaded).(*api.Block)
+	dirtyBlock.Metadata.ObjectKeyMain = singleBlockKey
+	dirtyBlock.Metadata.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK
+	require.True(storageutils.HasBlockStoragePlacement(dirtyBlock))
+	dirtyPayload, err := proto.Marshal(dirtyBlock)
+	require.NoError(err)
+	dirtyKey, dirtyPlacements, err := blob.UploadConsolidated(ctx, []blobstorage.ConsolidatedBlockPayload{{
+		Metadata:           records[0].Metadata,
+		MetadataID:         blockMetadataID,
+		RawBlockPayload:    blobstorage.BytesPayloadSource(dirtyPayload),
+		UncompressedLength: uint64(len(dirtyPayload)),
+	}})
+	require.NoError(err)
+	require.Len(dirtyPlacements, 1)
+	dirtyPlacement := dirtyPlacements[0]
+	require.NoError(meta.PersistBlockConsolidationShadows(ctx, []*metastorage.ConsolidationShadowPlacement{{
+		BlockMetadataID:           blockMetadataID,
+		Tag:                       tag,
+		Height:                    height,
+		Hash:                      block.Metadata.Hash,
+		SingleBlockObjectKeyMain:  singleBlockKey,
+		ConsolidatedObjectKeyMain: dirtyKey,
+		ObjectFormat:              dirtyPlacement.ObjectFormat,
+		ByteOffset:                dirtyPlacement.ByteOffset,
+		ByteLength:                dirtyPlacement.ByteLength,
+		UncompressedLength:        dirtyPlacement.UncompressedLength,
+	}}))
+	promotion, err := meta.PromoteBlockConsolidationShadows(ctx, tag, height, height+1, 1, 72*time.Hour)
+	require.NoError(err)
+	require.Equal(uint64(1), promotion.Blocks)
+
+	store := retirement.NewS3ObjectStore(rawS3)
+	repairer := cscbrepair.NewRepairer(cscbrepair.NewPostgresRepository(db), store, bucket)
+	manifest, err := repairer.PrepareNext(ctx, tag, height, height+1, 1, nil)
+	require.NoError(err)
+	require.NotNil(manifest)
+	repairID = manifest.ID
+	require.Equal(cscbrepair.StatePrepared, manifest.State)
+	require.Equal(dirtyKey, manifest.OldConsolidatedObjectKey)
+	require.Len(manifest.Blocks, 1)
+	require.Len(manifest.Blocks[0].PayloadSHA256, 64)
+
+	manifest, err = repairer.Restore(ctx, manifest.ID, nil)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateRestored, manifest.State)
+	require.NotNil(manifest.RestoredAt)
+	activeSingleBlock, err := meta.GetBlockByHeight(ctx, tag, height)
+	require.NoError(err)
+	require.Equal(singleBlockKey, activeSingleBlock.ObjectKeyMain)
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK, activeSingleBlock.ObjectFormat)
+	require.Zero(activeSingleBlock.ByteLength)
+	restoredBlock, err := blob.Download(ctx, activeSingleBlock)
+	require.NoError(err)
+	require.True(proto.Equal(storageutils.CloneBlockWithoutStoragePlacement(block), storageutils.CloneBlockWithoutStoragePlacement(restoredBlock)))
+
+	records, err = meta.GetBlocksMissingConsolidationShadow(ctx, tag, height, height+1, 1)
+	require.NoError(err)
+	require.Len(records, 1)
+	cleanBlock, err := blob.Download(ctx, records[0].Metadata)
+	require.NoError(err)
+	cleanPayload, err := proto.Marshal(storageutils.CloneBlockWithoutStoragePlacement(cleanBlock))
+	require.NoError(err)
+	cleanKey, cleanPlacements, err := blob.UploadConsolidated(ctx, []blobstorage.ConsolidatedBlockPayload{{
+		Metadata:           records[0].Metadata,
+		MetadataID:         blockMetadataID,
+		RawBlockPayload:    blobstorage.BytesPayloadSource(cleanPayload),
+		UncompressedLength: uint64(len(cleanPayload)),
+	}})
+	require.NoError(err)
+	require.NotEqual(dirtyKey, cleanKey)
+	require.Len(cleanPlacements, 1)
+	cleanPlacement := cleanPlacements[0]
+	require.NoError(meta.PersistBlockConsolidationShadows(ctx, []*metastorage.ConsolidationShadowPlacement{{
+		BlockMetadataID:           blockMetadataID,
+		Tag:                       tag,
+		Height:                    height,
+		Hash:                      block.Metadata.Hash,
+		SingleBlockObjectKeyMain:  singleBlockKey,
+		ConsolidatedObjectKeyMain: cleanKey,
+		ObjectFormat:              cleanPlacement.ObjectFormat,
+		ByteOffset:                cleanPlacement.ByteOffset,
+		ByteLength:                cleanPlacement.ByteLength,
+		UncompressedLength:        cleanPlacement.UncompressedLength,
+	}}))
+	promotion, err = meta.PromoteBlockConsolidationShadows(ctx, tag, height, height+1, 1, 72*time.Hour)
+	require.NoError(err)
+	require.Equal(uint64(1), promotion.Blocks)
+	var retentionStartedAt, singleBlockDeleteAfter time.Time
+	require.NoError(db.QueryRowContext(ctx, `
+		SELECT single_block_retention_started_at, single_block_delete_after
+		FROM block_consolidation_shadow
+		WHERE block_metadata_id = $1`, blockMetadataID).Scan(&retentionStartedAt, &singleBlockDeleteAfter))
+	require.False(retentionStartedAt.Before(*manifest.RestoredAt))
+	require.WithinDuration(retentionStartedAt.Add(72*time.Hour), singleBlockDeleteAfter, time.Microsecond)
+
+	manifest, err = repairer.VerifyRebuilt(ctx, manifest.ID, nil)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateVerified, manifest.State)
+	require.Equal(cleanKey, manifest.NewConsolidatedObjectKey)
+	require.NotZero(manifest.NewConsolidatedObjectVersion.Bytes)
+	require.NotNil(manifest.VerifiedAt)
+
+	manifest, err = repairer.DeleteOldObject(ctx, manifest.ID)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateCompleted, manifest.State)
+	require.NotNil(manifest.OldObjectDeletedAt)
+	require.NotNil(manifest.CompletedAt)
+	dirtyTopology, err := store.ListObjectVersions(ctx, bucket, dirtyKey)
+	require.NoError(err)
+	require.Empty(dirtyTopology.Versions)
+	require.Empty(dirtyTopology.DeleteMarkers)
+	cleanTopology, err := store.ListObjectVersions(ctx, bucket, cleanKey)
+	require.NoError(err)
+	require.Len(cleanTopology.Versions, 1)
+	rawClean, err := retirement.NewPinnedPayloadVerifier(store).InspectConsolidated(ctx, retirement.Candidate{
+		Bucket:             bucket,
+		ConsolidatedKey:    cleanKey,
+		CSCBVersionID:      cleanTopology.Versions[0].VersionID,
+		Tag:                tag,
+		Height:             height,
+		Hash:               block.Metadata.Hash,
+		ByteOffset:         cleanPlacement.ByteOffset,
+		ByteLength:         cleanPlacement.ByteLength,
+		UncompressedLength: cleanPlacement.UncompressedLength,
+	})
+	require.NoError(err)
+	require.False(rawClean.HasStoragePlacement)
+	singleBlockTopology, err := store.ListObjectVersions(ctx, bucket, singleBlockKey)
+	require.NoError(err)
+	require.Len(singleBlockTopology.Versions, 1)
+
+	activeClean, err := meta.GetBlockByHeight(ctx, tag, height)
+	require.NoError(err)
+	require.Equal(cleanKey, activeClean.ObjectKeyMain)
+	readClean, err := blob.Download(ctx, activeClean)
+	require.NoError(err)
+	// Normal downloads overlay the active database placement after parsing; raw
+	// CSCB neutrality is asserted independently above.
+	require.True(storageutils.HasBlockStoragePlacement(readClean))
+	require.True(proto.Equal(
+		storageutils.CloneBlockWithoutStoragePlacement(block),
+		storageutils.CloneBlockWithoutStoragePlacement(readClean),
+	))
+
+	resumed, err := repairer.DeleteOldObject(ctx, manifest.ID)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateCompleted, resumed.State)
+	next, err := repairer.PrepareNext(ctx, tag, height, height+1, 1, nil)
+	require.NoError(err)
+	require.Nil(next)
+}
+
+func newRepairLocalStackConfig(ctx context.Context) aws.Config {
+	cfg, err := awsconfig.LoadDefaultConfig(
+		ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+		awsconfig.WithEndpointResolverWithOptions(
+			aws.EndpointResolverWithOptionsFunc(func(string, string, ...interface{}) (aws.Endpoint, error) {
+				return aws.Endpoint{URL: "http://localhost:4566", HostnameImmutable: true}, nil
+			}),
+		),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("failed to configure LocalStack: %v", err))
+	}
+	return cfg
+}
+
+func openRepairDB(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, error) {
+	dsn := fmt.Sprintf(
+		"host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
+		cfg.Host,
+		cfg.Port,
+		cfg.Database,
+		cfg.User,
+		cfg.Password,
+		cfg.SSLMode,
+	)
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func cleanupRepairMetadata(t *testing.T, db *sql.DB, blockMetadataID int64, repairID *int64) {
+	t.Helper()
+	ctx := context.Background()
+	if repairID != nil && *repairID != 0 {
+		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_block DISABLE TRIGGER cscb_repair_block_delete_trigger`)
+		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_manifest DISABLE TRIGGER cscb_repair_manifest_delete_trigger`)
+		_, _ = db.ExecContext(ctx, `DELETE FROM cscb_repair_block WHERE repair_id = $1`, *repairID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM cscb_repair_manifest WHERE id = $1`, *repairID)
+		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_manifest ENABLE TRIGGER cscb_repair_manifest_delete_trigger`)
+		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_block ENABLE TRIGGER cscb_repair_block_delete_trigger`)
+	}
+	_, _ = db.ExecContext(ctx, `DELETE FROM block_consolidation_shadow WHERE block_metadata_id = $1`, blockMetadataID)
+	_, _ = db.ExecContext(ctx, `DELETE FROM canonical_blocks WHERE block_metadata_id = $1`, blockMetadataID)
+	_, _ = db.ExecContext(ctx, `DELETE FROM block_metadata WHERE id = $1`, blockMetadataID)
+}
+
+func cleanupRepairBucket(t *testing.T, client *awss3.Client, bucket string) {
+	t.Helper()
+	ctx := context.Background()
+	versions, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{Bucket: aws.String(bucket)})
+	if err == nil {
+		for _, version := range versions.Versions {
+			_, _ = client.DeleteObject(ctx, &awss3.DeleteObjectInput{Bucket: aws.String(bucket), Key: version.Key, VersionId: version.VersionId})
+		}
+		for _, marker := range versions.DeleteMarkers {
+			_, _ = client.DeleteObject(ctx, &awss3.DeleteObjectInput{Bucket: aws.String(bucket), Key: marker.Key, VersionId: marker.VersionId})
+		}
+	}
+	_, _ = client.DeleteBucket(ctx, &awss3.DeleteBucketInput{Bucket: aws.String(bucket)})
+}

--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -2,7 +2,9 @@ package cscbrepair_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"testing"
@@ -57,14 +59,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	cfg.AWS.Bucket = bucket
 	cfg.AWS.IsLocalStack = true
 	cfg.AWS.IsResetLocal = true
-	// Pin the Docker test credentials so shell-level environment overrides cannot
-	// silently redirect or skip this destructive lifecycle test.
-	cfg.AWS.Postgres.Host = "localhost"
-	cfg.AWS.Postgres.Port = 5433
-	cfg.AWS.Postgres.Database = "chainstorage_solana_mainnet"
-	cfg.AWS.Postgres.User = "cs_solana_mainnet_worker"
-	cfg.AWS.Postgres.Password = "worker_password"
-	cfg.AWS.Postgres.SSLMode = "require"
+	localStackEndpoint := configureRepairTestEnvironment(t, cfg.AWS.Postgres)
 	cfg.Chain.BlockStartHeight = height
 	cfg.AWS.Storage.Consolidation.Enabled = true
 	cfg.AWS.Storage.Consolidation.Mode = config.ConsolidationModeHistoricalBackfill
@@ -89,7 +84,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 		chains3.Module,
 		metastorage.Module,
 		blobstorage.Module,
-		fx.Replace(newRepairLocalStackConfig(ctx)),
+		fx.Replace(newRepairLocalStackConfig(ctx, localStackEndpoint)),
 		fx.Populate(&meta, &blob, &singleBlockUploader, &s3Session),
 	)
 	defer app.Close()
@@ -170,7 +165,8 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 
 	store := retirement.NewS3ObjectStore(rawS3)
 	repairer := cscbrepair.NewRepairer(cscbrepair.NewPostgresRepository(db), store, bucket)
-	manifest, err := repairer.PrepareNext(ctx, tag, height, height+1, 1, nil)
+	executionKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	manifest, err := repairer.PrepareNext(ctx, executionKey, tag, height, height+1, 1, nil)
 	require.NoError(err)
 	require.NotNil(manifest)
 	repairID = manifest.ID
@@ -178,6 +174,38 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Equal(dirtyKey, manifest.OldConsolidatedObjectKey)
 	require.Len(manifest.Blocks, 1)
 	require.Len(manifest.Blocks[0].PayloadSHA256, 64)
+
+	uploadGuard, err := meta.AcquireSingleBlockUploadGuard(ctx, tag, height, block.Metadata.Hash)
+	require.NoError(err)
+	require.True(uploadGuard.RetirementFenced(), "active repair must fence single-block uploads")
+	require.NoError(uploadGuard.Release())
+	_, err = db.ExecContext(ctx, `
+		UPDATE block_consolidation_shadow
+		SET single_block_delete_after = clock_timestamp() - INTERVAL '1 second'
+		WHERE block_metadata_id = $1`, blockMetadataID)
+	require.NoError(err)
+	err = retirement.NewPostgresRepository(db).PrepareRetirement(ctx, retirement.RetirementManifest{
+		BlockMetadataID:                blockMetadataID,
+		Tag:                            tag,
+		Height:                         height,
+		Hash:                           block.Metadata.Hash,
+		State:                          retirement.RetirementStateEligible,
+		Bucket:                         bucket,
+		SingleBlockObjectKey:           singleBlockKey,
+		SingleBlockObjectKeySHA256:     repairSHA256(singleBlockKey),
+		SingleBlockObjectVersionIDs:    []string{manifest.Blocks[0].SingleBlockObjectVersion.VersionID},
+		SingleBlockObjectETag:          manifest.Blocks[0].SingleBlockObjectVersion.ETag,
+		SingleBlockObjectBytes:         manifest.Blocks[0].SingleBlockObjectVersion.Bytes,
+		ConsolidatedObjectKey:          dirtyKey,
+		ConsolidatedObjectVersionID:    manifest.OldConsolidatedObjectVersion.VersionID,
+		ConsolidatedObjectETag:         manifest.OldConsolidatedObjectVersion.ETag,
+		ConsolidatedByteOffset:         manifest.Blocks[0].OldByteOffset,
+		ConsolidatedByteLength:         manifest.Blocks[0].OldByteLength,
+		ConsolidatedUncompressedLength: manifest.Blocks[0].OldUncompressedLength,
+		PayloadSHA256:                  manifest.Blocks[0].PayloadSHA256,
+		PreparedAt:                     time.Now().UTC(),
+	})
+	require.ErrorContains(err, "failed to lock canonical retirement metadata")
 
 	manifest, err = repairer.Restore(ctx, manifest.ID, nil)
 	require.NoError(err)
@@ -191,6 +219,26 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	restoredBlock, err := blob.Download(ctx, activeSingleBlock)
 	require.NoError(err)
 	require.True(proto.Equal(storageutils.CloneBlockWithoutStoragePlacement(block), storageutils.CloneBlockWithoutStoragePlacement(restoredBlock)))
+	_, err = db.ExecContext(ctx, `UPDATE block_metadata SET object_key_main = $2 WHERE id = $1`, blockMetadataID, dirtyKey)
+	require.ErrorContains(err, "cannot reference a pinned old CSCB object")
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO block_consolidation_shadow (
+			block_metadata_id, tag, height, hash, single_block_object_key_main,
+			consolidated_object_key_main, object_format, byte_offset, byte_length,
+			uncompressed_length, validated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, clock_timestamp())`,
+		blockMetadataID,
+		tag,
+		height,
+		block.Metadata.Hash,
+		singleBlockKey,
+		dirtyKey,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		manifest.Blocks[0].OldByteOffset,
+		manifest.Blocks[0].OldByteLength,
+		manifest.Blocks[0].OldUncompressedLength,
+	)
+	require.ErrorContains(err, "cannot reference a pinned old CSCB object")
 
 	records, err = meta.GetBlocksMissingConsolidationShadow(ctx, tag, height, height+1, 1)
 	require.NoError(err)
@@ -284,19 +332,53 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	resumed, err := repairer.DeleteOldObject(ctx, manifest.ID)
 	require.NoError(err)
 	require.Equal(cscbrepair.StateCompleted, resumed.State)
-	next, err := repairer.PrepareNext(ctx, tag, height, height+1, 1, nil)
+	retried, err := repairer.PrepareNext(ctx, executionKey, tag, height, height+1, 1, nil)
+	require.NoError(err)
+	require.Equal(manifest.ID, retried.ID)
+	require.Equal(cscbrepair.StateCompleted, retried.State)
+	noCandidateExecutionKey := "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
+	next, err := repairer.PrepareNext(
+		ctx,
+		noCandidateExecutionKey,
+		tag,
+		height,
+		height+1,
+		1,
+		nil,
+	)
+	require.NoError(err)
+	require.Nil(next)
+	next, err = repairer.PrepareNext(ctx, noCandidateExecutionKey, tag, height, height+1, 1, nil)
 	require.NoError(err)
 	require.Nil(next)
 }
 
-func newRepairLocalStackConfig(ctx context.Context) aws.Config {
+func configureRepairTestEnvironment(t *testing.T, postgres *config.PostgresConfig) string {
+	t.Helper()
+	switch postgres.Host {
+	case "localhost", "127.0.0.1", "::1":
+		postgres.Port = 5433
+		postgres.Database = "chainstorage_solana_mainnet"
+		postgres.User = "cs_solana_mainnet_worker"
+		postgres.Password = "worker_password"
+		postgres.SSLMode = "require"
+		return "http://localhost:4566"
+	case "postgres":
+		return "http://localstack:4566"
+	default:
+		t.Fatalf("refusing to run CSCB repair lifecycle test against PostgreSQL host %q", postgres.Host)
+		return ""
+	}
+}
+
+func newRepairLocalStackConfig(ctx context.Context, endpoint string) aws.Config {
 	cfg, err := awsconfig.LoadDefaultConfig(
 		ctx,
 		awsconfig.WithRegion("us-east-1"),
 		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
 		awsconfig.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(func(string, string, ...interface{}) (aws.Endpoint, error) {
-				return aws.Endpoint{URL: "http://localhost:4566", HostnameImmutable: true}, nil
+				return aws.Endpoint{URL: endpoint, HostnameImmutable: true}, nil
 			}),
 		),
 	)
@@ -304,6 +386,11 @@ func newRepairLocalStackConfig(ctx context.Context) aws.Config {
 		panic(fmt.Sprintf("failed to configure LocalStack: %v", err))
 	}
 	return cfg
+}
+
+func repairSHA256(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
 }
 
 func openRepairDB(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, error) {
@@ -331,12 +418,15 @@ func cleanupRepairMetadata(t *testing.T, db *sql.DB, blockMetadataID int64, repa
 	t.Helper()
 	ctx := context.Background()
 	if repairID != nil && *repairID != 0 {
+		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_execution DISABLE TRIGGER cscb_repair_execution_delete_trigger`)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_block DISABLE TRIGGER cscb_repair_block_delete_trigger`)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_manifest DISABLE TRIGGER cscb_repair_manifest_delete_trigger`)
+		_, _ = db.ExecContext(ctx, `DELETE FROM cscb_repair_execution WHERE repair_id = $1`, *repairID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM cscb_repair_block WHERE repair_id = $1`, *repairID)
 		_, _ = db.ExecContext(ctx, `DELETE FROM cscb_repair_manifest WHERE id = $1`, *repairID)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_manifest ENABLE TRIGGER cscb_repair_manifest_delete_trigger`)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_block ENABLE TRIGGER cscb_repair_block_delete_trigger`)
+		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_execution ENABLE TRIGGER cscb_repair_execution_delete_trigger`)
 	}
 	_, _ = db.ExecContext(ctx, `DELETE FROM block_consolidation_shadow WHERE block_metadata_id = $1`, blockMetadataID)
 	_, _ = db.ExecContext(ctx, `DELETE FROM canonical_blocks WHERE block_metadata_id = $1`, blockMetadataID)

--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,7 +166,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 
 	store := retirement.NewS3ObjectStore(rawS3)
 	repairer := cscbrepair.NewRepairer(cscbrepair.NewPostgresRepository(db), store, bucket)
-	executionKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	executionKey := repairSHA256(fmt.Sprintf("repair-main-%d", unique))
 	manifest, err := repairer.PrepareNext(ctx, executionKey, tag, height, height+1, 1, nil)
 	require.NoError(err)
 	require.NotNil(manifest)
@@ -175,10 +176,49 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Len(manifest.Blocks, 1)
 	require.Len(manifest.Blocks[0].PayloadSHA256, 64)
 
+	// The trigger must serialize any reference to the pinned key, even when a
+	// writer changes only object_format to a non-CSCB value. This closes the
+	// final-reference-check race independently of the writer's claimed format.
+	objectLockTx, err := db.BeginTx(ctx, nil)
+	require.NoError(err)
+	_, err = objectLockTx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 1))`, dirtyKey)
+	require.NoError(err)
+	blockedWrite := make(chan error, 1)
+	writeCtx, cancelWrite := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelWrite()
+	go func() {
+		_, writeErr := db.ExecContext(writeCtx, `
+			UPDATE block_metadata
+			SET object_format = $2
+			WHERE id = $1`, blockMetadataID, api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK)
+		blockedWrite <- writeErr
+	}()
+	select {
+	case writeErr := <-blockedWrite:
+		require.Failf("format-only old-key writer bypassed advisory lock", "error=%v", writeErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.NoError(objectLockTx.Commit())
+	require.ErrorContains(<-blockedWrite, "cannot reference a pinned old CSCB object")
+
 	uploadGuard, err := meta.AcquireSingleBlockUploadGuard(ctx, tag, height, block.Metadata.Hash)
 	require.NoError(err)
 	require.True(uploadGuard.RetirementFenced(), "active repair must fence single-block uploads")
 	require.NoError(uploadGuard.Release())
+	replayedSingleBlock := proto.Clone(block.Metadata).(*api.BlockMetadata)
+	replayedSingleBlock.ObjectKeyMain = singleBlockKey
+	replayedSingleBlock.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK
+	replayedSingleBlock.ByteOffset = 0
+	replayedSingleBlock.ByteLength = 0
+	replayedSingleBlock.UncompressedLength = 0
+	require.NoError(meta.PersistBlockMetas(ctx, false, []*api.BlockMetadata{replayedSingleBlock}, nil))
+	pinnedActive, err := meta.GetBlockByHeight(ctx, tag, height)
+	require.NoError(err)
+	require.Equal(dirtyKey, pinnedActive.ObjectKeyMain, "late metadata persistence must not strand a prepared repair")
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, pinnedActive.ObjectFormat)
+	require.Equal(manifest.Blocks[0].OldByteOffset, pinnedActive.ByteOffset)
+	require.Equal(manifest.Blocks[0].OldByteLength, pinnedActive.ByteLength)
+	require.Equal(manifest.Blocks[0].OldUncompressedLength, pinnedActive.UncompressedLength)
 	_, err = db.ExecContext(ctx, `
 		UPDATE block_consolidation_shadow
 		SET single_block_delete_after = clock_timestamp() - INTERVAL '1 second'
@@ -287,15 +327,17 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.NotZero(manifest.NewConsolidatedObjectVersion.Bytes)
 	require.NotNil(manifest.VerifiedAt)
 
-	manifest, err = repairer.DeleteOldObject(ctx, manifest.ID)
+	manifest, err = repairer.Complete(ctx, manifest.ID, nil)
 	require.NoError(err)
 	require.Equal(cscbrepair.StateCompleted, manifest.State)
-	require.NotNil(manifest.OldObjectDeletedAt)
 	require.NotNil(manifest.CompletedAt)
+	require.Equal("old_consolidated_object_retained_unreferenced", manifest.Outcome)
+	requireOldCSCBUnreferenced(t, db, dirtyKey)
 	dirtyTopology, err := store.ListObjectVersions(ctx, bucket, dirtyKey)
 	require.NoError(err)
-	require.Empty(dirtyTopology.Versions)
+	require.Len(dirtyTopology.Versions, 1)
 	require.Empty(dirtyTopology.DeleteMarkers)
+	require.Equal(manifest.OldConsolidatedObjectVersion.VersionID, dirtyTopology.Versions[0].VersionID)
 	cleanTopology, err := store.ListObjectVersions(ctx, bucket, cleanKey)
 	require.NoError(err)
 	require.Len(cleanTopology.Versions, 1)
@@ -329,28 +371,344 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 		storageutils.CloneBlockWithoutStoragePlacement(readClean),
 	))
 
-	resumed, err := repairer.DeleteOldObject(ctx, manifest.ID)
+	resumed, err := repairer.Complete(ctx, manifest.ID, nil)
 	require.NoError(err)
 	require.Equal(cscbrepair.StateCompleted, resumed.State)
 	retried, err := repairer.PrepareNext(ctx, executionKey, tag, height, height+1, 1, nil)
 	require.NoError(err)
 	require.Equal(manifest.ID, retried.ID)
 	require.Equal(cscbrepair.StateCompleted, retried.State)
-	noCandidateExecutionKey := "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
-	next, err := repairer.PrepareNext(
-		ctx,
-		noCandidateExecutionKey,
+
+	// Exercise the real retirement executor after repair completion. The S3
+	// object deletion, shadow cleanup, retirement manifest, and repair audit
+	// path scrub must commit as one recoverable lifecycle.
+	_, err = db.ExecContext(ctx, `
+		UPDATE block_consolidation_shadow
+		SET single_block_retention_started_at = clock_timestamp() - INTERVAL '96 hours',
+			single_block_delete_after = clock_timestamp() - INTERVAL '24 hours'
+		WHERE block_metadata_id = $1`, blockMetadataID)
+	require.NoError(err)
+	policy := repairRetentionSafeBucketPolicy(bucket)
+	_, err = rawS3.PutBucketPolicy(ctx, &awss3.PutBucketPolicyInput{Bucket: aws.String(bucket), Policy: aws.String(policy)})
+	require.NoError(err)
+	retirementPlanner := retirement.NewPlanner(retirement.NewPostgresRepository(db), store)
+	retirementRequest := retirement.PlanRequest{
+		Environment:               "local",
+		Blockchain:                "solana",
+		Network:                   "mainnet",
+		Bucket:                    bucket,
+		Tag:                       tag,
+		StartHeight:               height,
+		EndHeight:                 height + 1,
+		Limit:                     1,
+		Now:                       time.Now().UTC(),
+		Execute:                   true,
+		ClientMigrationApproved:   true,
+		SingleBlockWritersGuarded: true,
+		Approval: retirement.Approval{
+			Chain:       "solana-mainnet",
+			StartHeight: height,
+			EndHeight:   height + 1,
+		},
+	}
+	retirementReport, err := retirementPlanner.Plan(ctx, retirementRequest)
+	require.NoError(err)
+	require.Len(retirementReport.Items, 1)
+	require.Equal(retirement.ActionDeleteObjectVersion, retirementReport.Items[0].Action)
+	require.Empty(retirementReport.Items[0].SkipReason)
+	safety, err := store.InspectObjectRetentionSafety(ctx, bucket, cleanKey)
+	require.NoError(err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO cscb_retirement_safety_observation (
+			bucket, consolidated_object_key_main, configuration_sha256,
+			first_observed_at, last_observed_at
+		) VALUES ($1, $2, $3, clock_timestamp() - INTERVAL '16 minutes', clock_timestamp() - INTERVAL '16 minutes')
+		ON CONFLICT (bucket, consolidated_object_key_main) DO UPDATE SET
+			configuration_sha256 = EXCLUDED.configuration_sha256,
+			first_observed_at = EXCLUDED.first_observed_at,
+			last_observed_at = EXCLUDED.last_observed_at`, bucket, cleanKey, safety.ConfigurationSHA256)
+	require.NoError(err)
+	require.NoError(retirementPlanner.Apply(ctx, retirementRequest, retirementReport))
+	require.Equal(retirement.ActionDeletedVerified, retirementReport.Items[0].Action)
+
+	retiredSingleTopology, err := store.ListObjectVersions(ctx, bucket, singleBlockKey)
+	require.NoError(err)
+	require.Empty(retiredSingleTopology.Versions)
+	require.Empty(retiredSingleTopology.DeleteMarkers)
+	var repairSinglePath sql.NullString
+	var repairSinglePathHash string
+	require.NoError(db.QueryRowContext(ctx, `
+		SELECT single_block_object_key_main, single_block_object_key_sha256
+		FROM cscb_repair_block
+		WHERE repair_id = $1 AND block_metadata_id = $2`, manifest.ID, blockMetadataID).Scan(
+		&repairSinglePath,
+		&repairSinglePathHash,
+	))
+	require.False(repairSinglePath.Valid)
+	require.Equal(repairSHA256(singleBlockKey), repairSinglePathHash)
+	activeAfterRetirement, err := meta.GetBlockByHeight(ctx, tag, height)
+	require.NoError(err)
+	require.Equal(cleanKey, activeAfterRetirement.ObjectKeyMain)
+	readAfterRetirement, err := blob.Download(ctx, activeAfterRetirement)
+	require.NoError(err)
+	require.True(proto.Equal(
+		storageutils.CloneBlockWithoutStoragePlacement(block),
+		storageutils.CloneBlockWithoutStoragePlacement(readAfterRetirement),
+	))
+
+	// A CSCB whose rows all became non-canonical must still be restored and
+	// audited. It does not produce a replacement CSCB because normal
+	// consolidation intentionally processes canonical rows only.
+	nonCanonicalHeight := height + 1
+	nonCanonicalBlock := proto.Clone(block).(*api.Block)
+	nonCanonicalBlock.Metadata = proto.Clone(block.Metadata).(*api.BlockMetadata)
+	nonCanonicalBlock.Metadata.Height = nonCanonicalHeight
+	nonCanonicalBlock.Metadata.ParentHeight = height
+	nonCanonicalBlock.Metadata.Hash = fmt.Sprintf("repair-noncanonical-hash-%d", unique)
+	nonCanonicalBlock.Metadata.ParentHash = block.Metadata.Hash
+	nonCanonicalSingleKey, err := singleBlockUploader.Upload(ctx, nonCanonicalBlock, api.Compression_GZIP)
+	require.NoError(err)
+	nonCanonicalBlock.Metadata.ObjectKeyMain = nonCanonicalSingleKey
+	require.NoError(meta.PersistBlockMetas(ctx, true, []*api.BlockMetadata{nonCanonicalBlock.Metadata}, nil))
+	nonCanonicalRecords, err := meta.GetBlocksMissingConsolidationShadow(ctx, tag, nonCanonicalHeight, nonCanonicalHeight+1, 1)
+	require.NoError(err)
+	require.Len(nonCanonicalRecords, 1)
+	nonCanonicalMetadataID := nonCanonicalRecords[0].ID
+	var nonCanonicalRepairID int64
+	defer cleanupRepairMetadata(t, db, nonCanonicalMetadataID, &nonCanonicalRepairID)
+
+	nonCanonicalDownloaded, err := blob.Download(ctx, nonCanonicalRecords[0].Metadata)
+	require.NoError(err)
+	nonCanonicalDirty := proto.Clone(nonCanonicalDownloaded).(*api.Block)
+	nonCanonicalDirty.Metadata.ObjectKeyMain = nonCanonicalSingleKey
+	nonCanonicalDirty.Metadata.ObjectFormat = api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK
+	nonCanonicalPayload, err := proto.Marshal(nonCanonicalDirty)
+	require.NoError(err)
+	nonCanonicalDirtyKey, nonCanonicalPlacements, err := blob.UploadConsolidated(ctx, []blobstorage.ConsolidatedBlockPayload{{
+		Metadata:           nonCanonicalRecords[0].Metadata,
+		MetadataID:         nonCanonicalMetadataID,
+		RawBlockPayload:    blobstorage.BytesPayloadSource(nonCanonicalPayload),
+		UncompressedLength: uint64(len(nonCanonicalPayload)),
+	}})
+	require.NoError(err)
+	require.Len(nonCanonicalPlacements, 1)
+	nonCanonicalPlacement := nonCanonicalPlacements[0]
+	require.NoError(meta.PersistBlockConsolidationShadows(ctx, []*metastorage.ConsolidationShadowPlacement{{
+		BlockMetadataID:           nonCanonicalMetadataID,
+		Tag:                       tag,
+		Height:                    nonCanonicalHeight,
+		Hash:                      nonCanonicalBlock.Metadata.Hash,
+		SingleBlockObjectKeyMain:  nonCanonicalSingleKey,
+		ConsolidatedObjectKeyMain: nonCanonicalDirtyKey,
+		ObjectFormat:              nonCanonicalPlacement.ObjectFormat,
+		ByteOffset:                nonCanonicalPlacement.ByteOffset,
+		ByteLength:                nonCanonicalPlacement.ByteLength,
+		UncompressedLength:        nonCanonicalPlacement.UncompressedLength,
+	}}))
+	promotion, err = meta.PromoteBlockConsolidationShadows(ctx, tag, nonCanonicalHeight, nonCanonicalHeight+1, 1, 72*time.Hour)
+	require.NoError(err)
+	require.Equal(uint64(1), promotion.Blocks)
+	replacementBlock := proto.Clone(nonCanonicalBlock).(*api.Block)
+	replacementBlock.Metadata = proto.Clone(nonCanonicalBlock.Metadata).(*api.BlockMetadata)
+	replacementBlock.Metadata.Hash = fmt.Sprintf("repair-replacement-hash-%d", unique)
+	replacementBlock.Metadata.ParentHash = block.Metadata.Hash
+	replacementSingleKey, err := singleBlockUploader.Upload(ctx, replacementBlock, api.Compression_GZIP)
+	require.NoError(err)
+	replacementBlock.Metadata.ObjectKeyMain = replacementSingleKey
+	require.NoError(meta.PersistBlockMetas(ctx, true, []*api.BlockMetadata{replacementBlock.Metadata}, nil))
+	var replacementMetadataID int64
+	err = db.QueryRowContext(ctx, `
+		SELECT id FROM block_metadata
+		WHERE tag = $1 AND height = $2 AND hash = $3 AND skipped = FALSE`,
 		tag,
-		height,
-		height+1,
+		nonCanonicalHeight,
+		replacementBlock.Metadata.Hash,
+	).Scan(&replacementMetadataID)
+	require.NoError(err)
+	defer cleanupRepairMetadata(t, db, replacementMetadataID, nil)
+
+	nonCanonicalExecutionKey := repairSHA256(fmt.Sprintf("repair-noncanonical-%d", unique))
+	nonCanonicalManifest, err := repairer.PrepareNext(
+		ctx,
+		nonCanonicalExecutionKey,
+		tag,
+		nonCanonicalHeight,
+		nonCanonicalHeight+1,
 		1,
 		nil,
 	)
 	require.NoError(err)
-	require.Nil(next)
-	next, err = repairer.PrepareNext(ctx, noCandidateExecutionKey, tag, height, height+1, 1, nil)
+	require.NotNil(nonCanonicalManifest)
+	nonCanonicalRepairID = nonCanonicalManifest.ID
+	require.Zero(nonCanonicalManifest.CanonicalBlockCount)
+	require.Equal(uint64(1), nonCanonicalManifest.TotalBlockCount)
+	nonCanonicalManifest, err = repairer.Restore(ctx, nonCanonicalManifest.ID, nil)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateRestored, nonCanonicalManifest.State)
+	activeNonCanonical, err := meta.GetBlockByHash(ctx, tag, nonCanonicalHeight, nonCanonicalBlock.Metadata.Hash)
+	require.NoError(err)
+	require.Equal(nonCanonicalSingleKey, activeNonCanonical.ObjectKeyMain)
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK, activeNonCanonical.ObjectFormat)
+	readNonCanonical, err := blob.Download(ctx, activeNonCanonical)
+	require.NoError(err)
+	require.True(proto.Equal(
+		storageutils.CloneBlockWithoutStoragePlacement(nonCanonicalBlock),
+		storageutils.CloneBlockWithoutStoragePlacement(readNonCanonical),
+	))
+	nonCanonicalManifest, err = repairer.Complete(ctx, nonCanonicalManifest.ID, nil)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateCompleted, nonCanonicalManifest.State)
+	require.Empty(nonCanonicalManifest.NewConsolidatedObjectKey)
+	requireOldCSCBUnreferenced(t, db, nonCanonicalDirtyKey)
+	nonCanonicalDirtyTopology, err := store.ListObjectVersions(ctx, bucket, nonCanonicalDirtyKey)
+	require.NoError(err)
+	require.Len(nonCanonicalDirtyTopology.Versions, 1)
+	require.Empty(nonCanonicalDirtyTopology.DeleteMarkers)
+
+	shadowOnlyKey := fmt.Sprintf("BLOCKCHAIN_SOLANA/NETWORK_SOLANA_MAINNET/consolidated/v=2/shadow-only-%d.cscb.zstd", unique)
+	tagLockTx, err := db.BeginTx(ctx, nil)
+	require.NoError(err)
+	_, err = tagLockTx.ExecContext(
+		ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 2))`,
+		fmt.Sprintf("cscb_repair_tag/%d", tag),
+	)
+	require.NoError(err)
+	shadowWrite := make(chan error, 1)
+	go func() {
+		shadowWrite <- meta.PersistBlockConsolidationShadows(ctx, []*metastorage.ConsolidationShadowPlacement{{
+			BlockMetadataID:           nonCanonicalMetadataID,
+			Tag:                       tag,
+			Height:                    nonCanonicalHeight,
+			Hash:                      nonCanonicalBlock.Metadata.Hash,
+			SingleBlockObjectKeyMain:  nonCanonicalSingleKey,
+			ConsolidatedObjectKeyMain: shadowOnlyKey,
+			ObjectFormat:              api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			ByteOffset:                nonCanonicalPlacement.ByteOffset,
+			ByteLength:                nonCanonicalPlacement.ByteLength,
+			UncompressedLength:        nonCanonicalPlacement.UncompressedLength,
+		}})
+	}()
+	select {
+	case writeErr := <-shadowWrite:
+		require.Failf("consolidated shadow writer bypassed repair tag lock", "error=%v", writeErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.NoError(tagLockTx.Commit())
+	require.NoError(<-shadowWrite)
+	shadowOnlyExecutionKey := repairSHA256(fmt.Sprintf("repair-shadow-only-%d", unique))
+	_, err = repairer.PrepareNext(
+		ctx,
+		shadowOnlyExecutionKey,
+		tag,
+		nonCanonicalHeight,
+		nonCanonicalHeight+1,
+		1,
+		nil,
+	)
+	require.ErrorContains(err, "shadow-only consolidated object")
+	_, err = db.ExecContext(ctx, `DELETE FROM block_consolidation_shadow WHERE block_metadata_id = $1`, nonCanonicalMetadataID)
+	require.NoError(err)
+
+	// Application writers acquire the tag lock before touching metadata rows.
+	// Holding the tag lock must block persistence while leaving the row lock free.
+	tagLockTx, err = db.BeginTx(ctx, nil)
+	require.NoError(err)
+	_, err = tagLockTx.ExecContext(
+		ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 2))`,
+		fmt.Sprintf("cscb_repair_tag/%d", tag),
+	)
+	require.NoError(err)
+	metadataWrite := make(chan error, 1)
+	go func() {
+		metadataWrite <- meta.PersistBlockMetas(ctx, false, []*api.BlockMetadata{proto.Clone(activeClean).(*api.BlockMetadata)}, nil)
+	}()
+	select {
+	case writeErr := <-metadataWrite:
+		require.Failf("metadata writer bypassed repair tag lock", "error=%v", writeErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	var lockedMetadataID int64
+	require.NoError(tagLockTx.QueryRowContext(
+		ctx,
+		`SELECT id FROM block_metadata WHERE id = $1 FOR UPDATE NOWAIT`,
+		blockMetadataID,
+	).Scan(&lockedMetadataID))
+	require.Equal(blockMetadataID, lockedMetadataID)
+	require.NoError(tagLockTx.Commit())
+	require.NoError(<-metadataWrite)
+
+	noCandidateExecutionKey := repairSHA256(fmt.Sprintf("repair-no-candidate-%d", unique))
+	defer cleanupRepairExecution(t, db, noCandidateExecutionKey)
+	tagLockTx, err = db.BeginTx(ctx, nil)
+	require.NoError(err)
+	_, err = tagLockTx.ExecContext(
+		ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 2))`,
+		fmt.Sprintf("cscb_repair_tag/%d", tag),
+	)
+	require.NoError(err)
+	type candidateResult struct {
+		manifest *cscbrepair.Manifest
+		err      error
+	}
+	noCandidateResult := make(chan candidateResult, 1)
+	go func() {
+		next, prepareErr := repairer.PrepareNext(
+			ctx,
+			noCandidateExecutionKey,
+			tag,
+			height,
+			height+1,
+			1,
+			nil,
+		)
+		noCandidateResult <- candidateResult{manifest: next, err: prepareErr}
+	}()
+	select {
+	case result := <-noCandidateResult:
+		require.Failf("terminal no-candidate binding bypassed repair tag lock", "manifest=%v error=%v", result.manifest, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.NoError(tagLockTx.Commit())
+	result := <-noCandidateResult
+	require.NoError(result.err)
+	require.Nil(result.manifest)
+	next, err := repairer.PrepareNext(ctx, noCandidateExecutionKey, tag, height, height+1, 1, nil)
 	require.NoError(err)
 	require.Nil(next)
+
+	// Pinned-key fencing is based on exact manifest identity, not a path naming
+	// convention or a caller-supplied CSCB format value.
+	nonstandardOldKey := fmt.Sprintf("custom-layout/dirty-object-%d", unique)
+	var nonstandardRepairID int64
+	err = db.QueryRowContext(ctx, `
+		INSERT INTO cscb_repair_manifest (
+			tag, state, bucket, old_consolidated_object_key_main,
+			old_consolidated_object_version_id, old_consolidated_object_etag,
+			old_consolidated_object_bytes, start_height, end_height,
+			canonical_block_count, total_block_count, row_set_sha256
+		) VALUES ($1, 'prepared', $2, $3, 'version', 'etag', 1, $4, $5, 0, 0, $6)
+		RETURNING id`,
+		tag,
+		bucket,
+		nonstandardOldKey,
+		height,
+		height+1,
+		strings.Repeat("0", 64),
+	).Scan(&nonstandardRepairID)
+	require.NoError(err)
+	defer cleanupRepairMetadata(t, db, 0, &nonstandardRepairID)
+	_, err = db.ExecContext(ctx, `
+		UPDATE block_metadata
+		SET object_key_main = $2, object_format = $3
+		WHERE id = $1`,
+		replacementMetadataID,
+		nonstandardOldKey,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK,
+	)
+	require.ErrorContains(err, "cannot reference a pinned old CSCB object")
 }
 
 func configureRepairTestEnvironment(t *testing.T, postgres *config.PostgresConfig) string {
@@ -393,6 +751,31 @@ func repairSHA256(value string) string {
 	return hex.EncodeToString(digest[:])
 }
 
+func repairRetentionSafeBucketPolicy(bucket string) string {
+	return fmt.Sprintf(`{
+		"Version":"2012-10-17",
+		"Statement":[
+			{"Effect":"Deny","Principal":"*","Action":"s3:PutObject","Resource":"arn:aws:s3:::%[1]s/*/consolidated/*","Condition":{"Null":{"s3:if-none-match":"true"}}},
+			{"Effect":"Deny","Principal":"*","Action":["s3:DeleteObject","s3:DeleteObjectVersion","s3:ReplicateObject","s3:ReplicateDelete"],"Resource":"arn:aws:s3:::%[1]s/*/consolidated/*"},
+			{"Effect":"Deny","Principal":"*","Action":"s3:PutLifecycleConfiguration","Resource":"arn:aws:s3:::%[1]s"}
+		]
+	}`, bucket)
+}
+
+func requireOldCSCBUnreferenced(t *testing.T, db *sql.DB, objectKey string) {
+	t.Helper()
+	var references uint64
+	err := db.QueryRowContext(context.Background(), `
+		SELECT
+			(SELECT COUNT(*) FROM block_metadata WHERE object_key_main = $1)
+			+
+			(SELECT COUNT(*) FROM block_consolidation_shadow WHERE consolidated_object_key_main = $1)`,
+		objectKey,
+	).Scan(&references)
+	require.NoError(t, err)
+	require.Zero(t, references)
+}
+
 func openRepairDB(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
@@ -418,6 +801,7 @@ func cleanupRepairMetadata(t *testing.T, db *sql.DB, blockMetadataID int64, repa
 	t.Helper()
 	ctx := context.Background()
 	if repairID != nil && *repairID != 0 {
+		_, _ = db.ExecContext(ctx, `DELETE FROM cscb_retirement_safety_observation WHERE bucket = (SELECT bucket FROM cscb_repair_manifest WHERE id = $1)`, *repairID)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_execution DISABLE TRIGGER cscb_repair_execution_delete_trigger`)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_block DISABLE TRIGGER cscb_repair_block_delete_trigger`)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_manifest DISABLE TRIGGER cscb_repair_manifest_delete_trigger`)
@@ -428,14 +812,26 @@ func cleanupRepairMetadata(t *testing.T, db *sql.DB, blockMetadataID int64, repa
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_block ENABLE TRIGGER cscb_repair_block_delete_trigger`)
 		_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_execution ENABLE TRIGGER cscb_repair_execution_delete_trigger`)
 	}
+	_, _ = db.ExecContext(ctx, `ALTER TABLE block_single_block_retention DISABLE TRIGGER block_single_block_retention_delete_trigger`)
+	_, _ = db.ExecContext(ctx, `DELETE FROM block_single_block_retention WHERE block_metadata_id = $1`, blockMetadataID)
+	_, _ = db.ExecContext(ctx, `ALTER TABLE block_single_block_retention ENABLE TRIGGER block_single_block_retention_delete_trigger`)
 	_, _ = db.ExecContext(ctx, `DELETE FROM block_consolidation_shadow WHERE block_metadata_id = $1`, blockMetadataID)
 	_, _ = db.ExecContext(ctx, `DELETE FROM canonical_blocks WHERE block_metadata_id = $1`, blockMetadataID)
 	_, _ = db.ExecContext(ctx, `DELETE FROM block_metadata WHERE id = $1`, blockMetadataID)
 }
 
+func cleanupRepairExecution(t *testing.T, db *sql.DB, executionKey string) {
+	t.Helper()
+	ctx := context.Background()
+	_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_execution DISABLE TRIGGER cscb_repair_execution_delete_trigger`)
+	_, _ = db.ExecContext(ctx, `DELETE FROM cscb_repair_execution WHERE execution_key = $1`, executionKey)
+	_, _ = db.ExecContext(ctx, `ALTER TABLE cscb_repair_execution ENABLE TRIGGER cscb_repair_execution_delete_trigger`)
+}
+
 func cleanupRepairBucket(t *testing.T, client *awss3.Client, bucket string) {
 	t.Helper()
 	ctx := context.Background()
+	_, _ = client.DeleteBucketPolicy(ctx, &awss3.DeleteBucketPolicyInput{Bucket: aws.String(bucket)})
 	versions, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{Bucket: aws.String(bucket)})
 	if err == nil {
 		for _, version := range versions.Versions {

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -43,6 +43,36 @@ func NewPostgresRepository(db *sql.DB) *PostgresRepository {
 	return &PostgresRepository{db: db}
 }
 
+func (r *PostgresRepository) FindByExecutionKey(
+	ctx context.Context,
+	executionKey string,
+) (*Manifest, bool, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, false, err
+	}
+	if !validExecutionKey(executionKey) {
+		return nil, false, xerrors.New("valid CSCB repair execution key is required")
+	}
+	var repairID sql.NullInt64
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT repair_id
+		FROM cscb_repair_execution
+		WHERE execution_key = $1`, executionKey).Scan(&repairID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, false, nil
+		}
+		return nil, false, xerrors.Errorf("failed to find CSCB repair execution binding: %w", err)
+	}
+	if !repairID.Valid {
+		return nil, true, nil
+	}
+	manifest, err := loadManifest(ctx, r.db, repairID.Int64, false)
+	if err != nil {
+		return nil, false, err
+	}
+	return manifest, true, nil
+}
+
 func (r *PostgresRepository) FindPending(
 	ctx context.Context,
 	tag uint32,
@@ -144,6 +174,9 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 	if err := lockCandidateRows(ctx, tx, manifest.Blocks); err != nil {
 		return nil, err
 	}
+	if err := lockConsolidatedObjectKey(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
 	current, err := loadCandidateByKey(ctx, tx, manifest.Tag, manifest.OldConsolidatedObjectKey)
 	if err != nil {
 		return nil, err
@@ -234,6 +267,104 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 		return nil, xerrors.Errorf("failed to commit CSCB repair preparation: %w", err)
 	}
 	return prepared, nil
+}
+
+func (r *PostgresRepository) BindExecutionKey(
+	ctx context.Context,
+	executionKey string,
+	repairID int64,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if !validExecutionKey(executionKey) || repairID <= 0 {
+		return nil, xerrors.New("valid CSCB repair execution binding is required")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin CSCB repair execution binding: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const insert = `
+		INSERT INTO cscb_repair_execution (execution_key, repair_id)
+		VALUES ($1, $2)
+		ON CONFLICT (execution_key) DO NOTHING`
+	if _, err := tx.ExecContext(ctx, insert, executionKey, repairID); err != nil {
+		return nil, xerrors.Errorf("failed to bind CSCB repair execution: %w", err)
+	}
+	var boundRepairID sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT repair_id
+		FROM cscb_repair_execution
+		WHERE execution_key = $1
+		FOR UPDATE`, executionKey).Scan(&boundRepairID); err != nil {
+		return nil, xerrors.Errorf("failed to load CSCB repair execution binding: %w", err)
+	}
+	if !boundRepairID.Valid {
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to commit CSCB repair no-candidate execution binding: %w", err)
+		}
+		return nil, nil
+	}
+	if boundRepairID.Int64 != repairID {
+		return nil, xerrors.Errorf(
+			"CSCB repair execution key is already bound to repair id %d, requested %d",
+			boundRepairID.Int64,
+			repairID,
+		)
+	}
+	manifest, err := loadManifest(ctx, tx, boundRepairID.Int64, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair execution binding: %w", err)
+	}
+	return manifest, nil
+}
+
+func (r *PostgresRepository) BindNoCandidateExecution(
+	ctx context.Context,
+	executionKey string,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if !validExecutionKey(executionKey) {
+		return nil, xerrors.New("valid CSCB repair execution key is required")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin CSCB repair no-candidate execution binding: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO cscb_repair_execution (execution_key, repair_id)
+		VALUES ($1, NULL)
+		ON CONFLICT (execution_key) DO NOTHING`, executionKey); err != nil {
+		return nil, xerrors.Errorf("failed to bind CSCB repair no-candidate execution: %w", err)
+	}
+	var boundRepairID sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT repair_id
+		FROM cscb_repair_execution
+		WHERE execution_key = $1
+		FOR UPDATE`, executionKey).Scan(&boundRepairID); err != nil {
+		return nil, xerrors.Errorf("failed to load CSCB repair no-candidate execution binding: %w", err)
+	}
+	var manifest *Manifest
+	if boundRepairID.Valid {
+		manifest, err = loadManifest(ctx, tx, boundRepairID.Int64, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair no-candidate execution binding: %w", err)
+	}
+	return manifest, nil
 }
 
 func (r *PostgresRepository) Get(ctx context.Context, repairID int64) (*Manifest, error) {
@@ -464,7 +595,10 @@ func (r *PostgresRepository) RecordVerified(
 	if manifest.State != StateRestored {
 		return nil, xerrors.Errorf("CSCB repair must be restored before verification: id=%d state=%s", manifest.ID, manifest.State)
 	}
-	if err := lockRebuiltRows(ctx, tx, manifest.Blocks); err != nil {
+	if err := lockRepairRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	if err := lockConsolidatedObjectKey(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
 		return nil, err
 	}
 	if err := loadRebuiltBlocks(ctx, tx, manifest); err != nil {
@@ -514,12 +648,17 @@ func (r *PostgresRepository) RecordVerified(
 	return verified, nil
 }
 
-func (r *PostgresRepository) Complete(ctx context.Context, repairID int64, outcome string) (*Manifest, error) {
+func (r *PostgresRepository) CompleteWithOldObjectDeletion(
+	ctx context.Context,
+	repairID int64,
+	outcome string,
+	deleteObject DeleteOldObject,
+) (*Manifest, error) {
 	if err := r.validateDB(); err != nil {
 		return nil, err
 	}
-	if outcome == "" {
-		return nil, xerrors.New("CSCB repair completion outcome is required")
+	if outcome == "" || deleteObject == nil {
+		return nil, xerrors.New("CSCB repair completion outcome and old-object deletion are required")
 	}
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -539,7 +678,16 @@ func (r *PostgresRepository) Complete(ctx context.Context, repairID int64, outco
 	if manifest.State != StateVerified {
 		return nil, xerrors.Errorf("CSCB repair must be verified before completion: id=%d state=%s", manifest.ID, manifest.State)
 	}
+	if err := lockRepairRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	if err := lockConsolidatedObjectKey(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
 	if err := requireNoOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
+	if err := deleteObject(manifest); err != nil {
 		return nil, err
 	}
 	const update = `
@@ -908,9 +1056,39 @@ func lockCandidateRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
 	return nil
 }
 
-func lockRebuiltRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
-	ids := make([]int64, 0, len(blocks))
-	for _, block := range blocks {
+func lockConsolidatedObjectKey(ctx context.Context, tx *sql.Tx, objectKey string) error {
+	if objectKey == "" {
+		return xerrors.New("consolidated object key is required for CSCB repair lock")
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 1))`,
+		objectKey,
+	); err != nil {
+		return xerrors.Errorf("failed to acquire CSCB repair object lock: %w", err)
+	}
+	return nil
+}
+
+func lockRepairRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
+	ordered := append([]Block(nil), blocks...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Tag != ordered[j].Tag {
+			return ordered[i].Tag < ordered[j].Tag
+		}
+		if ordered[i].Height != ordered[j].Height {
+			return ordered[i].Height < ordered[j].Height
+		}
+		if ordered[i].Hash != ordered[j].Hash {
+			return ordered[i].Hash < ordered[j].Hash
+		}
+		return ordered[i].BlockMetadataID < ordered[j].BlockMetadataID
+	})
+	ids := make([]int64, 0, len(ordered))
+	for _, block := range ordered {
+		if err := retirementlock.Acquire(ctx, tx, block.Tag, block.Height, block.Hash); err != nil {
+			return err
+		}
 		ids = append(ids, block.BlockMetadataID)
 	}
 	rows, err := tx.QueryContext(ctx, `

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lib/pq"
 	"golang.org/x/xerrors"
 
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepairlock"
 	"github.com/coinbase/chainstorage/internal/storage/retirementlock"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
@@ -22,7 +23,7 @@ const manifestColumns = `
 	new_consolidated_object_key_main, new_consolidated_object_version_id,
 	new_consolidated_object_etag, new_consolidated_object_bytes,
 	outcome, prepared_at, restored_at, verified_at,
-	old_object_deleted_at, completed_at`
+	completed_at`
 
 type (
 	PostgresRepository struct {
@@ -112,44 +113,15 @@ func (r *PostgresRepository) FindNextCandidate(
 	if endHeight <= startHeight {
 		return nil, nil
 	}
-	const keyQuery = `
-		SELECT bm.object_key_main
-		FROM canonical_blocks cb
-		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
-			AND bm.tag = cb.tag
-			AND bm.height = cb.height
-		WHERE cb.tag = $1
-			AND cb.height >= $2
-			AND cb.height < $3
-			AND bm.skipped = FALSE
-			AND bm.object_format = $4
-			AND bm.object_key_main IS NOT NULL
-			AND bm.object_key_main <> ''
-			AND NOT EXISTS (
-				SELECT 1
-				FROM cscb_repair_manifest repair
-				WHERE repair.tag = bm.tag
-					AND (
-						repair.old_consolidated_object_key_main = bm.object_key_main
-						OR repair.new_consolidated_object_key_main = bm.object_key_main
-					)
-			)
-		GROUP BY bm.object_key_main
-		ORDER BY MAX(cb.height) DESC, bm.object_key_main DESC
-		LIMIT 1`
-	var objectKey string
-	if err := r.db.QueryRowContext(
-		ctx,
-		keyQuery,
-		tag,
-		startHeight,
-		endHeight,
-		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-	).Scan(&objectKey); err != nil {
-		if err == sql.ErrNoRows {
-			return nil, nil
+	objectKey, err := findNextCandidateObject(ctx, r.db, tag, startHeight, endHeight)
+	if err != nil {
+		return nil, err
+	}
+	if objectKey == "" {
+		if err := requireNoShadowOnlyCandidates(ctx, r.db, tag, startHeight, endHeight); err != nil {
+			return nil, err
 		}
-		return nil, xerrors.Errorf("failed to find next active CSCB repair candidate: %w", err)
+		return nil, nil
 	}
 	manifest, err := loadCandidateByKey(ctx, r.db, tag, objectKey)
 	if err != nil {
@@ -158,19 +130,147 @@ func (r *PostgresRepository) FindNextCandidate(
 	return manifest, nil
 }
 
-func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*Manifest, error) {
+func findNextCandidateObject(
+	ctx context.Context,
+	q queryer,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+) (string, error) {
+	if endHeight <= startHeight {
+		return "", nil
+	}
+	const query = `
+		WITH overlapping_keys AS (
+			SELECT DISTINCT bm.object_key_main
+			FROM block_metadata bm
+			WHERE bm.tag = $1
+				AND bm.height >= $2
+				AND bm.height < $3
+				AND bm.object_format = $4
+				AND bm.object_key_main IS NOT NULL
+				AND bm.object_key_main <> ''
+				AND NOT EXISTS (
+					SELECT 1
+					FROM cscb_repair_manifest repair
+					WHERE repair.tag = bm.tag
+						AND (
+							repair.old_consolidated_object_key_main = bm.object_key_main
+							OR repair.new_consolidated_object_key_main = bm.object_key_main
+						)
+				)
+		)
+		SELECT bm.object_key_main, MIN(bm.height), MAX(bm.height)
+		FROM block_metadata bm
+		JOIN overlapping_keys candidate ON candidate.object_key_main = bm.object_key_main
+		WHERE bm.tag = $1
+			AND bm.object_format = $4
+		GROUP BY bm.object_key_main
+		ORDER BY MAX(bm.height) DESC, bm.object_key_main DESC
+		LIMIT 1`
+	var objectKey string
+	var minHeight, maxHeight uint64
+	if err := q.QueryRowContext(
+		ctx,
+		query,
+		tag,
+		startHeight,
+		endHeight,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	).Scan(&objectKey, &minHeight, &maxHeight); err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", xerrors.Errorf("failed to find next active CSCB repair candidate: %w", err)
+	}
+	if minHeight < startHeight || maxHeight >= endHeight {
+		return "", xerrors.Errorf(
+			"CSCB repair object %q crosses approved range: object=[%d, %d] approved=[%d, %d)",
+			objectKey,
+			minHeight,
+			maxHeight,
+			startHeight,
+			endHeight,
+		)
+	}
+	return objectKey, nil
+}
+
+func requireNoShadowOnlyCandidates(
+	ctx context.Context,
+	q queryer,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+) error {
+	const query = `
+		SELECT shadow.consolidated_object_key_main, MIN(bm.height), MAX(bm.height)
+		FROM block_consolidation_shadow shadow
+		JOIN block_metadata bm ON bm.id = shadow.block_metadata_id
+			AND bm.tag = shadow.tag
+			AND bm.height = shadow.height
+			AND bm.hash IS NOT DISTINCT FROM shadow.hash
+		WHERE bm.tag = $1
+			AND bm.height >= $2
+			AND bm.height < $3
+			AND shadow.object_format = $4
+			AND shadow.consolidated_object_key_main IS NOT NULL
+			AND shadow.consolidated_object_key_main <> ''
+			AND (
+				bm.object_key_main IS DISTINCT FROM shadow.consolidated_object_key_main
+				OR bm.object_format <> $4
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM cscb_repair_manifest repair
+				WHERE repair.tag = bm.tag
+					AND (
+						repair.old_consolidated_object_key_main = shadow.consolidated_object_key_main
+						OR repair.new_consolidated_object_key_main = shadow.consolidated_object_key_main
+					)
+			)
+		GROUP BY shadow.consolidated_object_key_main
+		ORDER BY MAX(bm.height) DESC, shadow.consolidated_object_key_main DESC
+		LIMIT 1`
+	var objectKey string
+	var minHeight, maxHeight uint64
+	if err := q.QueryRowContext(
+		ctx,
+		query,
+		tag,
+		startHeight,
+		endHeight,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	).Scan(&objectKey, &minHeight, &maxHeight); err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return xerrors.Errorf("failed to inspect shadow-only CSCB repair candidates: %w", err)
+	}
+	return xerrors.Errorf(
+		"CSCB repair range contains shadow-only consolidated object %q at heights [%d, %d]",
+		objectKey,
+		minHeight,
+		maxHeight,
+	)
+}
+
+func (r *PostgresRepository) FenceCandidate(ctx context.Context, manifest *Manifest) (*Manifest, error) {
 	if err := r.validateDB(); err != nil {
 		return nil, err
 	}
-	if err := validatePreparedInput(manifest); err != nil {
+	if err := validateFencedInput(manifest); err != nil {
 		return nil, err
 	}
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to begin CSCB repair preparation: %w", err)
+		return nil, xerrors.Errorf("failed to begin CSCB repair fencing: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := lockRepairTag(ctx, tx, manifest.Tag); err != nil {
+		return nil, err
+	}
 	if err := lockCandidateRows(ctx, tx, manifest.Blocks); err != nil {
 		return nil, err
 	}
@@ -184,14 +284,15 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 	if err := compareCandidateRows(current, manifest); err != nil {
 		return nil, err
 	}
+	if err := requireNoUnexpectedOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey, manifest.Blocks); err != nil {
+		return nil, err
+	}
 
 	const insertManifest = `
 		INSERT INTO cscb_repair_manifest (
-			tag, state, bucket,
-			old_consolidated_object_key_main, old_consolidated_object_version_id,
-			old_consolidated_object_etag, old_consolidated_object_bytes,
+			tag, state, bucket, old_consolidated_object_key_main,
 			start_height, end_height, canonical_block_count, total_block_count, row_set_sha256
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (tag, old_consolidated_object_key_main) DO NOTHING
 		RETURNING id`
 	var repairID int64
@@ -199,12 +300,9 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 		ctx,
 		insertManifest,
 		manifest.Tag,
-		StatePrepared,
+		StatePreparing,
 		manifest.Bucket,
 		manifest.OldConsolidatedObjectKey,
-		manifest.OldConsolidatedObjectVersion.VersionID,
-		manifest.OldConsolidatedObjectVersion.ETag,
-		manifest.OldConsolidatedObjectVersion.Bytes,
 		manifest.StartHeight,
 		manifest.EndHeight,
 		manifest.CanonicalBlockCount,
@@ -220,10 +318,9 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 		const insertBlock = `
 			INSERT INTO cscb_repair_block (
 				repair_id, block_metadata_id, canonical, tag, height, hash,
-				single_block_object_key_main, single_block_object_version_id,
-				single_block_object_etag, single_block_object_bytes, payload_sha256,
+				single_block_object_key_main, single_block_object_key_sha256,
 				old_byte_offset, old_byte_length, old_uncompressed_length
-			) VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), $7, $8, $9, $10, $11, $12, $13, $14)`
+			) VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), $7, $8, $9, $10, $11)`
 		for _, block := range manifest.Blocks {
 			if _, err := tx.ExecContext(
 				ctx,
@@ -235,10 +332,7 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 				block.Height,
 				block.Hash,
 				block.SingleBlockObjectKey,
-				block.SingleBlockObjectVersion.VersionID,
-				block.SingleBlockObjectVersion.ETag,
-				block.SingleBlockObjectVersion.Bytes,
-				block.PayloadSHA256,
+				block.SingleBlockObjectKeySHA256,
 				block.OldByteOffset,
 				block.OldByteLength,
 				block.OldUncompressedLength,
@@ -256,17 +350,158 @@ func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*
 		}
 	}
 
-	prepared, err := loadManifest(ctx, tx, repairID, false)
+	fenced, err := loadManifest(ctx, tx, repairID, false)
 	if err != nil {
 		return nil, err
 	}
-	if !samePreparedManifest(prepared, manifest) {
+	if !sameFencedManifest(fenced, manifest) {
 		return nil, xerrors.Errorf("CSCB repair manifest conflict for old object %q", manifest.OldConsolidatedObjectKey)
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, xerrors.Errorf("failed to commit CSCB repair preparation: %w", err)
+		return nil, xerrors.Errorf("failed to commit CSCB repair fence: %w", err)
 	}
-	return prepared, nil
+	return fenced, nil
+}
+
+func (r *PostgresRepository) RecordInspection(
+	ctx context.Context,
+	repairID int64,
+	oldObject ObjectVersion,
+	blocks []Block,
+	alreadyClean bool,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if err := validateInspectionInput(oldObject, blocks); err != nil {
+		return nil, err
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin recording CSCB repair inspection: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	manifest, err := lockManifestForRepair(ctx, tx, repairID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State != StatePreparing {
+		if !sameInspection(manifest, oldObject, blocks, alreadyClean) {
+			return nil, xerrors.Errorf("CSCB repair inspection changed for repair id %d", repairID)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to commit idempotent CSCB repair inspection: %w", err)
+		}
+		return manifest, nil
+	}
+	if len(blocks) != len(manifest.Blocks) {
+		return nil, xerrors.Errorf("CSCB repair inspection block count changed: expected=%d actual=%d", len(manifest.Blocks), len(blocks))
+	}
+	if err := lockCandidateRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	if err := lockConsolidatedObjectKey(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
+	current, err := loadCandidateByKey(ctx, tx, manifest.Tag, manifest.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := compareCandidateRows(current, manifest); err != nil {
+		return nil, err
+	}
+	if err := requireNoUnexpectedOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey, manifest.Blocks); err != nil {
+		return nil, err
+	}
+
+	const updateBlock = `
+		UPDATE cscb_repair_block
+		SET single_block_object_version_id = $3,
+			single_block_object_etag = $4,
+			single_block_object_bytes = $5,
+			payload_sha256 = $6
+		WHERE repair_id = $1
+			AND block_metadata_id = $2
+			AND single_block_object_key_main = $7
+			AND single_block_object_key_sha256 = $8
+			AND single_block_object_version_id IS NULL
+			AND single_block_object_etag IS NULL
+			AND single_block_object_bytes IS NULL
+			AND payload_sha256 IS NULL`
+	for i := range blocks {
+		block := &blocks[i]
+		expected := manifest.Blocks[i]
+		if block.BlockMetadataID != expected.BlockMetadataID ||
+			block.SingleBlockObjectKey != expected.SingleBlockObjectKey ||
+			block.SingleBlockObjectKeySHA256 != expected.SingleBlockObjectKeySHA256 {
+			return nil, xerrors.Errorf("CSCB repair inspection row changed for metadata_id=%d", expected.BlockMetadataID)
+		}
+		result, err := tx.ExecContext(
+			ctx,
+			updateBlock,
+			manifest.ID,
+			block.BlockMetadataID,
+			block.SingleBlockObjectVersion.VersionID,
+			block.SingleBlockObjectVersion.ETag,
+			block.SingleBlockObjectVersion.Bytes,
+			block.PayloadSHA256,
+			block.SingleBlockObjectKey,
+			block.SingleBlockObjectKeySHA256,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to record CSCB repair block inspection metadata_id=%d: %w", block.BlockMetadataID, err)
+		}
+		if err := requireRowsAffected(result, 1, "record CSCB repair block inspection"); err != nil {
+			return nil, err
+		}
+	}
+
+	state := StatePrepared
+	outcome := ""
+	terminal := false
+	if alreadyClean {
+		state = StateCompleted
+		outcome = alreadyCleanOutcome
+		terminal = true
+	}
+	const updateManifest = `
+		UPDATE cscb_repair_manifest
+		SET state = $2,
+			old_consolidated_object_version_id = $3,
+			old_consolidated_object_etag = $4,
+			old_consolidated_object_bytes = $5,
+			outcome = $6,
+			verified_at = CASE WHEN $7 THEN clock_timestamp() ELSE NULL END,
+			completed_at = CASE WHEN $7 THEN clock_timestamp() ELSE NULL END,
+			updated_at = clock_timestamp()
+		WHERE id = $1 AND state = $8`
+	result, err := tx.ExecContext(
+		ctx,
+		updateManifest,
+		manifest.ID,
+		state,
+		oldObject.VersionID,
+		oldObject.ETag,
+		oldObject.Bytes,
+		outcome,
+		terminal,
+		StatePreparing,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to record CSCB repair inspection: %w", err)
+	}
+	if err := requireRowsAffected(result, 1, "record CSCB repair inspection"); err != nil {
+		return nil, err
+	}
+	inspected, err := loadManifest(ctx, tx, manifest.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair inspection: %w", err)
+	}
+	return inspected, nil
 }
 
 func (r *PostgresRepository) BindExecutionKey(
@@ -327,6 +562,9 @@ func (r *PostgresRepository) BindExecutionKey(
 func (r *PostgresRepository) BindNoCandidateExecution(
 	ctx context.Context,
 	executionKey string,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
 ) (*Manifest, error) {
 	if err := r.validateDB(); err != nil {
 		return nil, err
@@ -339,6 +577,20 @@ func (r *PostgresRepository) BindNoCandidateExecution(
 		return nil, xerrors.Errorf("failed to begin CSCB repair no-candidate execution binding: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+
+	if err := lockRepairTag(ctx, tx, tag); err != nil {
+		return nil, err
+	}
+	objectKey, err := findNextCandidateObject(ctx, tx, tag, startHeight, endHeight)
+	if err != nil {
+		return nil, xerrors.Errorf("failed terminal CSCB repair candidate check: %w", err)
+	}
+	if objectKey != "" {
+		return nil, xerrors.Errorf("CSCB repair candidate appeared before range completion: object=%q", objectKey)
+	}
+	if err := requireNoShadowOnlyCandidates(ctx, tx, tag, startHeight, endHeight); err != nil {
+		return nil, xerrors.Errorf("failed terminal CSCB repair shadow check: %w", err)
+	}
 
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO cscb_repair_execution (execution_key, repair_id)
@@ -377,7 +629,6 @@ func (r *PostgresRepository) Get(ctx context.Context, repairID int64) (*Manifest
 func (r *PostgresRepository) RestoreToSingleBlock(
 	ctx context.Context,
 	repairID int64,
-	validate func(*Manifest) error,
 ) (*Manifest, error) {
 	if err := r.validateDB(); err != nil {
 		return nil, err
@@ -388,7 +639,7 @@ func (r *PostgresRepository) RestoreToSingleBlock(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	manifest, err := loadManifest(ctx, tx, repairID, true)
+	manifest, err := lockManifestForRepair(ctx, tx, repairID)
 	if err != nil {
 		return nil, err
 	}
@@ -409,51 +660,35 @@ func (r *PostgresRepository) RestoreToSingleBlock(
 		return nil, err
 	}
 
-	const unrelatedMissing = `
-		SELECT bm.id
-		FROM canonical_blocks cb
-		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
-			AND bm.tag = cb.tag
-			AND bm.height = cb.height
-		WHERE cb.tag = $1
-			AND cb.height >= $2
-			AND cb.height < $3
-			AND bm.skipped = FALSE
-			AND bm.object_format = $4
-			AND bm.byte_length IS NULL
-			AND bm.object_key_main IS NOT NULL
-			AND bm.object_key_main <> ''
-			AND NOT EXISTS (
-				SELECT 1 FROM cscb_repair_block block
-				WHERE block.repair_id = $5 AND block.block_metadata_id = bm.id
-			)
-			AND NOT EXISTS (
-				SELECT 1 FROM block_consolidation_shadow shadow
-				WHERE shadow.block_metadata_id = bm.id
-					AND shadow.single_block_object_key_main = bm.object_key_main
-					AND shadow.validated_at IS NOT NULL
-			)
-		LIMIT 1`
-	var unrelatedID int64
-	err = tx.QueryRowContext(
-		ctx,
-		unrelatedMissing,
-		manifest.Tag,
-		manifest.StartHeight,
-		manifest.EndHeight,
-		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK,
-		manifest.ID,
-	).Scan(&unrelatedID)
-	if err != nil && err != sql.ErrNoRows {
-		return nil, xerrors.Errorf("failed to check CSCB repair range isolation: %w", err)
-	}
-	if err == nil {
-		return nil, xerrors.Errorf("CSCB repair range contains unrelated unconsolidated metadata_id=%d", unrelatedID)
-	}
-
-	if validate != nil {
-		if err := validate(manifest); err != nil {
-			return nil, err
+	if manifest.CanonicalBlockCount > 0 {
+		const unrelatedCanonical = `
+			SELECT bm.id
+			FROM canonical_blocks cb
+			JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+				AND bm.tag = cb.tag
+				AND bm.height = cb.height
+			WHERE cb.tag = $1
+				AND cb.height >= $2
+				AND cb.height < $3
+				AND NOT EXISTS (
+					SELECT 1 FROM cscb_repair_block block
+					WHERE block.repair_id = $4 AND block.block_metadata_id = bm.id
+				)
+			LIMIT 1`
+		var unrelatedID int64
+		err = tx.QueryRowContext(
+			ctx,
+			unrelatedCanonical,
+			manifest.Tag,
+			manifest.StartHeight,
+			manifest.EndHeight,
+			manifest.ID,
+		).Scan(&unrelatedID)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, xerrors.Errorf("failed to check CSCB repair range isolation: %w", err)
+		}
+		if err == nil {
+			return nil, xerrors.Errorf("CSCB repair range contains unrelated canonical metadata_id=%d", unrelatedID)
 		}
 	}
 
@@ -576,7 +811,7 @@ func (r *PostgresRepository) RecordVerified(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	manifest, err := loadManifest(ctx, tx, repairID, true)
+	manifest, err := lockManifestForRepair(ctx, tx, repairID)
 	if err != nil {
 		return nil, err
 	}
@@ -598,13 +833,16 @@ func (r *PostgresRepository) RecordVerified(
 	if err := lockRepairRows(ctx, tx, manifest.Blocks); err != nil {
 		return nil, err
 	}
-	if err := lockConsolidatedObjectKey(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+	if err := lockConsolidatedObjectKeys(ctx, tx, manifest.OldConsolidatedObjectKey, objectKey); err != nil {
 		return nil, err
 	}
 	if err := loadRebuiltBlocks(ctx, tx, manifest); err != nil {
 		return nil, err
 	}
 	if err := validateRebuiltMetadata(manifest, objectKey); err != nil {
+		return nil, err
+	}
+	if err := requireExactNewReferences(ctx, tx, manifest, objectKey); err != nil {
 		return nil, err
 	}
 	if err := requireNoOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
@@ -648,24 +886,23 @@ func (r *PostgresRepository) RecordVerified(
 	return verified, nil
 }
 
-func (r *PostgresRepository) CompleteWithOldObjectDeletion(
+func (r *PostgresRepository) CompleteRetainingOldObject(
 	ctx context.Context,
 	repairID int64,
 	outcome string,
-	deleteObject DeleteOldObject,
 ) (*Manifest, error) {
 	if err := r.validateDB(); err != nil {
 		return nil, err
 	}
-	if outcome == "" || deleteObject == nil {
-		return nil, xerrors.New("CSCB repair completion outcome and old-object deletion are required")
+	if outcome == "" {
+		return nil, xerrors.New("CSCB repair completion outcome is required")
 	}
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to begin CSCB repair completion: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	manifest, err := loadManifest(ctx, tx, repairID, true)
+	manifest, err := lockManifestForRepair(ctx, tx, repairID)
 	if err != nil {
 		return nil, err
 	}
@@ -675,30 +912,46 @@ func (r *PostgresRepository) CompleteWithOldObjectDeletion(
 		}
 		return manifest, nil
 	}
-	if manifest.State != StateVerified {
+	if manifest.CanonicalBlockCount == 0 {
+		if manifest.State != StateRestored {
+			return nil, xerrors.Errorf("zero-canonical CSCB repair must be restored before completion: id=%d state=%s", manifest.ID, manifest.State)
+		}
+	} else if manifest.State != StateVerified {
 		return nil, xerrors.Errorf("CSCB repair must be verified before completion: id=%d state=%s", manifest.ID, manifest.State)
 	}
 	if err := lockRepairRows(ctx, tx, manifest.Blocks); err != nil {
 		return nil, err
 	}
-	if err := lockConsolidatedObjectKey(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+	if err := lockConsolidatedObjectKeys(
+		ctx,
+		tx,
+		manifest.OldConsolidatedObjectKey,
+		manifest.NewConsolidatedObjectKey,
+	); err != nil {
 		return nil, err
+	}
+	if err := loadRebuiltBlocks(ctx, tx, manifest); err != nil {
+		return nil, err
+	}
+	if err := validateRebuiltMetadata(manifest, manifest.NewConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
+	if manifest.CanonicalBlockCount > 0 {
+		if err := requireExactNewReferences(ctx, tx, manifest, manifest.NewConsolidatedObjectKey); err != nil {
+			return nil, err
+		}
 	}
 	if err := requireNoOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
-		return nil, err
-	}
-	if err := deleteObject(manifest); err != nil {
 		return nil, err
 	}
 	const update = `
 		UPDATE cscb_repair_manifest
 		SET state = $2,
 			outcome = $3,
-			old_object_deleted_at = clock_timestamp(),
 			completed_at = clock_timestamp(),
 			updated_at = clock_timestamp()
 		WHERE id = $1 AND state = $4`
-	result, err := tx.ExecContext(ctx, update, manifest.ID, StateCompleted, outcome, StateVerified)
+	result, err := tx.ExecContext(ctx, update, manifest.ID, StateCompleted, outcome, manifest.State)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to complete CSCB repair: %w", err)
 	}
@@ -835,18 +1088,20 @@ func loadManifest(ctx context.Context, q queryer, repairID int64, forUpdate bool
 func scanManifest(row rowScanner) (*Manifest, error) {
 	var manifest Manifest
 	var state string
+	var oldVersionID, oldETag sql.NullString
+	var oldBytes sql.NullInt64
 	var newKey, newVersionID, newETag sql.NullString
 	var newBytes sql.NullInt64
-	var restoredAt, verifiedAt, oldDeletedAt, completedAt sql.NullTime
+	var restoredAt, verifiedAt, completedAt sql.NullTime
 	if err := row.Scan(
 		&manifest.ID,
 		&manifest.Tag,
 		&state,
 		&manifest.Bucket,
 		&manifest.OldConsolidatedObjectKey,
-		&manifest.OldConsolidatedObjectVersion.VersionID,
-		&manifest.OldConsolidatedObjectVersion.ETag,
-		&manifest.OldConsolidatedObjectVersion.Bytes,
+		&oldVersionID,
+		&oldETag,
+		&oldBytes,
 		&manifest.StartHeight,
 		&manifest.EndHeight,
 		&manifest.CanonicalBlockCount,
@@ -860,12 +1115,16 @@ func scanManifest(row rowScanner) (*Manifest, error) {
 		&manifest.PreparedAt,
 		&restoredAt,
 		&verifiedAt,
-		&oldDeletedAt,
 		&completedAt,
 	); err != nil {
 		return nil, err
 	}
 	manifest.State = State(state)
+	manifest.OldConsolidatedObjectVersion.VersionID = oldVersionID.String
+	manifest.OldConsolidatedObjectVersion.ETag = oldETag.String
+	if oldBytes.Valid && oldBytes.Int64 > 0 {
+		manifest.OldConsolidatedObjectVersion.Bytes = uint64(oldBytes.Int64)
+	}
 	manifest.NewConsolidatedObjectKey = newKey.String
 	manifest.NewConsolidatedObjectVersion.VersionID = newVersionID.String
 	manifest.NewConsolidatedObjectVersion.ETag = newETag.String
@@ -874,7 +1133,6 @@ func scanManifest(row rowScanner) (*Manifest, error) {
 	}
 	manifest.RestoredAt = nullableTime(restoredAt)
 	manifest.VerifiedAt = nullableTime(verifiedAt)
-	manifest.OldObjectDeletedAt = nullableTime(oldDeletedAt)
 	manifest.CompletedAt = nullableTime(completedAt)
 	return &manifest, nil
 }
@@ -882,8 +1140,10 @@ func scanManifest(row rowScanner) (*Manifest, error) {
 func loadManifestBlocks(ctx context.Context, q queryer, manifest *Manifest) error {
 	const query = `
 		SELECT block_metadata_id, canonical, tag, height, COALESCE(hash, ''),
-			single_block_object_key_main, single_block_object_version_id,
-			single_block_object_etag, single_block_object_bytes, payload_sha256,
+			COALESCE(single_block_object_key_main, ''), single_block_object_key_sha256,
+			COALESCE(single_block_object_version_id, ''),
+			COALESCE(single_block_object_etag, ''), COALESCE(single_block_object_bytes, 0),
+			COALESCE(payload_sha256, ''),
 			old_byte_offset, old_byte_length, old_uncompressed_length
 		FROM cscb_repair_block
 		WHERE repair_id = $1
@@ -904,6 +1164,7 @@ func loadManifestBlocks(ctx context.Context, q queryer, manifest *Manifest) erro
 			&block.Height,
 			&block.Hash,
 			&block.SingleBlockObjectKey,
+			&block.SingleBlockObjectKeySHA256,
 			&block.SingleBlockObjectVersion.VersionID,
 			&block.SingleBlockObjectVersion.ETag,
 			&block.SingleBlockObjectVersion.Bytes,
@@ -1011,6 +1272,20 @@ func loadRebuiltBlocks(ctx context.Context, q queryer, manifest *Manifest) error
 	return nil
 }
 
+func lockManifestForRepair(ctx context.Context, tx *sql.Tx, repairID int64) (*Manifest, error) {
+	var tag uint32
+	if err := tx.QueryRowContext(ctx, `SELECT tag FROM cscb_repair_manifest WHERE id = $1`, repairID).Scan(&tag); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, xerrors.Errorf("CSCB repair manifest not found: id=%d", repairID)
+		}
+		return nil, xerrors.Errorf("failed to load CSCB repair tag: %w", err)
+	}
+	if err := lockRepairTag(ctx, tx, tag); err != nil {
+		return nil, err
+	}
+	return loadManifest(ctx, tx, repairID, true)
+}
+
 func lockCandidateRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
 	ordered := append([]Block(nil), blocks...)
 	sort.Slice(ordered, func(i, j int) bool {
@@ -1068,6 +1343,35 @@ func lockConsolidatedObjectKey(ctx context.Context, tx *sql.Tx, objectKey string
 		return xerrors.Errorf("failed to acquire CSCB repair object lock: %w", err)
 	}
 	return nil
+}
+
+func lockConsolidatedObjectKeys(ctx context.Context, tx *sql.Tx, objectKeys ...string) error {
+	unique := make(map[string]struct{}, len(objectKeys))
+	ordered := make([]string, 0, len(objectKeys))
+	for _, objectKey := range objectKeys {
+		if objectKey == "" {
+			continue
+		}
+		if _, ok := unique[objectKey]; ok {
+			continue
+		}
+		unique[objectKey] = struct{}{}
+		ordered = append(ordered, objectKey)
+	}
+	if len(ordered) == 0 {
+		return xerrors.New("at least one consolidated object key is required for CSCB repair locks")
+	}
+	sort.Strings(ordered)
+	for _, objectKey := range ordered {
+		if err := lockConsolidatedObjectKey(ctx, tx, objectKey); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func lockRepairTag(ctx context.Context, tx *sql.Tx, tag uint32) error {
+	return cscbrepairlock.AcquireTag(ctx, tx, tag)
 }
 
 func lockRepairRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
@@ -1206,8 +1510,74 @@ func validateRebuiltMetadata(manifest *Manifest, objectKey string) error {
 	if canonicalCount != manifest.CanonicalBlockCount {
 		return xerrors.Errorf("rebuilt canonical block count mismatch: expected=%d actual=%d", manifest.CanonicalBlockCount, canonicalCount)
 	}
+	if canonicalCount == 0 {
+		if objectKey != "" {
+			return xerrors.Errorf("zero-canonical CSCB repair unexpectedly produced object %q", objectKey)
+		}
+		return nil
+	}
+	if objectKey == "" {
+		return xerrors.New("rebuilt CSCB object key is missing")
+	}
 	if objectKey == manifest.OldConsolidatedObjectKey {
 		return xerrors.Errorf("rebuilt CSCB reused dirty object key %q", objectKey)
+	}
+	return nil
+}
+
+func requireNoUnexpectedOldReferences(ctx context.Context, q queryer, objectKey string, blocks []Block) error {
+	ids := make([]int64, 0, len(blocks))
+	for _, block := range blocks {
+		ids = append(ids, block.BlockMetadataID)
+	}
+	const query = `
+		SELECT
+			(SELECT COUNT(*)
+			 FROM block_metadata
+			 WHERE object_key_main = $1 AND NOT (id = ANY($2)))
+			+
+			(SELECT COUNT(*)
+			 FROM block_consolidation_shadow
+			 WHERE consolidated_object_key_main = $1 AND NOT (block_metadata_id = ANY($2)))`
+	var references uint64
+	if err := q.QueryRowContext(ctx, query, objectKey, pq.Array(ids)).Scan(&references); err != nil {
+		return xerrors.Errorf("failed to count unexpected dirty CSCB references: %w", err)
+	}
+	if references != 0 {
+		return xerrors.Errorf("dirty CSCB %q has %d references outside the pinned row set", objectKey, references)
+	}
+	return nil
+}
+
+func requireExactNewReferences(ctx context.Context, q queryer, manifest *Manifest, objectKey string) error {
+	ids := make([]int64, 0, manifest.CanonicalBlockCount)
+	for _, block := range manifest.Blocks {
+		if block.Canonical {
+			ids = append(ids, block.BlockMetadataID)
+		}
+	}
+	if len(ids) == 0 || uint64(len(ids)) != manifest.CanonicalBlockCount {
+		return xerrors.Errorf(
+			"rebuilt CSCB expected canonical reference count mismatch: expected=%d actual=%d",
+			manifest.CanonicalBlockCount,
+			len(ids),
+		)
+	}
+	const query = `
+		SELECT
+			(SELECT COUNT(*)
+			 FROM block_metadata
+			 WHERE object_key_main = $1 AND NOT (id = ANY($2)))
+			+
+			(SELECT COUNT(*)
+			 FROM block_consolidation_shadow
+			 WHERE consolidated_object_key_main = $1 AND NOT (block_metadata_id = ANY($2)))`
+	var references uint64
+	if err := q.QueryRowContext(ctx, query, objectKey, pq.Array(ids)).Scan(&references); err != nil {
+		return xerrors.Errorf("failed to count unexpected rebuilt CSCB references: %w", err)
+	}
+	if references != 0 {
+		return xerrors.Errorf("rebuilt CSCB %q has %d references outside the pinned canonical row set", objectKey, references)
 	}
 	return nil
 }
@@ -1228,37 +1598,56 @@ func requireNoOldReferences(ctx context.Context, q queryer, objectKey string) er
 	return nil
 }
 
-func validatePreparedInput(manifest *Manifest) error {
+func validateFencedInput(manifest *Manifest) error {
 	if manifest == nil || manifest.Tag == 0 || manifest.Bucket == "" ||
+		manifest.State != StatePreparing ||
 		manifest.OldConsolidatedObjectKey == "" ||
-		manifest.OldConsolidatedObjectVersion.VersionID == "" ||
-		manifest.OldConsolidatedObjectVersion.ETag == "" ||
-		manifest.OldConsolidatedObjectVersion.Bytes == 0 ||
 		manifest.EndHeight <= manifest.StartHeight ||
-		manifest.CanonicalBlockCount == 0 ||
 		manifest.TotalBlockCount != uint64(len(manifest.Blocks)) ||
-		len(manifest.RowSetSHA256) != 64 {
-		return xerrors.New("complete pinned CSCB repair manifest is required")
+		len(manifest.RowSetSHA256) != 64 || manifest.RowSetSHA256 != rowSetSHA256(manifest) {
+		return xerrors.New("complete CSCB repair fence is required")
 	}
+	canonicalCount := uint64(0)
 	for _, block := range manifest.Blocks {
 		if block.BlockMetadataID == 0 || block.Tag != manifest.Tag || block.SingleBlockObjectKey == "" ||
-			block.SingleBlockObjectVersion.VersionID == "" || block.SingleBlockObjectVersion.ETag == "" ||
-			block.SingleBlockObjectVersion.Bytes == 0 || len(block.PayloadSHA256) != 64 ||
+			len(block.SingleBlockObjectKeySHA256) != 64 ||
+			block.SingleBlockObjectKeySHA256 != objectKeySHA256(block.SingleBlockObjectKey) ||
 			block.OldConsolidatedObjectKey != manifest.OldConsolidatedObjectKey ||
 			block.OldByteLength == 0 || block.OldUncompressedLength == 0 {
-			return xerrors.Errorf("incomplete pinned CSCB repair block metadata_id=%d", block.BlockMetadataID)
+			return xerrors.Errorf("incomplete CSCB repair fence block metadata_id=%d", block.BlockMetadataID)
+		}
+		if block.Canonical {
+			canonicalCount++
+		}
+	}
+	if canonicalCount != manifest.CanonicalBlockCount {
+		return xerrors.Errorf("CSCB repair fence canonical count mismatch: expected=%d actual=%d", manifest.CanonicalBlockCount, canonicalCount)
+	}
+	return nil
+}
+
+func validateInspectionInput(oldObject ObjectVersion, blocks []Block) error {
+	if !immutableVersionID(oldObject.VersionID) || oldObject.ETag == "" || oldObject.Bytes == 0 || len(blocks) == 0 {
+		return xerrors.New("complete CSCB repair object inspection is required")
+	}
+	for _, block := range blocks {
+		if block.BlockMetadataID == 0 || block.SingleBlockObjectKey == "" ||
+			block.SingleBlockObjectKeySHA256 != objectKeySHA256(block.SingleBlockObjectKey) ||
+			!immutableVersionID(block.SingleBlockObjectVersion.VersionID) ||
+			block.SingleBlockObjectVersion.ETag == "" || block.SingleBlockObjectVersion.Bytes == 0 ||
+			len(block.PayloadSHA256) != 64 {
+			return xerrors.Errorf("incomplete CSCB repair inspection block metadata_id=%d", block.BlockMetadataID)
 		}
 	}
 	return nil
 }
 
-func samePreparedManifest(actual *Manifest, expected *Manifest) bool {
+func sameFencedManifest(actual *Manifest, expected *Manifest) bool {
 	if actual == nil || expected == nil ||
 		actual.Tag != expected.Tag ||
-		actual.State != StatePrepared ||
+		actual.State != StatePreparing ||
 		actual.Bucket != expected.Bucket ||
 		actual.OldConsolidatedObjectKey != expected.OldConsolidatedObjectKey ||
-		actual.OldConsolidatedObjectVersion != expected.OldConsolidatedObjectVersion ||
 		actual.StartHeight != expected.StartHeight ||
 		actual.EndHeight != expected.EndHeight ||
 		actual.CanonicalBlockCount != expected.CanonicalBlockCount ||
@@ -1273,10 +1662,34 @@ func samePreparedManifest(actual *Manifest, expected *Manifest) bool {
 		if a.BlockMetadataID != b.BlockMetadataID || a.Canonical != b.Canonical ||
 			a.Tag != b.Tag || a.Height != b.Height || a.Hash != b.Hash ||
 			a.SingleBlockObjectKey != b.SingleBlockObjectKey ||
-			a.SingleBlockObjectVersion != b.SingleBlockObjectVersion ||
-			a.PayloadSHA256 != b.PayloadSHA256 ||
+			a.SingleBlockObjectKeySHA256 != b.SingleBlockObjectKeySHA256 ||
 			a.OldByteOffset != b.OldByteOffset || a.OldByteLength != b.OldByteLength ||
 			a.OldUncompressedLength != b.OldUncompressedLength {
+			return false
+		}
+	}
+	return true
+}
+
+func sameInspection(actual *Manifest, oldObject ObjectVersion, blocks []Block, alreadyClean bool) bool {
+	expectedState := StatePrepared
+	expectedOutcome := ""
+	if alreadyClean {
+		expectedState = StateCompleted
+		expectedOutcome = alreadyCleanOutcome
+	}
+	if actual == nil || actual.State != expectedState || actual.Outcome != expectedOutcome ||
+		actual.OldConsolidatedObjectVersion != oldObject || len(actual.Blocks) != len(blocks) {
+		return false
+	}
+	for i := range blocks {
+		a := actual.Blocks[i]
+		b := blocks[i]
+		if a.BlockMetadataID != b.BlockMetadataID ||
+			a.SingleBlockObjectKey != b.SingleBlockObjectKey ||
+			a.SingleBlockObjectKeySHA256 != b.SingleBlockObjectKeySHA256 ||
+			a.SingleBlockObjectVersion != b.SingleBlockObjectVersion ||
+			a.PayloadSHA256 != b.PayloadSHA256 {
 			return false
 		}
 	}

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -1,0 +1,1132 @@
+package cscbrepair
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/lib/pq"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/storage/retirementlock"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+const manifestColumns = `
+	id, tag, state, bucket,
+	old_consolidated_object_key_main, old_consolidated_object_version_id,
+	old_consolidated_object_etag, old_consolidated_object_bytes,
+	start_height, end_height, canonical_block_count, total_block_count, row_set_sha256,
+	new_consolidated_object_key_main, new_consolidated_object_version_id,
+	new_consolidated_object_etag, new_consolidated_object_bytes,
+	outcome, prepared_at, restored_at, verified_at,
+	old_object_deleted_at, completed_at`
+
+type (
+	PostgresRepository struct {
+		db *sql.DB
+	}
+
+	rowScanner interface {
+		Scan(dest ...any) error
+	}
+
+	queryer interface {
+		QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+		QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	}
+)
+
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) FindPending(
+	ctx context.Context,
+	tag uint32,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	query := fmt.Sprintf(`
+			SELECT %s
+			FROM cscb_repair_manifest
+			WHERE tag = $1
+				AND state <> $2
+			ORDER BY id ASC
+			LIMIT 1`, manifestColumns)
+	manifest, err := scanManifest(r.db.QueryRowContext(ctx, query, tag, StateCompleted))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, xerrors.Errorf("failed to find pending CSCB repair: %w", err)
+	}
+	if err := loadManifestBlocks(ctx, r.db, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (r *PostgresRepository) FindNextCandidate(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if endHeight <= startHeight {
+		return nil, nil
+	}
+	const keyQuery = `
+		SELECT bm.object_key_main
+		FROM canonical_blocks cb
+		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+			AND bm.tag = cb.tag
+			AND bm.height = cb.height
+		WHERE cb.tag = $1
+			AND cb.height >= $2
+			AND cb.height < $3
+			AND bm.skipped = FALSE
+			AND bm.object_format = $4
+			AND bm.object_key_main IS NOT NULL
+			AND bm.object_key_main <> ''
+			AND NOT EXISTS (
+				SELECT 1
+				FROM cscb_repair_manifest repair
+				WHERE repair.tag = bm.tag
+					AND (
+						repair.old_consolidated_object_key_main = bm.object_key_main
+						OR repair.new_consolidated_object_key_main = bm.object_key_main
+					)
+			)
+		GROUP BY bm.object_key_main
+		ORDER BY MAX(cb.height) DESC, bm.object_key_main DESC
+		LIMIT 1`
+	var objectKey string
+	if err := r.db.QueryRowContext(
+		ctx,
+		keyQuery,
+		tag,
+		startHeight,
+		endHeight,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	).Scan(&objectKey); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, xerrors.Errorf("failed to find next active CSCB repair candidate: %w", err)
+	}
+	manifest, err := loadCandidateByKey(ctx, r.db, tag, objectKey)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (r *PostgresRepository) Prepare(ctx context.Context, manifest *Manifest) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if err := validatePreparedInput(manifest); err != nil {
+		return nil, err
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin CSCB repair preparation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := lockCandidateRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	current, err := loadCandidateByKey(ctx, tx, manifest.Tag, manifest.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := compareCandidateRows(current, manifest); err != nil {
+		return nil, err
+	}
+
+	const insertManifest = `
+		INSERT INTO cscb_repair_manifest (
+			tag, state, bucket,
+			old_consolidated_object_key_main, old_consolidated_object_version_id,
+			old_consolidated_object_etag, old_consolidated_object_bytes,
+			start_height, end_height, canonical_block_count, total_block_count, row_set_sha256
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		ON CONFLICT (tag, old_consolidated_object_key_main) DO NOTHING
+		RETURNING id`
+	var repairID int64
+	err = tx.QueryRowContext(
+		ctx,
+		insertManifest,
+		manifest.Tag,
+		StatePrepared,
+		manifest.Bucket,
+		manifest.OldConsolidatedObjectKey,
+		manifest.OldConsolidatedObjectVersion.VersionID,
+		manifest.OldConsolidatedObjectVersion.ETag,
+		manifest.OldConsolidatedObjectVersion.Bytes,
+		manifest.StartHeight,
+		manifest.EndHeight,
+		manifest.CanonicalBlockCount,
+		manifest.TotalBlockCount,
+		manifest.RowSetSHA256,
+	).Scan(&repairID)
+	inserted := err == nil
+	if err != nil && err != sql.ErrNoRows {
+		return nil, xerrors.Errorf("failed to insert CSCB repair manifest: %w", err)
+	}
+
+	if inserted {
+		const insertBlock = `
+			INSERT INTO cscb_repair_block (
+				repair_id, block_metadata_id, canonical, tag, height, hash,
+				single_block_object_key_main, single_block_object_version_id,
+				single_block_object_etag, single_block_object_bytes, payload_sha256,
+				old_byte_offset, old_byte_length, old_uncompressed_length
+			) VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), $7, $8, $9, $10, $11, $12, $13, $14)`
+		for _, block := range manifest.Blocks {
+			if _, err := tx.ExecContext(
+				ctx,
+				insertBlock,
+				repairID,
+				block.BlockMetadataID,
+				block.Canonical,
+				block.Tag,
+				block.Height,
+				block.Hash,
+				block.SingleBlockObjectKey,
+				block.SingleBlockObjectVersion.VersionID,
+				block.SingleBlockObjectVersion.ETag,
+				block.SingleBlockObjectVersion.Bytes,
+				block.PayloadSHA256,
+				block.OldByteOffset,
+				block.OldByteLength,
+				block.OldUncompressedLength,
+			); err != nil {
+				return nil, xerrors.Errorf("failed to insert CSCB repair block metadata_id=%d: %w", block.BlockMetadataID, err)
+			}
+		}
+	} else {
+		const existingID = `
+			SELECT id
+			FROM cscb_repair_manifest
+			WHERE tag = $1 AND old_consolidated_object_key_main = $2`
+		if err := tx.QueryRowContext(ctx, existingID, manifest.Tag, manifest.OldConsolidatedObjectKey).Scan(&repairID); err != nil {
+			return nil, xerrors.Errorf("failed to load concurrent CSCB repair manifest: %w", err)
+		}
+	}
+
+	prepared, err := loadManifest(ctx, tx, repairID, false)
+	if err != nil {
+		return nil, err
+	}
+	if !samePreparedManifest(prepared, manifest) {
+		return nil, xerrors.Errorf("CSCB repair manifest conflict for old object %q", manifest.OldConsolidatedObjectKey)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair preparation: %w", err)
+	}
+	return prepared, nil
+}
+
+func (r *PostgresRepository) Get(ctx context.Context, repairID int64) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	return loadManifest(ctx, r.db, repairID, false)
+}
+
+func (r *PostgresRepository) RestoreToSingleBlock(
+	ctx context.Context,
+	repairID int64,
+	validate func(*Manifest) error,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin CSCB repair restore: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	manifest, err := loadManifest(ctx, tx, repairID, true)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State != StatePrepared {
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to commit idempotent CSCB repair restore: %w", err)
+		}
+		return manifest, nil
+	}
+	if err := lockCandidateRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	current, err := loadCandidateByKey(ctx, tx, manifest.Tag, manifest.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := compareCandidateRows(current, manifest); err != nil {
+		return nil, err
+	}
+
+	const unrelatedMissing = `
+		SELECT bm.id
+		FROM canonical_blocks cb
+		JOIN block_metadata bm ON bm.id = cb.block_metadata_id
+			AND bm.tag = cb.tag
+			AND bm.height = cb.height
+		WHERE cb.tag = $1
+			AND cb.height >= $2
+			AND cb.height < $3
+			AND bm.skipped = FALSE
+			AND bm.object_format = $4
+			AND bm.byte_length IS NULL
+			AND bm.object_key_main IS NOT NULL
+			AND bm.object_key_main <> ''
+			AND NOT EXISTS (
+				SELECT 1 FROM cscb_repair_block block
+				WHERE block.repair_id = $5 AND block.block_metadata_id = bm.id
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM block_consolidation_shadow shadow
+				WHERE shadow.block_metadata_id = bm.id
+					AND shadow.single_block_object_key_main = bm.object_key_main
+					AND shadow.validated_at IS NOT NULL
+			)
+		LIMIT 1`
+	var unrelatedID int64
+	err = tx.QueryRowContext(
+		ctx,
+		unrelatedMissing,
+		manifest.Tag,
+		manifest.StartHeight,
+		manifest.EndHeight,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK,
+		manifest.ID,
+	).Scan(&unrelatedID)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, xerrors.Errorf("failed to check CSCB repair range isolation: %w", err)
+	}
+	if err == nil {
+		return nil, xerrors.Errorf("CSCB repair range contains unrelated unconsolidated metadata_id=%d", unrelatedID)
+	}
+
+	if validate != nil {
+		if err := validate(manifest); err != nil {
+			return nil, err
+		}
+	}
+
+	const restoreMetadata = `
+		UPDATE block_metadata bm
+		SET object_key_main = block.single_block_object_key_main,
+			object_format = $2,
+			byte_offset = NULL,
+			byte_length = NULL,
+			uncompressed_length = NULL
+		FROM cscb_repair_block block
+		WHERE block.repair_id = $1
+			AND bm.id = block.block_metadata_id
+			AND bm.tag = block.tag
+			AND bm.height = block.height
+			AND bm.hash IS NOT DISTINCT FROM block.hash
+			AND bm.skipped = FALSE
+			AND bm.single_block_retention_fenced_at IS NULL
+			AND bm.object_key_main = $3
+			AND bm.object_format = $4
+			AND bm.byte_offset = block.old_byte_offset
+			AND bm.byte_length = block.old_byte_length
+			AND bm.uncompressed_length = block.old_uncompressed_length`
+	result, err := tx.ExecContext(
+		ctx,
+		restoreMetadata,
+		manifest.ID,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK,
+		manifest.OldConsolidatedObjectKey,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore active single-block metadata: %w", err)
+	}
+	if err := requireRowsAffected(result, manifest.TotalBlockCount, "restore active single-block metadata"); err != nil {
+		return nil, err
+	}
+
+	const deleteOldShadows = `
+		DELETE FROM block_consolidation_shadow shadow
+		USING cscb_repair_block block
+		WHERE block.repair_id = $1
+			AND shadow.block_metadata_id = block.block_metadata_id
+			AND shadow.tag = block.tag
+			AND shadow.height = block.height
+			AND shadow.hash IS NOT DISTINCT FROM block.hash
+			AND shadow.single_block_object_key_main = block.single_block_object_key_main
+			AND shadow.single_block_object_deleted_at IS NULL
+			AND shadow.consolidated_object_key_main = $2
+			AND shadow.object_format = $3
+			AND shadow.byte_offset = block.old_byte_offset
+			AND shadow.byte_length = block.old_byte_length
+			AND shadow.uncompressed_length = block.old_uncompressed_length`
+	result, err = tx.ExecContext(
+		ctx,
+		deleteOldShadows,
+		manifest.ID,
+		manifest.OldConsolidatedObjectKey,
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to remove invalidated CSCB shadows: %w", err)
+	}
+	if err := requireRowsAffected(result, manifest.TotalBlockCount, "remove invalidated CSCB shadows"); err != nil {
+		return nil, err
+	}
+
+	const markRestored = `
+		UPDATE cscb_repair_manifest
+		SET state = $2,
+			restored_at = clock_timestamp(),
+			updated_at = clock_timestamp()
+		WHERE id = $1 AND state = $3`
+	result, err = tx.ExecContext(ctx, markRestored, manifest.ID, StateRestored, StatePrepared)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to mark CSCB repair restored: %w", err)
+	}
+	if err := requireRowsAffected(result, 1, "mark CSCB repair restored"); err != nil {
+		return nil, err
+	}
+	restored, err := loadManifest(ctx, tx, manifest.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair restore: %w", err)
+	}
+	return restored, nil
+}
+
+func (r *PostgresRepository) GetRebuilt(ctx context.Context, repairID int64) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	manifest, err := loadManifest(ctx, r.db, repairID, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := loadRebuiltBlocks(ctx, r.db, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (r *PostgresRepository) RecordVerified(
+	ctx context.Context,
+	repairID int64,
+	objectKey string,
+	object ObjectVersion,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if objectKey == "" || object.VersionID == "" || object.ETag == "" || object.Bytes == 0 {
+		return nil, xerrors.New("verified CSCB object identity is required")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin recording verified CSCB repair: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	manifest, err := loadManifest(ctx, tx, repairID, true)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State == StateVerified || manifest.State == StateCompleted {
+		if manifest.NewConsolidatedObjectKey != objectKey ||
+			manifest.NewConsolidatedObjectVersion.VersionID != object.VersionID ||
+			manifest.NewConsolidatedObjectVersion.ETag != object.ETag ||
+			manifest.NewConsolidatedObjectVersion.Bytes != object.Bytes {
+			return nil, xerrors.Errorf("verified CSCB repair identity changed for repair id %d", manifest.ID)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to commit idempotent verified CSCB repair: %w", err)
+		}
+		return manifest, nil
+	}
+	if manifest.State != StateRestored {
+		return nil, xerrors.Errorf("CSCB repair must be restored before verification: id=%d state=%s", manifest.ID, manifest.State)
+	}
+	if err := lockRebuiltRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	if err := loadRebuiltBlocks(ctx, tx, manifest); err != nil {
+		return nil, err
+	}
+	if err := validateRebuiltMetadata(manifest, objectKey); err != nil {
+		return nil, err
+	}
+	if err := requireNoOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
+
+	const update = `
+		UPDATE cscb_repair_manifest
+		SET state = $2,
+			new_consolidated_object_key_main = $3,
+			new_consolidated_object_version_id = $4,
+			new_consolidated_object_etag = $5,
+			new_consolidated_object_bytes = $6,
+			verified_at = clock_timestamp(),
+			updated_at = clock_timestamp()
+		WHERE id = $1 AND state = $7`
+	result, err := tx.ExecContext(
+		ctx,
+		update,
+		manifest.ID,
+		StateVerified,
+		objectKey,
+		object.VersionID,
+		object.ETag,
+		object.Bytes,
+		StateRestored,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to record verified CSCB repair: %w", err)
+	}
+	if err := requireRowsAffected(result, 1, "record verified CSCB repair"); err != nil {
+		return nil, err
+	}
+	verified, err := loadManifest(ctx, tx, manifest.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit verified CSCB repair: %w", err)
+	}
+	return verified, nil
+}
+
+func (r *PostgresRepository) Complete(ctx context.Context, repairID int64, outcome string) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if outcome == "" {
+		return nil, xerrors.New("CSCB repair completion outcome is required")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin CSCB repair completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	manifest, err := loadManifest(ctx, tx, repairID, true)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State == StateCompleted {
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to commit idempotent CSCB repair completion: %w", err)
+		}
+		return manifest, nil
+	}
+	if manifest.State != StateVerified {
+		return nil, xerrors.Errorf("CSCB repair must be verified before completion: id=%d state=%s", manifest.ID, manifest.State)
+	}
+	if err := requireNoOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
+	const update = `
+		UPDATE cscb_repair_manifest
+		SET state = $2,
+			outcome = $3,
+			old_object_deleted_at = clock_timestamp(),
+			completed_at = clock_timestamp(),
+			updated_at = clock_timestamp()
+		WHERE id = $1 AND state = $4`
+	result, err := tx.ExecContext(ctx, update, manifest.ID, StateCompleted, outcome, StateVerified)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to complete CSCB repair: %w", err)
+	}
+	if err := requireRowsAffected(result, 1, "complete CSCB repair"); err != nil {
+		return nil, err
+	}
+	completed, err := loadManifest(ctx, tx, manifest.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair completion: %w", err)
+	}
+	return completed, nil
+}
+
+func (r *PostgresRepository) validateDB() error {
+	if r == nil || r.db == nil {
+		return xerrors.New("postgres db is required for CSCB repair")
+	}
+	return nil
+}
+
+func loadCandidateByKey(ctx context.Context, q queryer, tag uint32, objectKey string) (*Manifest, error) {
+	const query = `
+		SELECT
+			bm.id,
+			EXISTS (
+				SELECT 1 FROM canonical_blocks cb
+				WHERE cb.block_metadata_id = bm.id AND cb.tag = bm.tag AND cb.height = bm.height
+			) AS canonical,
+			bm.tag,
+			bm.height,
+			COALESCE(bm.hash, ''),
+			bm.skipped,
+			(bm.single_block_retention_fenced_at IS NOT NULL),
+			(retirement.block_metadata_id IS NOT NULL),
+			COALESCE(shadow.single_block_object_key_main, ''),
+			(shadow.single_block_object_deleted_at IS NOT NULL),
+			COALESCE(shadow.consolidated_object_key_main, ''),
+			bm.byte_offset,
+			bm.byte_length,
+			bm.uncompressed_length
+		FROM block_metadata bm
+		LEFT JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+		LEFT JOIN block_single_block_retention retirement ON retirement.block_metadata_id = bm.id
+		WHERE bm.tag = $1
+			AND bm.object_key_main = $2
+			AND bm.object_format = $3
+		ORDER BY bm.height ASC, bm.id ASC`
+	rows, err := q.QueryContext(ctx, query, tag, objectKey, api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query active CSCB repair rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	manifest := &Manifest{
+		Tag:                      tag,
+		OldConsolidatedObjectKey: objectKey,
+		StartHeight:              ^uint64(0),
+	}
+	for rows.Next() {
+		var block Block
+		var oldOffset, oldLength, oldUncompressed sql.NullInt64
+		if err := rows.Scan(
+			&block.BlockMetadataID,
+			&block.Canonical,
+			&block.Tag,
+			&block.Height,
+			&block.Hash,
+			&block.Skipped,
+			&block.RetirementFenced,
+			&block.RetirementManifestExists,
+			&block.SingleBlockObjectKey,
+			&block.SingleBlockObjectDeleted,
+			&block.OldConsolidatedObjectKey,
+			&oldOffset,
+			&oldLength,
+			&oldUncompressed,
+		); err != nil {
+			return nil, xerrors.Errorf("failed to scan active CSCB repair row: %w", err)
+		}
+		if oldOffset.Valid && oldOffset.Int64 >= 0 {
+			block.OldByteOffset = uint64(oldOffset.Int64)
+		}
+		if oldLength.Valid && oldLength.Int64 >= 0 {
+			block.OldByteLength = uint64(oldLength.Int64)
+		}
+		if oldUncompressed.Valid && oldUncompressed.Int64 >= 0 {
+			block.OldUncompressedLength = uint64(oldUncompressed.Int64)
+		}
+		manifest.Blocks = append(manifest.Blocks, block)
+		manifest.TotalBlockCount++
+		if block.Canonical {
+			manifest.CanonicalBlockCount++
+		}
+		if block.Height < manifest.StartHeight {
+			manifest.StartHeight = block.Height
+		}
+		if block.Height == ^uint64(0) {
+			return nil, xerrors.New("CSCB repair row height overflows exclusive end height")
+		}
+		if block.Height+1 > manifest.EndHeight {
+			manifest.EndHeight = block.Height + 1
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate active CSCB repair rows: %w", err)
+	}
+	if len(manifest.Blocks) == 0 {
+		return nil, xerrors.Errorf("active CSCB repair object %q has no metadata references", objectKey)
+	}
+	return manifest, nil
+}
+
+func loadManifest(ctx context.Context, q queryer, repairID int64, forUpdate bool) (*Manifest, error) {
+	suffix := ""
+	if forUpdate {
+		suffix = " FOR UPDATE"
+	}
+	query := fmt.Sprintf(`SELECT %s FROM cscb_repair_manifest WHERE id = $1%s`, manifestColumns, suffix)
+	manifest, err := scanManifest(q.QueryRowContext(ctx, query, repairID))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, xerrors.Errorf("CSCB repair manifest not found: id=%d", repairID)
+		}
+		return nil, xerrors.Errorf("failed to load CSCB repair manifest: %w", err)
+	}
+	if err := loadManifestBlocks(ctx, q, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func scanManifest(row rowScanner) (*Manifest, error) {
+	var manifest Manifest
+	var state string
+	var newKey, newVersionID, newETag sql.NullString
+	var newBytes sql.NullInt64
+	var restoredAt, verifiedAt, oldDeletedAt, completedAt sql.NullTime
+	if err := row.Scan(
+		&manifest.ID,
+		&manifest.Tag,
+		&state,
+		&manifest.Bucket,
+		&manifest.OldConsolidatedObjectKey,
+		&manifest.OldConsolidatedObjectVersion.VersionID,
+		&manifest.OldConsolidatedObjectVersion.ETag,
+		&manifest.OldConsolidatedObjectVersion.Bytes,
+		&manifest.StartHeight,
+		&manifest.EndHeight,
+		&manifest.CanonicalBlockCount,
+		&manifest.TotalBlockCount,
+		&manifest.RowSetSHA256,
+		&newKey,
+		&newVersionID,
+		&newETag,
+		&newBytes,
+		&manifest.Outcome,
+		&manifest.PreparedAt,
+		&restoredAt,
+		&verifiedAt,
+		&oldDeletedAt,
+		&completedAt,
+	); err != nil {
+		return nil, err
+	}
+	manifest.State = State(state)
+	manifest.NewConsolidatedObjectKey = newKey.String
+	manifest.NewConsolidatedObjectVersion.VersionID = newVersionID.String
+	manifest.NewConsolidatedObjectVersion.ETag = newETag.String
+	if newBytes.Valid && newBytes.Int64 > 0 {
+		manifest.NewConsolidatedObjectVersion.Bytes = uint64(newBytes.Int64)
+	}
+	manifest.RestoredAt = nullableTime(restoredAt)
+	manifest.VerifiedAt = nullableTime(verifiedAt)
+	manifest.OldObjectDeletedAt = nullableTime(oldDeletedAt)
+	manifest.CompletedAt = nullableTime(completedAt)
+	return &manifest, nil
+}
+
+func loadManifestBlocks(ctx context.Context, q queryer, manifest *Manifest) error {
+	const query = `
+		SELECT block_metadata_id, canonical, tag, height, COALESCE(hash, ''),
+			single_block_object_key_main, single_block_object_version_id,
+			single_block_object_etag, single_block_object_bytes, payload_sha256,
+			old_byte_offset, old_byte_length, old_uncompressed_length
+		FROM cscb_repair_block
+		WHERE repair_id = $1
+		ORDER BY height ASC, block_metadata_id ASC`
+	rows, err := q.QueryContext(ctx, query, manifest.ID)
+	if err != nil {
+		return xerrors.Errorf("failed to query CSCB repair blocks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	manifest.Blocks = nil
+	for rows.Next() {
+		var block Block
+		block.OldConsolidatedObjectKey = manifest.OldConsolidatedObjectKey
+		if err := rows.Scan(
+			&block.BlockMetadataID,
+			&block.Canonical,
+			&block.Tag,
+			&block.Height,
+			&block.Hash,
+			&block.SingleBlockObjectKey,
+			&block.SingleBlockObjectVersion.VersionID,
+			&block.SingleBlockObjectVersion.ETag,
+			&block.SingleBlockObjectVersion.Bytes,
+			&block.PayloadSHA256,
+			&block.OldByteOffset,
+			&block.OldByteLength,
+			&block.OldUncompressedLength,
+		); err != nil {
+			return xerrors.Errorf("failed to scan CSCB repair block: %w", err)
+		}
+		manifest.Blocks = append(manifest.Blocks, block)
+	}
+	if err := rows.Err(); err != nil {
+		return xerrors.Errorf("failed to iterate CSCB repair blocks: %w", err)
+	}
+	if manifest.ID != 0 && uint64(len(manifest.Blocks)) != manifest.TotalBlockCount {
+		return xerrors.Errorf(
+			"CSCB repair manifest block count mismatch: id=%d expected=%d actual=%d",
+			manifest.ID,
+			manifest.TotalBlockCount,
+			len(manifest.Blocks),
+		)
+	}
+	return nil
+}
+
+func loadRebuiltBlocks(ctx context.Context, q queryer, manifest *Manifest) error {
+	const query = `
+		SELECT
+			block.block_metadata_id,
+			EXISTS (
+				SELECT 1 FROM canonical_blocks cb
+				WHERE cb.block_metadata_id = bm.id AND cb.tag = bm.tag AND cb.height = bm.height
+			) AS canonical,
+			COALESCE(bm.object_key_main, ''),
+			bm.object_format,
+			bm.byte_offset,
+			bm.byte_length,
+			bm.uncompressed_length,
+			COALESCE(shadow.consolidated_object_key_main, ''),
+			shadow.validated_at,
+			shadow.single_block_retention_started_at,
+			shadow.single_block_delete_after
+		FROM cscb_repair_block block
+		JOIN block_metadata bm ON bm.id = block.block_metadata_id
+		LEFT JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+		WHERE block.repair_id = $1
+		ORDER BY block.height ASC, block.block_metadata_id ASC`
+	rows, err := q.QueryContext(ctx, query, manifest.ID)
+	if err != nil {
+		return xerrors.Errorf("failed to query rebuilt CSCB repair rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	blocksByID := make(map[int64]*Block, len(manifest.Blocks))
+	for i := range manifest.Blocks {
+		blocksByID[manifest.Blocks[i].BlockMetadataID] = &manifest.Blocks[i]
+	}
+	seen := 0
+	for rows.Next() {
+		var id int64
+		var canonical bool
+		var activeOffset, activeLength, activeUncompressed sql.NullInt64
+		var validatedAt, retentionStartedAt, deleteAfter sql.NullTime
+		var activeKey, newKey string
+		var objectFormat int32
+		if err := rows.Scan(
+			&id,
+			&canonical,
+			&activeKey,
+			&objectFormat,
+			&activeOffset,
+			&activeLength,
+			&activeUncompressed,
+			&newKey,
+			&validatedAt,
+			&retentionStartedAt,
+			&deleteAfter,
+		); err != nil {
+			return xerrors.Errorf("failed to scan rebuilt CSCB repair row: %w", err)
+		}
+		block, ok := blocksByID[id]
+		if !ok {
+			return xerrors.Errorf("rebuilt CSCB repair returned unexpected metadata_id=%d", id)
+		}
+		if canonical != block.Canonical {
+			return xerrors.Errorf("canonical identity changed during CSCB repair for metadata_id=%d", id)
+		}
+		block.ActiveObjectKey = activeKey
+		block.ActiveObjectFormat = objectFormat
+		block.NewConsolidatedObjectKey = newKey
+		block.NewByteOffset = nullableUint64(activeOffset)
+		block.NewByteLength = nullableUint64(activeLength)
+		block.NewUncompressedLength = nullableUint64(activeUncompressed)
+		block.NewValidatedAt = nullableTime(validatedAt)
+		block.NewRetentionStartedAt = nullableTime(retentionStartedAt)
+		block.NewSingleBlockDeleteAfter = nullableTime(deleteAfter)
+		seen++
+	}
+	if err := rows.Err(); err != nil {
+		return xerrors.Errorf("failed to iterate rebuilt CSCB repair rows: %w", err)
+	}
+	if uint64(seen) != manifest.TotalBlockCount {
+		return xerrors.Errorf("rebuilt CSCB repair row count mismatch: expected=%d actual=%d", manifest.TotalBlockCount, seen)
+	}
+	return nil
+}
+
+func lockCandidateRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
+	ordered := append([]Block(nil), blocks...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Tag != ordered[j].Tag {
+			return ordered[i].Tag < ordered[j].Tag
+		}
+		if ordered[i].Height != ordered[j].Height {
+			return ordered[i].Height < ordered[j].Height
+		}
+		if ordered[i].Hash != ordered[j].Hash {
+			return ordered[i].Hash < ordered[j].Hash
+		}
+		return ordered[i].BlockMetadataID < ordered[j].BlockMetadataID
+	})
+	ids := make([]int64, 0, len(ordered))
+	for _, block := range ordered {
+		if err := retirementlock.Acquire(ctx, tx, block.Tag, block.Height, block.Hash); err != nil {
+			return err
+		}
+		ids = append(ids, block.BlockMetadataID)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT bm.id
+		FROM block_metadata bm
+		JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+		WHERE bm.id = ANY($1)
+		ORDER BY bm.id
+		FOR UPDATE OF bm, shadow`, pq.Array(ids))
+	if err != nil {
+		return xerrors.Errorf("failed to lock CSCB repair metadata rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return xerrors.Errorf("failed to iterate locked CSCB repair rows: %w", err)
+	}
+	if count != len(ids) {
+		return xerrors.Errorf("CSCB repair lock count mismatch: expected=%d actual=%d", len(ids), count)
+	}
+	return nil
+}
+
+func lockRebuiltRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
+	ids := make([]int64, 0, len(blocks))
+	for _, block := range blocks {
+		ids = append(ids, block.BlockMetadataID)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id FROM block_metadata
+		WHERE id = ANY($1)
+		ORDER BY id
+		FOR UPDATE`, pq.Array(ids))
+	if err != nil {
+		return xerrors.Errorf("failed to lock rebuilt block metadata: %w", err)
+	}
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return xerrors.Errorf("failed to iterate locked rebuilt block metadata: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return xerrors.Errorf("failed to close rebuilt block metadata rows: %w", err)
+	}
+	if count != len(ids) {
+		return xerrors.Errorf("rebuilt metadata lock count mismatch: expected=%d actual=%d", len(ids), count)
+	}
+	shadowRows, err := tx.QueryContext(ctx, `
+		SELECT block_metadata_id FROM block_consolidation_shadow
+		WHERE block_metadata_id = ANY($1)
+		ORDER BY block_metadata_id
+		FOR UPDATE`, pq.Array(ids))
+	if err != nil {
+		return xerrors.Errorf("failed to lock rebuilt consolidation shadows: %w", err)
+	}
+	defer func() { _ = shadowRows.Close() }()
+	for shadowRows.Next() {
+	}
+	return shadowRows.Err()
+}
+
+func compareCandidateRows(current *Manifest, pinned *Manifest) error {
+	if current == nil || pinned == nil {
+		return xerrors.New("CSCB repair candidate is required")
+	}
+	if current.Tag != pinned.Tag ||
+		current.OldConsolidatedObjectKey != pinned.OldConsolidatedObjectKey ||
+		current.StartHeight != pinned.StartHeight ||
+		current.EndHeight != pinned.EndHeight ||
+		current.CanonicalBlockCount != pinned.CanonicalBlockCount ||
+		current.TotalBlockCount != pinned.TotalBlockCount ||
+		len(current.Blocks) != len(pinned.Blocks) {
+		return xerrors.Errorf("active CSCB repair candidate changed for old object %q", pinned.OldConsolidatedObjectKey)
+	}
+	for i := range pinned.Blocks {
+		a := current.Blocks[i]
+		b := pinned.Blocks[i]
+		if a.BlockMetadataID != b.BlockMetadataID ||
+			a.Canonical != b.Canonical ||
+			a.Tag != b.Tag ||
+			a.Height != b.Height ||
+			a.Hash != b.Hash ||
+			a.Skipped ||
+			a.RetirementFenced ||
+			a.RetirementManifestExists ||
+			a.SingleBlockObjectKey != b.SingleBlockObjectKey ||
+			a.SingleBlockObjectDeleted ||
+			a.OldConsolidatedObjectKey != b.OldConsolidatedObjectKey ||
+			a.OldByteOffset != b.OldByteOffset ||
+			a.OldByteLength != b.OldByteLength ||
+			a.OldUncompressedLength != b.OldUncompressedLength {
+			return xerrors.Errorf("active CSCB repair row changed for metadata_id=%d", b.BlockMetadataID)
+		}
+	}
+	return nil
+}
+
+func validateRebuiltMetadata(manifest *Manifest, objectKey string) error {
+	if manifest.RestoredAt == nil {
+		return xerrors.Errorf("CSCB repair restore timestamp is missing: id=%d", manifest.ID)
+	}
+	canonicalCount := uint64(0)
+	for _, block := range manifest.Blocks {
+		if !block.Canonical {
+			if block.ActiveObjectKey != block.SingleBlockObjectKey ||
+				block.ActiveObjectFormat != int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK) ||
+				block.NewConsolidatedObjectKey != "" ||
+				block.NewByteOffset != 0 ||
+				block.NewByteLength != 0 ||
+				block.NewUncompressedLength != 0 ||
+				block.NewValidatedAt != nil ||
+				block.NewRetentionStartedAt != nil ||
+				block.NewSingleBlockDeleteAfter != nil {
+				return xerrors.Errorf("non-canonical row did not remain on single-block storage: metadata_id=%d", block.BlockMetadataID)
+			}
+			continue
+		}
+		canonicalCount++
+		if block.ActiveObjectKey != objectKey ||
+			block.NewConsolidatedObjectKey != objectKey ||
+			block.ActiveObjectFormat != int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH) ||
+			block.NewByteLength == 0 ||
+			block.NewUncompressedLength == 0 ||
+			block.NewValidatedAt == nil ||
+			block.NewRetentionStartedAt == nil ||
+			block.NewSingleBlockDeleteAfter == nil ||
+			block.NewRetentionStartedAt.Before(*manifest.RestoredAt) ||
+			!block.NewSingleBlockDeleteAfter.After(*block.NewRetentionStartedAt) {
+			return xerrors.Errorf("canonical row is not on a freshly promoted CSCB: metadata_id=%d", block.BlockMetadataID)
+		}
+		if block.NewSingleBlockDeleteAfter.Before(block.NewRetentionStartedAt.Add(72 * time.Hour)) {
+			return xerrors.Errorf(
+				"canonical row does not have the required 72-hour single-block retention: metadata_id=%d",
+				block.BlockMetadataID,
+			)
+		}
+	}
+	if canonicalCount != manifest.CanonicalBlockCount {
+		return xerrors.Errorf("rebuilt canonical block count mismatch: expected=%d actual=%d", manifest.CanonicalBlockCount, canonicalCount)
+	}
+	if objectKey == manifest.OldConsolidatedObjectKey {
+		return xerrors.Errorf("rebuilt CSCB reused dirty object key %q", objectKey)
+	}
+	return nil
+}
+
+func requireNoOldReferences(ctx context.Context, q queryer, objectKey string) error {
+	const query = `
+		SELECT
+			(SELECT COUNT(*) FROM block_metadata WHERE object_key_main = $1)
+			+
+			(SELECT COUNT(*) FROM block_consolidation_shadow WHERE consolidated_object_key_main = $1)`
+	var references uint64
+	if err := q.QueryRowContext(ctx, query, objectKey).Scan(&references); err != nil {
+		return xerrors.Errorf("failed to count old CSCB references: %w", err)
+	}
+	if references != 0 {
+		return xerrors.Errorf("old CSCB %q still has %d database references", objectKey, references)
+	}
+	return nil
+}
+
+func validatePreparedInput(manifest *Manifest) error {
+	if manifest == nil || manifest.Tag == 0 || manifest.Bucket == "" ||
+		manifest.OldConsolidatedObjectKey == "" ||
+		manifest.OldConsolidatedObjectVersion.VersionID == "" ||
+		manifest.OldConsolidatedObjectVersion.ETag == "" ||
+		manifest.OldConsolidatedObjectVersion.Bytes == 0 ||
+		manifest.EndHeight <= manifest.StartHeight ||
+		manifest.CanonicalBlockCount == 0 ||
+		manifest.TotalBlockCount != uint64(len(manifest.Blocks)) ||
+		len(manifest.RowSetSHA256) != 64 {
+		return xerrors.New("complete pinned CSCB repair manifest is required")
+	}
+	for _, block := range manifest.Blocks {
+		if block.BlockMetadataID == 0 || block.Tag != manifest.Tag || block.SingleBlockObjectKey == "" ||
+			block.SingleBlockObjectVersion.VersionID == "" || block.SingleBlockObjectVersion.ETag == "" ||
+			block.SingleBlockObjectVersion.Bytes == 0 || len(block.PayloadSHA256) != 64 ||
+			block.OldConsolidatedObjectKey != manifest.OldConsolidatedObjectKey ||
+			block.OldByteLength == 0 || block.OldUncompressedLength == 0 {
+			return xerrors.Errorf("incomplete pinned CSCB repair block metadata_id=%d", block.BlockMetadataID)
+		}
+	}
+	return nil
+}
+
+func samePreparedManifest(actual *Manifest, expected *Manifest) bool {
+	if actual == nil || expected == nil ||
+		actual.Tag != expected.Tag ||
+		actual.State != StatePrepared ||
+		actual.Bucket != expected.Bucket ||
+		actual.OldConsolidatedObjectKey != expected.OldConsolidatedObjectKey ||
+		actual.OldConsolidatedObjectVersion != expected.OldConsolidatedObjectVersion ||
+		actual.StartHeight != expected.StartHeight ||
+		actual.EndHeight != expected.EndHeight ||
+		actual.CanonicalBlockCount != expected.CanonicalBlockCount ||
+		actual.TotalBlockCount != expected.TotalBlockCount ||
+		actual.RowSetSHA256 != expected.RowSetSHA256 ||
+		len(actual.Blocks) != len(expected.Blocks) {
+		return false
+	}
+	for i := range actual.Blocks {
+		a := actual.Blocks[i]
+		b := expected.Blocks[i]
+		if a.BlockMetadataID != b.BlockMetadataID || a.Canonical != b.Canonical ||
+			a.Tag != b.Tag || a.Height != b.Height || a.Hash != b.Hash ||
+			a.SingleBlockObjectKey != b.SingleBlockObjectKey ||
+			a.SingleBlockObjectVersion != b.SingleBlockObjectVersion ||
+			a.PayloadSHA256 != b.PayloadSHA256 ||
+			a.OldByteOffset != b.OldByteOffset || a.OldByteLength != b.OldByteLength ||
+			a.OldUncompressedLength != b.OldUncompressedLength {
+			return false
+		}
+	}
+	return true
+}
+
+func requireRowsAffected(result sql.Result, expected uint64, action string) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return xerrors.Errorf("failed to inspect %s result: %w", action, err)
+	}
+	if uint64(rows) != expected {
+		return xerrors.Errorf("%s guard failed: expected=%d actual=%d", action, expected, rows)
+	}
+	return nil
+}
+
+func nullableUint64(value sql.NullInt64) uint64 {
+	if !value.Valid || value.Int64 < 0 {
+		return 0
+	}
+	return uint64(value.Int64)
+}
+
+func nullableTime(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Time
+	return &result
+}

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -30,6 +30,7 @@ func NewRepairer(repository Repository, store retirement.ObjectStore, bucket str
 
 func (r *repairerImpl) PrepareNext(
 	ctx context.Context,
+	executionKey string,
 	tag uint32,
 	startHeight uint64,
 	endHeight uint64,
@@ -39,6 +40,25 @@ func (r *repairerImpl) PrepareNext(
 	if err := r.validate(); err != nil {
 		return nil, err
 	}
+	if !validExecutionKey(executionKey) {
+		return nil, xerrors.New("valid CSCB repair execution key is required")
+	}
+	bound, found, err := r.repository.FindByExecutionKey(ctx, executionKey)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		if bound == nil {
+			return nil, nil
+		}
+		if bound.Tag != tag {
+			return nil, xerrors.Errorf("bound CSCB repair tag changed: expected=%d actual=%d", tag, bound.Tag)
+		}
+		if err := validateCandidate(bound, startHeight, endHeight, maxBlocks); err != nil {
+			return nil, xerrors.Errorf("bound CSCB repair does not fit the approved request: %w", err)
+		}
+		return bound, nil
+	}
 	pending, err := r.repository.FindPending(ctx, tag)
 	if err != nil {
 		return nil, err
@@ -47,11 +67,14 @@ func (r *repairerImpl) PrepareNext(
 		if err := validateCandidate(pending, startHeight, endHeight, maxBlocks); err != nil {
 			return nil, xerrors.Errorf("pending CSCB repair does not fit the approved request: %w", err)
 		}
-		return pending, nil
+		return r.repository.BindExecutionKey(ctx, executionKey, pending.ID)
 	}
 	candidate, err := r.repository.FindNextCandidate(ctx, tag, startHeight, endHeight)
-	if err != nil || candidate == nil {
-		return candidate, err
+	if err != nil {
+		return nil, err
+	}
+	if candidate == nil {
+		return r.repository.BindNoCandidateExecution(ctx, executionKey)
 	}
 	if err := validateCandidate(candidate, startHeight, endHeight, maxBlocks); err != nil {
 		return nil, err
@@ -98,6 +121,10 @@ func (r *repairerImpl) PrepareNext(
 	prepared, err := r.repository.Prepare(ctx, candidate)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to persist CSCB repair manifest: %w", err)
+	}
+	prepared, err = r.repository.BindExecutionKey(ctx, executionKey, prepared.ID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to bind CSCB repair execution: %w", err)
 	}
 	reportProgress(progress, "prepared", len(candidate.Blocks), len(candidate.Blocks), candidate.EndHeight-1)
 	return prepared, nil
@@ -222,43 +249,50 @@ func (r *repairerImpl) DeleteOldObject(ctx context.Context, repairID int64) (*Ma
 	if manifest.State != StateVerified {
 		return nil, xerrors.Errorf("CSCB repair must be verified before old object deletion: id=%d state=%s", manifest.ID, manifest.State)
 	}
-	topology, err := r.store.ListObjectVersions(ctx, manifest.Bucket, manifest.OldConsolidatedObjectKey)
-	if err != nil {
-		return nil, err
-	}
-	if len(topology.Versions) == 0 && len(topology.DeleteMarkers) == 0 {
-		return r.repository.Complete(ctx, manifest.ID, completedOutcome)
-	}
-	if err := r.requirePinnedObjectVersion(
+	return r.repository.CompleteWithOldObjectDeletion(
 		ctx,
-		manifest.NewConsolidatedObjectKey,
-		manifest.NewConsolidatedObjectVersion,
-	); err != nil {
-		return nil, xerrors.Errorf("rebuilt CSCB changed before old-object deletion: %w", err)
-	}
-	if err := requireExactTopology(topology, manifest.OldConsolidatedObjectVersion); err != nil {
-		return nil, xerrors.Errorf("dirty CSCB topology changed before deletion: %w", err)
-	}
-	if err := r.store.DeleteObjectVersion(
-		ctx,
-		manifest.Bucket,
-		manifest.OldConsolidatedObjectKey,
-		manifest.OldConsolidatedObjectVersion.VersionID,
-	); err != nil {
-		return nil, xerrors.Errorf("failed to delete pinned dirty CSCB version: %w", err)
-	}
-	topology, err = r.store.ListObjectVersions(ctx, manifest.Bucket, manifest.OldConsolidatedObjectKey)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to verify dirty CSCB deletion: %w", err)
-	}
-	if len(topology.Versions) != 0 || len(topology.DeleteMarkers) != 0 {
-		return nil, xerrors.Errorf(
-			"dirty CSCB still has versions after exact-version deletion: versions=%d delete_markers=%d",
-			len(topology.Versions),
-			len(topology.DeleteMarkers),
-		)
-	}
-	return r.repository.Complete(ctx, manifest.ID, completedOutcome)
+		manifest.ID,
+		completedOutcome,
+		func(locked *Manifest) error {
+			if err := r.requirePinnedObjectVersion(
+				ctx,
+				locked.NewConsolidatedObjectKey,
+				locked.NewConsolidatedObjectVersion,
+			); err != nil {
+				return xerrors.Errorf("rebuilt CSCB changed before old-object deletion: %w", err)
+			}
+			topology, err := r.store.ListObjectVersions(ctx, locked.Bucket, locked.OldConsolidatedObjectKey)
+			if err != nil {
+				return xerrors.Errorf("failed to inspect old CSCB before deletion: %w", err)
+			}
+			if len(topology.Versions) == 0 && len(topology.DeleteMarkers) == 0 {
+				return nil
+			}
+			if err := requireExactTopology(topology, locked.OldConsolidatedObjectVersion); err != nil {
+				return xerrors.Errorf("old CSCB topology changed before deletion: %w", err)
+			}
+			if err := r.store.DeleteObjectVersion(
+				ctx,
+				locked.Bucket,
+				locked.OldConsolidatedObjectKey,
+				locked.OldConsolidatedObjectVersion.VersionID,
+			); err != nil {
+				return xerrors.Errorf("failed to delete pinned old CSCB version: %w", err)
+			}
+			topology, err = r.store.ListObjectVersions(ctx, locked.Bucket, locked.OldConsolidatedObjectKey)
+			if err != nil {
+				return xerrors.Errorf("failed to verify old CSCB deletion: %w", err)
+			}
+			if len(topology.Versions) != 0 || len(topology.DeleteMarkers) != 0 {
+				return xerrors.Errorf(
+					"old CSCB still has versions after exact-version deletion: versions=%d delete_markers=%d",
+					len(topology.Versions),
+					len(topology.DeleteMarkers),
+				)
+			}
+			return nil
+		},
+	)
 }
 
 func (r *repairerImpl) validate() error {
@@ -301,6 +335,18 @@ func validateCandidate(manifest *Manifest, startHeight uint64, endHeight uint64,
 		}
 	}
 	return nil
+}
+
+func validExecutionKey(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *repairerImpl) inspectExactObjectVersion(ctx context.Context, key string) (ObjectVersion, error) {

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -12,7 +12,10 @@ import (
 	"github.com/coinbase/chainstorage/internal/storage/retirement"
 )
 
-const completedOutcome = "old_consolidated_object_version_deleted"
+const (
+	completedOutcome    = "old_consolidated_object_retained_unreferenced"
+	alreadyCleanOutcome = OutcomeAlreadyCleanStorageNeutral
+)
 
 type repairerImpl struct {
 	repository Repository
@@ -54,80 +57,103 @@ func (r *repairerImpl) PrepareNext(
 		if bound.Tag != tag {
 			return nil, xerrors.Errorf("bound CSCB repair tag changed: expected=%d actual=%d", tag, bound.Tag)
 		}
-		if err := validateCandidate(bound, startHeight, endHeight, maxBlocks); err != nil {
+		if err := validateApprovedManifest(bound, startHeight, endHeight, maxBlocks); err != nil {
 			return nil, xerrors.Errorf("bound CSCB repair does not fit the approved request: %w", err)
 		}
-		return bound, nil
+		return r.inspectFencedCandidate(ctx, bound, progress)
 	}
 	pending, err := r.repository.FindPending(ctx, tag)
 	if err != nil {
 		return nil, err
 	}
 	if pending != nil {
-		if err := validateCandidate(pending, startHeight, endHeight, maxBlocks); err != nil {
+		if err := validateApprovedManifest(pending, startHeight, endHeight, maxBlocks); err != nil {
 			return nil, xerrors.Errorf("pending CSCB repair does not fit the approved request: %w", err)
 		}
-		return r.repository.BindExecutionKey(ctx, executionKey, pending.ID)
+		bound, err := r.repository.BindExecutionKey(ctx, executionKey, pending.ID)
+		if err != nil {
+			return nil, err
+		}
+		return r.inspectFencedCandidate(ctx, bound, progress)
 	}
 	candidate, err := r.repository.FindNextCandidate(ctx, tag, startHeight, endHeight)
 	if err != nil {
 		return nil, err
 	}
 	if candidate == nil {
-		return r.repository.BindNoCandidateExecution(ctx, executionKey)
+		return r.repository.BindNoCandidateExecution(ctx, executionKey, tag, startHeight, endHeight)
 	}
 	if err := validateCandidate(candidate, startHeight, endHeight, maxBlocks); err != nil {
 		return nil, err
 	}
-
-	oldVersion, err := r.inspectExactObjectVersion(ctx, candidate.OldConsolidatedObjectKey)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to pin dirty CSCB object: %w", err)
-	}
-	candidate.State = StatePrepared
+	candidate.State = StatePreparing
 	candidate.Bucket = r.bucket
-	candidate.OldConsolidatedObjectVersion = oldVersion
-	verifier := retirement.NewPinnedPayloadVerifier(r.store)
 	for i := range candidate.Blocks {
-		block := &candidate.Blocks[i]
+		candidate.Blocks[i].SingleBlockObjectKeySHA256 = objectKeySHA256(candidate.Blocks[i].SingleBlockObjectKey)
+	}
+	candidate.RowSetSHA256 = rowSetSHA256(candidate)
+	fenced, err := r.repository.FenceCandidate(ctx, candidate)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to persist CSCB repair fence: %w", err)
+	}
+	bound, err = r.repository.BindExecutionKey(ctx, executionKey, fenced.ID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to bind CSCB repair execution: %w", err)
+	}
+	return r.inspectFencedCandidate(ctx, bound, progress)
+}
+
+func (r *repairerImpl) inspectFencedCandidate(
+	ctx context.Context,
+	manifest *Manifest,
+	progress Progress,
+) (*Manifest, error) {
+	if manifest == nil || manifest.State != StatePreparing {
+		return manifest, nil
+	}
+	oldVersion, err := r.inspectExactObjectVersion(ctx, manifest.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to pin CSCB repair source object: %w", err)
+	}
+	blocks := append([]Block(nil), manifest.Blocks...)
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	hasStoragePlacement := false
+	for i := range blocks {
+		block := &blocks[i]
+		if objectKeySHA256(block.SingleBlockObjectKey) != block.SingleBlockObjectKeySHA256 {
+			return nil, xerrors.Errorf("single-block object key audit digest changed at height %d", block.Height)
+		}
 		singleVersion, err := r.inspectExactObjectVersion(ctx, block.SingleBlockObjectKey)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to pin single-block object at height %d: %w", block.Height, err)
 		}
 		block.SingleBlockObjectVersion = singleVersion
-		payload := makePayloadCandidate(candidate, block, candidate.OldConsolidatedObjectKey, oldVersion)
+		payload := makePayloadCandidate(manifest, block, manifest.OldConsolidatedObjectKey, oldVersion)
 		singleInspection, err := verifier.InspectSingleBlock(ctx, payload)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to verify pinned single-block payload at height %d: %w", block.Height, err)
 		}
 		oldInspection, err := verifier.InspectConsolidated(ctx, payload)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to verify dirty CSCB payload at height %d: %w", block.Height, err)
+			return nil, xerrors.Errorf("failed to verify source CSCB payload at height %d: %w", block.Height, err)
 		}
-		if !oldInspection.HasStoragePlacement {
-			return nil, xerrors.Errorf(
-				"CSCB repair candidate is already storage-neutral at height %d object=%q",
-				block.Height,
-				candidate.OldConsolidatedObjectKey,
-			)
-		}
+		hasStoragePlacement = hasStoragePlacement || oldInspection.HasStoragePlacement
 		if singleInspection.CanonicalSHA256 != oldInspection.CanonicalSHA256 {
-			return nil, xerrors.Errorf("single-block and dirty CSCB payloads differ at height %d", block.Height)
+			return nil, xerrors.Errorf("single-block and CSCB payloads differ at height %d", block.Height)
 		}
 		block.PayloadSHA256 = singleInspection.CanonicalSHA256
-		reportProgress(progress, "prepare_payload_verified", i+1, len(candidate.Blocks), block.Height)
+		reportProgress(progress, "prepare_payload_verified", i+1, len(blocks), block.Height)
 	}
-	candidate.RowSetSHA256 = rowSetSHA256(candidate)
-	prepared, err := r.repository.Prepare(ctx, candidate)
+	inspected, err := r.repository.RecordInspection(ctx, manifest.ID, oldVersion, blocks, !hasStoragePlacement)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to persist CSCB repair manifest: %w", err)
+		return nil, xerrors.Errorf("failed to persist CSCB repair inspection: %w", err)
 	}
-	prepared, err = r.repository.BindExecutionKey(ctx, executionKey, prepared.ID)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to bind CSCB repair execution: %w", err)
+	stage := "prepared"
+	if inspected.State == StateCompleted && inspected.Outcome == alreadyCleanOutcome {
+		stage = "already_clean_storage_neutral"
 	}
-	reportProgress(progress, "prepared", len(candidate.Blocks), len(candidate.Blocks), candidate.EndHeight-1)
-	return prepared, nil
+	reportProgress(progress, stage, len(inspected.Blocks), len(inspected.Blocks), inspected.EndHeight-1)
+	return inspected, nil
 }
 
 func (r *repairerImpl) Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error) {
@@ -141,19 +167,17 @@ func (r *repairerImpl) Restore(ctx context.Context, repairID int64, progress Pro
 	if manifest.State != StatePrepared {
 		return manifest, nil
 	}
-	restored, err := r.repository.RestoreToSingleBlock(ctx, repairID, func(locked *Manifest) error {
-		if err := r.requirePinnedObjectVersion(ctx, locked.OldConsolidatedObjectKey, locked.OldConsolidatedObjectVersion); err != nil {
-			return xerrors.Errorf("dirty CSCB changed before restore: %w", err)
+	if err := r.requirePinnedObjectVersion(ctx, manifest.OldConsolidatedObjectKey, manifest.OldConsolidatedObjectVersion); err != nil {
+		return nil, xerrors.Errorf("CSCB repair source changed before restore: %w", err)
+	}
+	for i := range manifest.Blocks {
+		block := &manifest.Blocks[i]
+		if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+			return nil, xerrors.Errorf("single-block object changed before restore at height %d: %w", block.Height, err)
 		}
-		for i := range locked.Blocks {
-			block := &locked.Blocks[i]
-			if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
-				return xerrors.Errorf("single-block object changed before restore at height %d: %w", block.Height, err)
-			}
-			reportProgress(progress, "restore_object_revalidated", i+1, len(locked.Blocks), block.Height)
-		}
-		return nil
-	})
+		reportProgress(progress, "restore_object_revalidated", i+1, len(manifest.Blocks), block.Height)
+	}
+	restored, err := r.repository.RestoreToSingleBlock(ctx, repairID)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore single-block metadata: %w", err)
 	}
@@ -235,64 +259,68 @@ func (r *repairerImpl) VerifyRebuilt(ctx context.Context, repairID int64, progre
 	return verified, nil
 }
 
-func (r *repairerImpl) DeleteOldObject(ctx context.Context, repairID int64) (*Manifest, error) {
+func (r *repairerImpl) Complete(ctx context.Context, repairID int64, progress Progress) (*Manifest, error) {
 	if err := r.validate(); err != nil {
 		return nil, err
 	}
-	manifest, err := r.repository.Get(ctx, repairID)
+	manifest, err := r.repository.GetRebuilt(ctx, repairID)
 	if err != nil {
 		return nil, err
 	}
 	if manifest.State == StateCompleted {
 		return manifest, nil
 	}
-	if manifest.State != StateVerified {
-		return nil, xerrors.Errorf("CSCB repair must be verified before old object deletion: id=%d state=%s", manifest.ID, manifest.State)
+	if manifest.CanonicalBlockCount == 0 {
+		if manifest.State != StateRestored {
+			return nil, xerrors.Errorf("zero-canonical CSCB repair must be restored before completion: id=%d state=%s", manifest.ID, manifest.State)
+		}
+	} else if manifest.State != StateVerified {
+		return nil, xerrors.Errorf("CSCB repair must be verified before completion: id=%d state=%s", manifest.ID, manifest.State)
 	}
-	return r.repository.CompleteWithOldObjectDeletion(
-		ctx,
-		manifest.ID,
-		completedOutcome,
-		func(locked *Manifest) error {
-			if err := r.requirePinnedObjectVersion(
-				ctx,
-				locked.NewConsolidatedObjectKey,
-				locked.NewConsolidatedObjectVersion,
-			); err != nil {
-				return xerrors.Errorf("rebuilt CSCB changed before old-object deletion: %w", err)
-			}
-			topology, err := r.store.ListObjectVersions(ctx, locked.Bucket, locked.OldConsolidatedObjectKey)
+	if err := r.requirePinnedObjectVersion(ctx, manifest.OldConsolidatedObjectKey, manifest.OldConsolidatedObjectVersion); err != nil {
+		return nil, xerrors.Errorf("retained CSCB repair source changed before completion: %w", err)
+	}
+	if manifest.CanonicalBlockCount > 0 {
+		if err := r.requirePinnedObjectVersion(
+			ctx,
+			manifest.NewConsolidatedObjectKey,
+			manifest.NewConsolidatedObjectVersion,
+		); err != nil {
+			return nil, xerrors.Errorf("rebuilt CSCB changed before repair completion: %w", err)
+		}
+	}
+
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	for i := range manifest.Blocks {
+		block := &manifest.Blocks[i]
+		if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+			return nil, xerrors.Errorf("single-block object changed before completion at height %d: %w", block.Height, err)
+		}
+		payload := makePayloadCandidate(manifest, block, manifest.NewConsolidatedObjectKey, manifest.NewConsolidatedObjectVersion)
+		singleInspection, err := verifier.InspectSingleBlock(ctx, payload)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to verify retained single-block payload at height %d: %w", block.Height, err)
+		}
+		if singleInspection.CanonicalSHA256 != block.PayloadSHA256 {
+			return nil, xerrors.Errorf("single-block payload digest changed before completion at height %d", block.Height)
+		}
+		if block.Canonical {
+			cleanInspection, err := verifier.InspectConsolidated(ctx, payload)
 			if err != nil {
-				return xerrors.Errorf("failed to inspect old CSCB before deletion: %w", err)
+				return nil, xerrors.Errorf("failed to verify rebuilt CSCB payload before completion at height %d: %w", block.Height, err)
 			}
-			if len(topology.Versions) == 0 && len(topology.DeleteMarkers) == 0 {
-				return nil
+			if cleanInspection.HasStoragePlacement || cleanInspection.CanonicalSHA256 != block.PayloadSHA256 {
+				return nil, xerrors.Errorf("rebuilt CSCB payload is not storage-neutral and identical at height %d", block.Height)
 			}
-			if err := requireExactTopology(topology, locked.OldConsolidatedObjectVersion); err != nil {
-				return xerrors.Errorf("old CSCB topology changed before deletion: %w", err)
-			}
-			if err := r.store.DeleteObjectVersion(
-				ctx,
-				locked.Bucket,
-				locked.OldConsolidatedObjectKey,
-				locked.OldConsolidatedObjectVersion.VersionID,
-			); err != nil {
-				return xerrors.Errorf("failed to delete pinned old CSCB version: %w", err)
-			}
-			topology, err = r.store.ListObjectVersions(ctx, locked.Bucket, locked.OldConsolidatedObjectKey)
-			if err != nil {
-				return xerrors.Errorf("failed to verify old CSCB deletion: %w", err)
-			}
-			if len(topology.Versions) != 0 || len(topology.DeleteMarkers) != 0 {
-				return xerrors.Errorf(
-					"old CSCB still has versions after exact-version deletion: versions=%d delete_markers=%d",
-					len(topology.Versions),
-					len(topology.DeleteMarkers),
-				)
-			}
-			return nil
-		},
-	)
+		}
+		reportProgress(progress, "completion_payload_verified", i+1, len(manifest.Blocks), block.Height)
+	}
+	completed, err := r.repository.CompleteRetainingOldObject(ctx, manifest.ID, completedOutcome)
+	if err != nil {
+		return nil, err
+	}
+	reportProgress(progress, "completed", len(completed.Blocks), len(completed.Blocks), completed.EndHeight-1)
+	return completed, nil
 }
 
 func (r *repairerImpl) validate() error {
@@ -303,19 +331,34 @@ func (r *repairerImpl) validate() error {
 }
 
 func validateCandidate(manifest *Manifest, startHeight uint64, endHeight uint64, maxBlocks uint64) error {
+	if err := validateApprovedManifest(manifest, startHeight, endHeight, maxBlocks); err != nil {
+		return err
+	}
+	for _, block := range manifest.Blocks {
+		if block.Skipped || block.RetirementFenced || block.RetirementManifestExists ||
+			block.SingleBlockObjectKey == "" || block.SingleBlockObjectDeleted ||
+			block.OldConsolidatedObjectKey != manifest.OldConsolidatedObjectKey ||
+			block.OldByteLength == 0 || block.OldUncompressedLength == 0 {
+			return xerrors.Errorf("CSCB repair candidate is blocked or incomplete at metadata_id=%d height=%d", block.BlockMetadataID, block.Height)
+		}
+	}
+	return nil
+}
+
+func validateApprovedManifest(manifest *Manifest, startHeight uint64, endHeight uint64, maxBlocks uint64) error {
 	if manifest == nil || manifest.OldConsolidatedObjectKey == "" || len(manifest.Blocks) == 0 {
-		return xerrors.New("active CSCB repair candidate is required")
+		return xerrors.New("active CSCB repair manifest is required")
 	}
 	if maxBlocks == 0 || manifest.TotalBlockCount > maxBlocks || manifest.CanonicalBlockCount > maxBlocks {
 		return xerrors.Errorf(
-			"CSCB repair candidate exceeds one consolidation object: total=%d canonical=%d max_blocks=%d",
+			"CSCB repair manifest exceeds one consolidation object: total=%d canonical=%d max_blocks=%d",
 			manifest.TotalBlockCount,
 			manifest.CanonicalBlockCount,
 			maxBlocks,
 		)
 	}
-	if manifest.CanonicalBlockCount == 0 || manifest.TotalBlockCount != uint64(len(manifest.Blocks)) {
-		return xerrors.New("CSCB repair candidate must contain at least one canonical row and a complete row set")
+	if manifest.TotalBlockCount == 0 || manifest.TotalBlockCount != uint64(len(manifest.Blocks)) {
+		return xerrors.New("CSCB repair manifest must contain a complete non-empty row set")
 	}
 	if manifest.StartHeight < startHeight || manifest.EndHeight > endHeight {
 		return xerrors.Errorf(
@@ -325,14 +368,6 @@ func validateCandidate(manifest *Manifest, startHeight uint64, endHeight uint64,
 			startHeight,
 			endHeight,
 		)
-	}
-	for _, block := range manifest.Blocks {
-		if block.Skipped || block.RetirementFenced || block.RetirementManifestExists ||
-			block.SingleBlockObjectKey == "" || block.SingleBlockObjectDeleted ||
-			block.OldConsolidatedObjectKey != manifest.OldConsolidatedObjectKey ||
-			block.OldByteLength == 0 || block.OldUncompressedLength == 0 {
-			return xerrors.Errorf("CSCB repair candidate is blocked or incomplete at metadata_id=%d height=%d", block.BlockMetadataID, block.Height)
-		}
 	}
 	return nil
 }
@@ -472,7 +507,7 @@ func rowSetSHA256(manifest *Manifest) string {
 	for _, block := range manifest.Blocks {
 		_, _ = fmt.Fprintf(
 			digest,
-			"%d\x1f%t\x1f%d\x1f%d\x1f%d:%s\x1f%d:%s\x1f%d:%s\x1f%d:%s\x1f%d\x1f%d\x1f%d\n",
+			"%d\x1f%t\x1f%d\x1f%d\x1f%d:%s\x1f%d:%s\x1f%s\x1f%d\x1f%d\x1f%d\n",
 			block.BlockMetadataID,
 			block.Canonical,
 			block.Tag,
@@ -481,16 +516,18 @@ func rowSetSHA256(manifest *Manifest) string {
 			block.Hash,
 			len(block.SingleBlockObjectKey),
 			block.SingleBlockObjectKey,
-			len(block.SingleBlockObjectVersion.VersionID),
-			block.SingleBlockObjectVersion.VersionID,
-			len(block.PayloadSHA256),
-			block.PayloadSHA256,
+			block.SingleBlockObjectKeySHA256,
 			block.OldByteOffset,
 			block.OldByteLength,
 			block.OldUncompressedLength,
 		)
 	}
 	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func objectKeySHA256(objectKey string) string {
+	digest := sha256.Sum256([]byte(objectKey))
+	return hex.EncodeToString(digest[:])
 }
 
 func immutableVersionID(versionID string) bool {

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -1,0 +1,455 @@
+package cscbrepair
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
+)
+
+const completedOutcome = "old_consolidated_object_version_deleted"
+
+type repairerImpl struct {
+	repository Repository
+	store      retirement.ObjectStore
+	bucket     string
+}
+
+func NewRepairer(repository Repository, store retirement.ObjectStore, bucket string) Repairer {
+	return &repairerImpl{
+		repository: repository,
+		store:      store,
+		bucket:     bucket,
+	}
+}
+
+func (r *repairerImpl) PrepareNext(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	maxBlocks uint64,
+	progress Progress,
+) (*Manifest, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	pending, err := r.repository.FindPending(ctx, tag)
+	if err != nil {
+		return nil, err
+	}
+	if pending != nil {
+		if err := validateCandidate(pending, startHeight, endHeight, maxBlocks); err != nil {
+			return nil, xerrors.Errorf("pending CSCB repair does not fit the approved request: %w", err)
+		}
+		return pending, nil
+	}
+	candidate, err := r.repository.FindNextCandidate(ctx, tag, startHeight, endHeight)
+	if err != nil || candidate == nil {
+		return candidate, err
+	}
+	if err := validateCandidate(candidate, startHeight, endHeight, maxBlocks); err != nil {
+		return nil, err
+	}
+
+	oldVersion, err := r.inspectExactObjectVersion(ctx, candidate.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to pin dirty CSCB object: %w", err)
+	}
+	candidate.State = StatePrepared
+	candidate.Bucket = r.bucket
+	candidate.OldConsolidatedObjectVersion = oldVersion
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	for i := range candidate.Blocks {
+		block := &candidate.Blocks[i]
+		singleVersion, err := r.inspectExactObjectVersion(ctx, block.SingleBlockObjectKey)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to pin single-block object at height %d: %w", block.Height, err)
+		}
+		block.SingleBlockObjectVersion = singleVersion
+		payload := makePayloadCandidate(candidate, block, candidate.OldConsolidatedObjectKey, oldVersion)
+		singleInspection, err := verifier.InspectSingleBlock(ctx, payload)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to verify pinned single-block payload at height %d: %w", block.Height, err)
+		}
+		oldInspection, err := verifier.InspectConsolidated(ctx, payload)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to verify dirty CSCB payload at height %d: %w", block.Height, err)
+		}
+		if !oldInspection.HasStoragePlacement {
+			return nil, xerrors.Errorf(
+				"CSCB repair candidate is already storage-neutral at height %d object=%q",
+				block.Height,
+				candidate.OldConsolidatedObjectKey,
+			)
+		}
+		if singleInspection.CanonicalSHA256 != oldInspection.CanonicalSHA256 {
+			return nil, xerrors.Errorf("single-block and dirty CSCB payloads differ at height %d", block.Height)
+		}
+		block.PayloadSHA256 = singleInspection.CanonicalSHA256
+		reportProgress(progress, "prepare_payload_verified", i+1, len(candidate.Blocks), block.Height)
+	}
+	candidate.RowSetSHA256 = rowSetSHA256(candidate)
+	prepared, err := r.repository.Prepare(ctx, candidate)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to persist CSCB repair manifest: %w", err)
+	}
+	reportProgress(progress, "prepared", len(candidate.Blocks), len(candidate.Blocks), candidate.EndHeight-1)
+	return prepared, nil
+}
+
+func (r *repairerImpl) Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	manifest, err := r.repository.Get(ctx, repairID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State != StatePrepared {
+		return manifest, nil
+	}
+	restored, err := r.repository.RestoreToSingleBlock(ctx, repairID, func(locked *Manifest) error {
+		if err := r.requirePinnedObjectVersion(ctx, locked.OldConsolidatedObjectKey, locked.OldConsolidatedObjectVersion); err != nil {
+			return xerrors.Errorf("dirty CSCB changed before restore: %w", err)
+		}
+		for i := range locked.Blocks {
+			block := &locked.Blocks[i]
+			if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+				return xerrors.Errorf("single-block object changed before restore at height %d: %w", block.Height, err)
+			}
+			reportProgress(progress, "restore_object_revalidated", i+1, len(locked.Blocks), block.Height)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore single-block metadata: %w", err)
+	}
+	reportProgress(progress, "restored", len(restored.Blocks), len(restored.Blocks), restored.EndHeight-1)
+	return restored, nil
+}
+
+func (r *repairerImpl) Get(ctx context.Context, repairID int64) (*Manifest, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	return r.repository.Get(ctx, repairID)
+}
+
+func (r *repairerImpl) VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	manifest, err := r.repository.GetRebuilt(ctx, repairID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State == StateVerified || manifest.State == StateCompleted {
+		return manifest, nil
+	}
+	if manifest.State != StateRestored {
+		return nil, xerrors.Errorf("CSCB repair must be restored before payload verification: id=%d state=%s", manifest.ID, manifest.State)
+	}
+	newObjectKey, err := rebuiltObjectKey(manifest)
+	if err != nil {
+		return nil, err
+	}
+	newVersion, err := r.inspectExactObjectVersion(ctx, newObjectKey)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to pin rebuilt CSCB object: %w", err)
+	}
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	verifiedCanonical := 0
+	for i := range manifest.Blocks {
+		block := &manifest.Blocks[i]
+		if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+			return nil, xerrors.Errorf("single-block object changed during repair at height %d: %w", block.Height, err)
+		}
+		payload := makePayloadCandidate(manifest, block, newObjectKey, newVersion)
+		singleInspection, err := verifier.InspectSingleBlock(ctx, payload)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to re-read pinned single-block payload at height %d: %w", block.Height, err)
+		}
+		if singleInspection.CanonicalSHA256 != block.PayloadSHA256 {
+			return nil, xerrors.Errorf("single-block payload digest changed during repair at height %d", block.Height)
+		}
+		if block.Canonical {
+			cleanInspection, err := verifier.InspectConsolidated(ctx, payload)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to verify rebuilt CSCB payload at height %d: %w", block.Height, err)
+			}
+			if cleanInspection.HasStoragePlacement {
+				return nil, xerrors.Errorf("rebuilt CSCB retains storage placement at height %d", block.Height)
+			}
+			if cleanInspection.CanonicalSHA256 != block.PayloadSHA256 {
+				return nil, xerrors.Errorf("rebuilt CSCB payload differs from pinned single-block payload at height %d", block.Height)
+			}
+			verifiedCanonical++
+		}
+		reportProgress(progress, "rebuilt_payload_verified", i+1, len(manifest.Blocks), block.Height)
+	}
+	if uint64(verifiedCanonical) != manifest.CanonicalBlockCount {
+		return nil, xerrors.Errorf(
+			"rebuilt CSCB canonical verification count mismatch: expected=%d actual=%d",
+			manifest.CanonicalBlockCount,
+			verifiedCanonical,
+		)
+	}
+	verified, err := r.repository.RecordVerified(ctx, manifest.ID, newObjectKey, newVersion)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to record verified CSCB repair: %w", err)
+	}
+	reportProgress(progress, "verified", len(manifest.Blocks), len(manifest.Blocks), manifest.EndHeight-1)
+	return verified, nil
+}
+
+func (r *repairerImpl) DeleteOldObject(ctx context.Context, repairID int64) (*Manifest, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	manifest, err := r.repository.Get(ctx, repairID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State == StateCompleted {
+		return manifest, nil
+	}
+	if manifest.State != StateVerified {
+		return nil, xerrors.Errorf("CSCB repair must be verified before old object deletion: id=%d state=%s", manifest.ID, manifest.State)
+	}
+	topology, err := r.store.ListObjectVersions(ctx, manifest.Bucket, manifest.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(topology.Versions) == 0 && len(topology.DeleteMarkers) == 0 {
+		return r.repository.Complete(ctx, manifest.ID, completedOutcome)
+	}
+	if err := r.requirePinnedObjectVersion(
+		ctx,
+		manifest.NewConsolidatedObjectKey,
+		manifest.NewConsolidatedObjectVersion,
+	); err != nil {
+		return nil, xerrors.Errorf("rebuilt CSCB changed before old-object deletion: %w", err)
+	}
+	if err := requireExactTopology(topology, manifest.OldConsolidatedObjectVersion); err != nil {
+		return nil, xerrors.Errorf("dirty CSCB topology changed before deletion: %w", err)
+	}
+	if err := r.store.DeleteObjectVersion(
+		ctx,
+		manifest.Bucket,
+		manifest.OldConsolidatedObjectKey,
+		manifest.OldConsolidatedObjectVersion.VersionID,
+	); err != nil {
+		return nil, xerrors.Errorf("failed to delete pinned dirty CSCB version: %w", err)
+	}
+	topology, err = r.store.ListObjectVersions(ctx, manifest.Bucket, manifest.OldConsolidatedObjectKey)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to verify dirty CSCB deletion: %w", err)
+	}
+	if len(topology.Versions) != 0 || len(topology.DeleteMarkers) != 0 {
+		return nil, xerrors.Errorf(
+			"dirty CSCB still has versions after exact-version deletion: versions=%d delete_markers=%d",
+			len(topology.Versions),
+			len(topology.DeleteMarkers),
+		)
+	}
+	return r.repository.Complete(ctx, manifest.ID, completedOutcome)
+}
+
+func (r *repairerImpl) validate() error {
+	if r == nil || r.repository == nil || r.store == nil || r.bucket == "" {
+		return xerrors.New("CSCB repair requires a repository, object store, and bucket")
+	}
+	return nil
+}
+
+func validateCandidate(manifest *Manifest, startHeight uint64, endHeight uint64, maxBlocks uint64) error {
+	if manifest == nil || manifest.OldConsolidatedObjectKey == "" || len(manifest.Blocks) == 0 {
+		return xerrors.New("active CSCB repair candidate is required")
+	}
+	if maxBlocks == 0 || manifest.TotalBlockCount > maxBlocks || manifest.CanonicalBlockCount > maxBlocks {
+		return xerrors.Errorf(
+			"CSCB repair candidate exceeds one consolidation object: total=%d canonical=%d max_blocks=%d",
+			manifest.TotalBlockCount,
+			manifest.CanonicalBlockCount,
+			maxBlocks,
+		)
+	}
+	if manifest.CanonicalBlockCount == 0 || manifest.TotalBlockCount != uint64(len(manifest.Blocks)) {
+		return xerrors.New("CSCB repair candidate must contain at least one canonical row and a complete row set")
+	}
+	if manifest.StartHeight < startHeight || manifest.EndHeight > endHeight {
+		return xerrors.Errorf(
+			"CSCB repair object range [%d, %d) exceeds approved range [%d, %d)",
+			manifest.StartHeight,
+			manifest.EndHeight,
+			startHeight,
+			endHeight,
+		)
+	}
+	for _, block := range manifest.Blocks {
+		if block.Skipped || block.RetirementFenced || block.RetirementManifestExists ||
+			block.SingleBlockObjectKey == "" || block.SingleBlockObjectDeleted ||
+			block.OldConsolidatedObjectKey != manifest.OldConsolidatedObjectKey ||
+			block.OldByteLength == 0 || block.OldUncompressedLength == 0 {
+			return xerrors.Errorf("CSCB repair candidate is blocked or incomplete at metadata_id=%d height=%d", block.BlockMetadataID, block.Height)
+		}
+	}
+	return nil
+}
+
+func (r *repairerImpl) inspectExactObjectVersion(ctx context.Context, key string) (ObjectVersion, error) {
+	topology, err := r.store.ListObjectVersions(ctx, r.bucket, key)
+	if err != nil {
+		return ObjectVersion{}, err
+	}
+	if len(topology.Versions) != 1 || len(topology.DeleteMarkers) != 0 {
+		return ObjectVersion{}, xerrors.Errorf(
+			"object must have exactly one data version and zero delete markers: key=%q versions=%d delete_markers=%d",
+			key,
+			len(topology.Versions),
+			len(topology.DeleteMarkers),
+		)
+	}
+	version := topology.Versions[0]
+	result := ObjectVersion{VersionID: version.VersionID, ETag: version.ETag, Bytes: version.Bytes}
+	if !version.IsLatest || !immutableVersionID(result.VersionID) || result.ETag == "" || result.Bytes == 0 {
+		return ObjectVersion{}, xerrors.Errorf("object current version is not immutable and complete: key=%q", key)
+	}
+	return result, nil
+}
+
+func (r *repairerImpl) requirePinnedObjectVersion(ctx context.Context, key string, expected ObjectVersion) error {
+	topology, err := r.store.ListObjectVersions(ctx, r.bucket, key)
+	if err != nil {
+		return err
+	}
+	return requireExactTopology(topology, expected)
+}
+
+func requireExactTopology(topology retirement.ObjectVersionTopology, expected ObjectVersion) error {
+	if len(topology.Versions) != 1 || len(topology.DeleteMarkers) != 0 {
+		return xerrors.Errorf(
+			"expected one data version and zero delete markers, got versions=%d delete_markers=%d",
+			len(topology.Versions),
+			len(topology.DeleteMarkers),
+		)
+	}
+	version := topology.Versions[0]
+	if !version.IsLatest || version.VersionID != expected.VersionID || version.ETag != expected.ETag || version.Bytes != expected.Bytes {
+		return xerrors.Errorf(
+			"pinned object version changed: version=%q etag=%q bytes=%d latest=%t",
+			version.VersionID,
+			version.ETag,
+			version.Bytes,
+			version.IsLatest,
+		)
+	}
+	return nil
+}
+
+func rebuiltObjectKey(manifest *Manifest) (string, error) {
+	objectKey := ""
+	for _, block := range manifest.Blocks {
+		if !block.Canonical {
+			continue
+		}
+		if block.NewConsolidatedObjectKey == "" || block.NewConsolidatedObjectKey != block.ActiveObjectKey {
+			return "", xerrors.Errorf("rebuilt CSCB placement is incomplete at height %d", block.Height)
+		}
+		if objectKey == "" {
+			objectKey = block.NewConsolidatedObjectKey
+			continue
+		}
+		if objectKey != block.NewConsolidatedObjectKey {
+			return "", xerrors.Errorf("one dirty CSCB repair produced multiple new objects: %q and %q", objectKey, block.NewConsolidatedObjectKey)
+		}
+	}
+	if objectKey == "" {
+		return "", xerrors.New("rebuilt CSCB object key is missing")
+	}
+	if objectKey == manifest.OldConsolidatedObjectKey {
+		return "", xerrors.Errorf("rebuilt CSCB reused dirty object key %q", objectKey)
+	}
+	return objectKey, nil
+}
+
+func makePayloadCandidate(
+	manifest *Manifest,
+	block *Block,
+	consolidatedKey string,
+	consolidatedVersion ObjectVersion,
+) retirement.Candidate {
+	return retirement.Candidate{
+		Bucket:             manifest.Bucket,
+		Key:                block.SingleBlockObjectKey,
+		VersionID:          block.SingleBlockObjectVersion.VersionID,
+		Height:             block.Height,
+		Hash:               block.Hash,
+		ConsolidatedKey:    consolidatedKey,
+		Tag:                block.Tag,
+		CSCBVersionID:      consolidatedVersion.VersionID,
+		ByteOffset:         blockPlacementOffset(block, consolidatedKey, manifest.OldConsolidatedObjectKey),
+		ByteLength:         blockPlacementLength(block, consolidatedKey, manifest.OldConsolidatedObjectKey),
+		UncompressedLength: blockPlacementUncompressedLength(block, consolidatedKey, manifest.OldConsolidatedObjectKey),
+	}
+}
+
+func blockPlacementOffset(block *Block, objectKey string, oldObjectKey string) uint64 {
+	if objectKey == oldObjectKey {
+		return block.OldByteOffset
+	}
+	return block.NewByteOffset
+}
+
+func blockPlacementLength(block *Block, objectKey string, oldObjectKey string) uint64 {
+	if objectKey == oldObjectKey {
+		return block.OldByteLength
+	}
+	return block.NewByteLength
+}
+
+func blockPlacementUncompressedLength(block *Block, objectKey string, oldObjectKey string) uint64 {
+	if objectKey == oldObjectKey {
+		return block.OldUncompressedLength
+	}
+	return block.NewUncompressedLength
+}
+
+func rowSetSHA256(manifest *Manifest) string {
+	digest := sha256.New()
+	for _, block := range manifest.Blocks {
+		_, _ = fmt.Fprintf(
+			digest,
+			"%d\x1f%t\x1f%d\x1f%d\x1f%d:%s\x1f%d:%s\x1f%d:%s\x1f%d:%s\x1f%d\x1f%d\x1f%d\n",
+			block.BlockMetadataID,
+			block.Canonical,
+			block.Tag,
+			block.Height,
+			len(block.Hash),
+			block.Hash,
+			len(block.SingleBlockObjectKey),
+			block.SingleBlockObjectKey,
+			len(block.SingleBlockObjectVersion.VersionID),
+			block.SingleBlockObjectVersion.VersionID,
+			len(block.PayloadSHA256),
+			block.PayloadSHA256,
+			block.OldByteOffset,
+			block.OldByteLength,
+			block.OldUncompressedLength,
+		)
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func immutableVersionID(versionID string) bool {
+	value := strings.TrimSpace(versionID)
+	return value != "" && !strings.EqualFold(value, "null")
+}
+
+var _ Repairer = (*repairerImpl)(nil)

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -1,0 +1,275 @@
+package cscbrepair
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+func TestDeleteOldObjectResumesAfterDeleteBeforeDatabaseCompletion(t *testing.T) {
+	manifest := verifiedRepairManifest()
+	repository := &deleteResumeRepository{
+		manifest:         manifest,
+		failNextComplete: true,
+	}
+	store := &deleteResumeObjectStore{
+		oldKey: manifest.OldConsolidatedObjectKey,
+		newKey: manifest.NewConsolidatedObjectKey,
+		oldTopology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
+			VersionID: manifest.OldConsolidatedObjectVersion.VersionID,
+			ETag:      manifest.OldConsolidatedObjectVersion.ETag,
+			Bytes:     manifest.OldConsolidatedObjectVersion.Bytes,
+			IsLatest:  true,
+		}}},
+		newTopology: topologyFor(manifest.NewConsolidatedObjectVersion),
+	}
+	repairer := NewRepairer(repository, store, manifest.Bucket)
+
+	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
+	require.ErrorContains(t, err, "database completion unavailable")
+	require.Equal(t, 1, store.deleteCalls)
+	require.Empty(t, store.oldTopology.Versions)
+	require.Equal(t, StateVerified, repository.manifest.State)
+
+	completed, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
+	require.NoError(t, err)
+	require.Equal(t, StateCompleted, completed.State)
+	require.Equal(t, 1, store.deleteCalls, "resume must not issue a second delete")
+	require.Equal(t, 2, repository.completeCalls)
+}
+
+func TestDeleteOldObjectRejectsVersionTopologyDrift(t *testing.T) {
+	manifest := verifiedRepairManifest()
+	repository := &deleteResumeRepository{manifest: manifest}
+	store := &deleteResumeObjectStore{
+		oldKey: manifest.OldConsolidatedObjectKey,
+		newKey: manifest.NewConsolidatedObjectKey,
+		oldTopology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
+			VersionID: "unexpected-version",
+			ETag:      manifest.OldConsolidatedObjectVersion.ETag,
+			Bytes:     manifest.OldConsolidatedObjectVersion.Bytes,
+			IsLatest:  true,
+		}}},
+		newTopology: topologyFor(manifest.NewConsolidatedObjectVersion),
+	}
+	repairer := NewRepairer(repository, store, manifest.Bucket)
+
+	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
+	require.ErrorContains(t, err, "topology changed before deletion")
+	require.Zero(t, store.deleteCalls)
+	require.Zero(t, repository.completeCalls)
+}
+
+func TestDeleteOldObjectRejectsRebuiltVersionTopologyDrift(t *testing.T) {
+	manifest := verifiedRepairManifest()
+	repository := &deleteResumeRepository{manifest: manifest}
+	store := &deleteResumeObjectStore{
+		oldKey:      manifest.OldConsolidatedObjectKey,
+		newKey:      manifest.NewConsolidatedObjectKey,
+		oldTopology: topologyFor(manifest.OldConsolidatedObjectVersion),
+		newTopology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
+			VersionID: "unexpected-clean-version",
+			ETag:      manifest.NewConsolidatedObjectVersion.ETag,
+			Bytes:     manifest.NewConsolidatedObjectVersion.Bytes,
+			IsLatest:  true,
+		}}},
+	}
+	repairer := NewRepairer(repository, store, manifest.Bucket)
+
+	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
+	require.ErrorContains(t, err, "rebuilt CSCB changed before old-object deletion")
+	require.Zero(t, store.deleteCalls)
+	require.Zero(t, repository.completeCalls)
+}
+
+func TestValidateCandidateRejectsUnsafeSingleBlockState(t *testing.T) {
+	valid := validRepairCandidate()
+	require.NoError(t, validateCandidate(valid, 1000, 1001, 1))
+
+	tests := map[string]func(*Manifest){
+		"retirement fence":         func(candidate *Manifest) { candidate.Blocks[0].RetirementFenced = true },
+		"retirement manifest":      func(candidate *Manifest) { candidate.Blocks[0].RetirementManifestExists = true },
+		"deleted single block":     func(candidate *Manifest) { candidate.Blocks[0].SingleBlockObjectDeleted = true },
+		"missing single block key": func(candidate *Manifest) { candidate.Blocks[0].SingleBlockObjectKey = "" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := validRepairCandidate()
+			mutate(candidate)
+			require.ErrorContains(t, validateCandidate(candidate, 1000, 1001, 1), "blocked or incomplete")
+		})
+	}
+}
+
+func TestPrepareNextRejectsPendingRepairOutsideApprovedRange(t *testing.T) {
+	pending := validRepairCandidate()
+	pending.State = StatePrepared
+	repository := &pendingRepairRepository{pending: pending}
+	repairer := NewRepairer(repository, &deleteResumeObjectStore{}, "repair-bucket")
+
+	_, err := repairer.PrepareNext(context.Background(), 2, 2000, 2001, 1, nil)
+	require.ErrorContains(t, err, "pending CSCB repair does not fit the approved request")
+	require.ErrorContains(t, err, "exceeds approved range")
+}
+
+func TestValidateRebuiltMetadataRequiresFreshRetentionAndCleanNonCanonicalRows(t *testing.T) {
+	restoredAt := time.Now().UTC()
+	validatedAt := restoredAt.Add(time.Second)
+	retentionStartedAt := restoredAt.Add(2 * time.Second)
+	deleteAfter := retentionStartedAt.Add(72 * time.Hour)
+	manifest := &Manifest{
+		ID:                  8,
+		RestoredAt:          &restoredAt,
+		CanonicalBlockCount: 1,
+		Blocks: []Block{
+			{
+				BlockMetadataID:           1,
+				Canonical:                 true,
+				ActiveObjectKey:           "consolidated/clean.cscb.zstd",
+				ActiveObjectFormat:        int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
+				NewConsolidatedObjectKey:  "consolidated/clean.cscb.zstd",
+				NewByteLength:             100,
+				NewUncompressedLength:     200,
+				NewValidatedAt:            &validatedAt,
+				NewRetentionStartedAt:     &retentionStartedAt,
+				NewSingleBlockDeleteAfter: &deleteAfter,
+			},
+			{
+				BlockMetadataID:      2,
+				SingleBlockObjectKey: "single/2.gzip",
+				ActiveObjectKey:      "single/2.gzip",
+				ActiveObjectFormat:   int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK),
+			},
+		},
+	}
+	require.NoError(t, validateRebuiltMetadata(manifest, "consolidated/clean.cscb.zstd"))
+
+	staleStartedAt := restoredAt.Add(-time.Second)
+	manifest.Blocks[0].NewRetentionStartedAt = &staleStartedAt
+	require.ErrorContains(t, validateRebuiltMetadata(manifest, "consolidated/clean.cscb.zstd"), "freshly promoted")
+
+	manifest.Blocks[0].NewRetentionStartedAt = &retentionStartedAt
+	manifest.Blocks[1].NewRetentionStartedAt = &retentionStartedAt
+	require.ErrorContains(t, validateRebuiltMetadata(manifest, "consolidated/clean.cscb.zstd"), "did not remain on single-block storage")
+
+	manifest.Blocks[1].NewRetentionStartedAt = nil
+	tooSoon := retentionStartedAt.Add(71*time.Hour + 59*time.Minute)
+	manifest.Blocks[0].NewSingleBlockDeleteAfter = &tooSoon
+	require.ErrorContains(t, validateRebuiltMetadata(manifest, "consolidated/clean.cscb.zstd"), "required 72-hour")
+}
+
+func validRepairCandidate() *Manifest {
+	return &Manifest{
+		Tag:                      2,
+		OldConsolidatedObjectKey: "consolidated/dirty.cscb.zstd",
+		StartHeight:              1000,
+		EndHeight:                1001,
+		CanonicalBlockCount:      1,
+		TotalBlockCount:          1,
+		Blocks: []Block{{
+			BlockMetadataID:          1,
+			Canonical:                true,
+			Tag:                      2,
+			Height:                   1000,
+			SingleBlockObjectKey:     "single/1000.gzip",
+			OldConsolidatedObjectKey: "consolidated/dirty.cscb.zstd",
+			OldByteLength:            100,
+			OldUncompressedLength:    200,
+		}},
+	}
+}
+
+func verifiedRepairManifest() *Manifest {
+	return &Manifest{
+		ID:                       7,
+		State:                    StateVerified,
+		Bucket:                   "repair-bucket",
+		OldConsolidatedObjectKey: "consolidated/dirty.cscb.zstd",
+		OldConsolidatedObjectVersion: ObjectVersion{
+			VersionID: "dirty-version",
+			ETag:      "dirty-etag",
+			Bytes:     1234,
+		},
+		NewConsolidatedObjectKey: "consolidated/clean.cscb.zstd",
+		NewConsolidatedObjectVersion: ObjectVersion{
+			VersionID: "clean-version",
+			ETag:      "clean-etag",
+			Bytes:     1200,
+		},
+	}
+}
+
+type deleteResumeRepository struct {
+	Repository
+	manifest         *Manifest
+	failNextComplete bool
+	completeCalls    int
+}
+
+type pendingRepairRepository struct {
+	Repository
+	pending *Manifest
+}
+
+func (r *pendingRepairRepository) FindPending(context.Context, uint32) (*Manifest, error) {
+	return r.pending, nil
+}
+
+func (r *deleteResumeRepository) Get(context.Context, int64) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+func (r *deleteResumeRepository) Complete(_ context.Context, _ int64, outcome string) (*Manifest, error) {
+	r.completeCalls++
+	if r.failNextComplete {
+		r.failNextComplete = false
+		return nil, xerrors.New("database completion unavailable")
+	}
+	r.manifest.State = StateCompleted
+	r.manifest.Outcome = outcome
+	return r.manifest, nil
+}
+
+type deleteResumeObjectStore struct {
+	retirement.ObjectStore
+	oldKey      string
+	newKey      string
+	oldTopology retirement.ObjectVersionTopology
+	newTopology retirement.ObjectVersionTopology
+	deleteCalls int
+}
+
+func (s *deleteResumeObjectStore) ListObjectVersions(_ context.Context, _ string, key string) (retirement.ObjectVersionTopology, error) {
+	switch key {
+	case s.oldKey:
+		return s.oldTopology, nil
+	case s.newKey:
+		return s.newTopology, nil
+	default:
+		return retirement.ObjectVersionTopology{}, xerrors.Errorf("unexpected object key %q", key)
+	}
+}
+
+func (s *deleteResumeObjectStore) DeleteObjectVersion(_ context.Context, _ string, key string, versionID string) error {
+	s.deleteCalls++
+	if key != s.oldKey || len(s.oldTopology.Versions) != 1 || s.oldTopology.Versions[0].VersionID != versionID {
+		return xerrors.New("unexpected version deletion")
+	}
+	s.oldTopology = retirement.ObjectVersionTopology{}
+	return nil
+}
+
+func topologyFor(object ObjectVersion) retirement.ObjectVersionTopology {
+	return retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
+		VersionID: object.VersionID,
+		ETag:      object.ETag,
+		Bytes:     object.Bytes,
+		IsLatest:  true,
+	}}}
+}

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -1,109 +1,31 @@
 package cscbrepair
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"hash/crc32"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage/cscb"
 	"github.com/coinbase/chainstorage/internal/storage/retirement"
+	storageutils "github.com/coinbase/chainstorage/internal/storage/utils"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
-func TestDeleteOldObjectResumesAfterDeleteBeforeDatabaseCompletion(t *testing.T) {
-	manifest := verifiedRepairManifest()
-	repository := &deleteResumeRepository{
-		manifest:         manifest,
-		failNextComplete: true,
-	}
-	store := &deleteResumeObjectStore{
-		oldKey: manifest.OldConsolidatedObjectKey,
-		newKey: manifest.NewConsolidatedObjectKey,
-		oldTopology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
-			VersionID: manifest.OldConsolidatedObjectVersion.VersionID,
-			ETag:      manifest.OldConsolidatedObjectVersion.ETag,
-			Bytes:     manifest.OldConsolidatedObjectVersion.Bytes,
-			IsLatest:  true,
-		}}},
-		newTopology: topologyFor(manifest.NewConsolidatedObjectVersion),
-	}
-	repairer := NewRepairer(repository, store, manifest.Bucket)
-
-	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
-	require.ErrorContains(t, err, "database completion unavailable")
-	require.Equal(t, 1, store.deleteCalls)
-	require.Empty(t, store.oldTopology.Versions)
-	require.Equal(t, StateVerified, repository.manifest.State)
-
-	completed, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
-	require.NoError(t, err)
-	require.Equal(t, StateCompleted, completed.State)
-	require.Equal(t, 1, store.deleteCalls, "resume must not issue a second delete")
-	require.Equal(t, 2, repository.completeCalls)
-}
-
-func TestDeleteOldObjectRejectsVersionTopologyDrift(t *testing.T) {
-	manifest := verifiedRepairManifest()
-	repository := &deleteResumeRepository{manifest: manifest}
-	store := &deleteResumeObjectStore{
-		oldKey: manifest.OldConsolidatedObjectKey,
-		newKey: manifest.NewConsolidatedObjectKey,
-		oldTopology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
-			VersionID: "unexpected-version",
-			ETag:      manifest.OldConsolidatedObjectVersion.ETag,
-			Bytes:     manifest.OldConsolidatedObjectVersion.Bytes,
-			IsLatest:  true,
-		}}},
-		newTopology: topologyFor(manifest.NewConsolidatedObjectVersion),
-	}
-	repairer := NewRepairer(repository, store, manifest.Bucket)
-
-	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
-	require.ErrorContains(t, err, "topology changed before deletion")
-	require.Zero(t, store.deleteCalls)
-	require.Equal(t, 1, repository.completeCalls)
-	require.Equal(t, StateVerified, repository.manifest.State)
-}
-
-func TestDeleteOldObjectRejectsRebuiltVersionTopologyDrift(t *testing.T) {
-	manifest := verifiedRepairManifest()
-	repository := &deleteResumeRepository{manifest: manifest}
-	store := &deleteResumeObjectStore{
-		oldKey:      manifest.OldConsolidatedObjectKey,
-		newKey:      manifest.NewConsolidatedObjectKey,
-		oldTopology: topologyFor(manifest.OldConsolidatedObjectVersion),
-		newTopology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
-			VersionID: "unexpected-clean-version",
-			ETag:      manifest.NewConsolidatedObjectVersion.ETag,
-			Bytes:     manifest.NewConsolidatedObjectVersion.Bytes,
-			IsLatest:  true,
-		}}},
-	}
-	repairer := NewRepairer(repository, store, manifest.Bucket)
-
-	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
-	require.ErrorContains(t, err, "rebuilt CSCB changed before old-object deletion")
-	require.Zero(t, store.deleteCalls)
-	require.Equal(t, 1, repository.completeCalls)
-	require.Equal(t, StateVerified, repository.manifest.State)
-}
-
-func TestDeleteOldObjectRejectsMissingRebuiltObjectDuringDeletionRecovery(t *testing.T) {
-	manifest := verifiedRepairManifest()
-	repository := &deleteResumeRepository{manifest: manifest}
-	store := &deleteResumeObjectStore{
-		oldKey: manifest.OldConsolidatedObjectKey,
-		newKey: manifest.NewConsolidatedObjectKey,
-	}
-	repairer := NewRepairer(repository, store, manifest.Bucket)
-
-	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
-	require.ErrorContains(t, err, "rebuilt CSCB changed before old-object deletion")
-	require.Zero(t, store.deleteCalls)
-	require.Equal(t, 1, repository.completeCalls)
-	require.Equal(t, StateVerified, repository.manifest.State)
+func TestValidateCandidateAllowsAllNonCanonicalRows(t *testing.T) {
+	candidate := validRepairCandidate()
+	candidate.Blocks[0].Canonical = false
+	candidate.CanonicalBlockCount = 0
+	require.NoError(t, validateCandidate(candidate, 1000, 1001, 1))
 }
 
 func TestValidateCandidateRejectsUnsafeSingleBlockState(t *testing.T) {
@@ -129,11 +51,143 @@ func TestPrepareNextRejectsPendingRepairOutsideApprovedRange(t *testing.T) {
 	pending := validRepairCandidate()
 	pending.State = StatePrepared
 	repository := &pendingRepairRepository{pending: pending}
-	repairer := NewRepairer(repository, &deleteResumeObjectStore{}, "repair-bucket")
+	repairer := NewRepairer(repository, &pendingObjectStore{}, "repair-bucket")
 
 	_, err := repairer.PrepareNext(context.Background(), executionKey("outside-range"), 2, 2000, 2001, 1, nil)
 	require.ErrorContains(t, err, "pending CSCB repair does not fit the approved request")
 	require.ErrorContains(t, err, "exceeds approved range")
+}
+
+func TestPrepareNextPersistsFenceBeforeS3InspectionAndRetriesSameManifest(t *testing.T) {
+	inspectionErr := errors.New("S3 inspection stopped")
+	repository := &preparationRepository{candidate: validRepairCandidate()}
+	store := &preparationObjectStore{repository: repository, listErr: inspectionErr}
+	repairer := NewRepairer(repository, store, "repair-bucket")
+	key := executionKey("durable-fence")
+
+	_, err := repairer.PrepareNext(context.Background(), key, 2, 1000, 1001, 1, nil)
+	require.ErrorIs(t, err, inspectionErr)
+	require.True(t, repository.fenced)
+	require.True(t, repository.bound)
+	require.False(t, repository.inspectionRecorded)
+	require.Equal(t, StatePreparing, repository.manifest.State)
+	require.Empty(t, repository.manifest.OldConsolidatedObjectVersion.VersionID)
+	require.Len(t, repository.manifest.RowSetSHA256, 64)
+	require.Equal(t, objectKeySHA256("single/1000.gzip"), repository.manifest.Blocks[0].SingleBlockObjectKeySHA256)
+	require.Equal(t, 1, repository.fenceCalls)
+
+	_, err = repairer.PrepareNext(context.Background(), key, 2, 1000, 1001, 1, nil)
+	require.ErrorIs(t, err, inspectionErr)
+	require.Equal(t, 1, repository.fenceCalls, "retry must reuse the durable preparing manifest")
+	require.Equal(t, 2, store.listCalls)
+}
+
+func TestPrepareNextCompletesAlreadyCleanCSCBWithoutRestore(t *testing.T) {
+	candidate := validRepairCandidate()
+	candidate.Blocks[0].Hash = "clean-hash"
+	candidate.Blocks[0].OldByteOffset = 0
+	block := &api.Block{Metadata: &api.BlockMetadata{
+		Tag:    candidate.Tag,
+		Height: candidate.Blocks[0].Height,
+		Hash:   candidate.Blocks[0].Hash,
+	}}
+	payload, err := proto.Marshal(block)
+	require.NoError(t, err)
+	singleObject, err := storageutils.Compress(payload, api.Compression_GZIP)
+	require.NoError(t, err)
+	candidate.Blocks[0].OldByteLength = uint64(len(payload))
+	candidate.Blocks[0].OldUncompressedLength = uint64(len(payload))
+	candidate.OldConsolidatedObjectKey = "consolidated/clean.cscb.gzip"
+	candidate.Blocks[0].OldConsolidatedObjectKey = candidate.OldConsolidatedObjectKey
+	cscbObject := buildRepairSingleBlockCSCB(t, retirement.Candidate{
+		BlockMetadataID:    candidate.Blocks[0].BlockMetadataID,
+		Tag:                candidate.Tag,
+		Height:             candidate.Blocks[0].Height,
+		Hash:               candidate.Blocks[0].Hash,
+		ByteOffset:         0,
+		ByteLength:         uint64(len(payload)),
+		UncompressedLength: uint64(len(payload)),
+	}, payload)
+
+	repository := &preparationRepository{candidate: candidate}
+	store := &preparationObjectStore{
+		repository: repository,
+		topologies: map[string]retirement.ObjectVersionTopology{
+			candidate.OldConsolidatedObjectKey: {
+				Versions: []retirement.ObjectVersion{{VersionID: "clean-cscb-version", ETag: "clean-cscb-etag", Bytes: uint64(len(cscbObject)), IsLatest: true}},
+			},
+			candidate.Blocks[0].SingleBlockObjectKey: {
+				Versions: []retirement.ObjectVersion{{VersionID: "single-version", ETag: "single-etag", Bytes: uint64(len(singleObject)), IsLatest: true}},
+			},
+		},
+		objects: map[string][]byte{
+			candidate.OldConsolidatedObjectKey:       cscbObject,
+			candidate.Blocks[0].SingleBlockObjectKey: singleObject,
+		},
+	}
+
+	manifest, err := NewRepairer(repository, store, "repair-bucket").PrepareNext(
+		context.Background(),
+		executionKey("already-clean"),
+		candidate.Tag,
+		candidate.StartHeight,
+		candidate.EndHeight,
+		1,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, StateCompleted, manifest.State)
+	require.Equal(t, alreadyCleanOutcome, manifest.Outcome)
+	require.NotNil(t, manifest.VerifiedAt)
+	require.NotNil(t, manifest.CompletedAt)
+	require.Nil(t, manifest.RestoredAt)
+	require.True(t, repository.inspectionRecorded)
+	require.True(t, repository.alreadyClean)
+}
+
+func TestCompleteRejectsRetainedObjectTopologyDrift(t *testing.T) {
+	manifest := completionManifest(t)
+	repository := &completionRepository{manifest: manifest}
+	store := &completionObjectStore{
+		topologies: map[string]retirement.ObjectVersionTopology{
+			manifest.OldConsolidatedObjectKey: {
+				Versions: []retirement.ObjectVersion{
+					objectTopologyVersion(manifest.OldConsolidatedObjectVersion),
+					{VersionID: "unexpected-version", ETag: "unexpected-etag", Bytes: 1},
+				},
+			},
+		},
+	}
+
+	_, err := NewRepairer(repository, store, "repair-bucket").Complete(context.Background(), manifest.ID, nil)
+	require.ErrorContains(t, err, "retained CSCB repair source changed before completion")
+	require.ErrorContains(t, err, "expected one data version and zero delete markers")
+	require.False(t, repository.completeCalled)
+	require.False(t, repository.committed)
+}
+
+func TestCompletePropagatesDatabaseFailureAfterValidation(t *testing.T) {
+	manifest := completionManifest(t)
+	completeErr := errors.New("database completion failed")
+	repository := &completionRepository{manifest: manifest, completeErr: completeErr}
+	store := &completionObjectStore{
+		topologies: map[string]retirement.ObjectVersionTopology{
+			manifest.OldConsolidatedObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.OldConsolidatedObjectVersion)},
+			},
+			manifest.Blocks[0].SingleBlockObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.Blocks[0].SingleBlockObjectVersion)},
+			},
+		},
+		objects: map[string][]byte{
+			manifest.Blocks[0].SingleBlockObjectKey: completionSingleBlockPayload(t, manifest.Blocks[0]),
+		},
+	}
+
+	_, err := NewRepairer(repository, store, "repair-bucket").Complete(context.Background(), manifest.ID, nil)
+	require.ErrorIs(t, err, completeErr)
+	require.True(t, repository.completeCalled)
+	require.False(t, repository.committed)
 }
 
 func TestValidateRebuiltMetadataRequiresFreshRetentionAndCleanNonCanonicalRows(t *testing.T) {
@@ -203,33 +257,6 @@ func validRepairCandidate() *Manifest {
 	}
 }
 
-func verifiedRepairManifest() *Manifest {
-	return &Manifest{
-		ID:                       7,
-		State:                    StateVerified,
-		Bucket:                   "repair-bucket",
-		OldConsolidatedObjectKey: "consolidated/dirty.cscb.zstd",
-		OldConsolidatedObjectVersion: ObjectVersion{
-			VersionID: "dirty-version",
-			ETag:      "dirty-etag",
-			Bytes:     1234,
-		},
-		NewConsolidatedObjectKey: "consolidated/clean.cscb.zstd",
-		NewConsolidatedObjectVersion: ObjectVersion{
-			VersionID: "clean-version",
-			ETag:      "clean-etag",
-			Bytes:     1200,
-		},
-	}
-}
-
-type deleteResumeRepository struct {
-	Repository
-	manifest         *Manifest
-	failNextComplete bool
-	completeCalls    int
-}
-
 type pendingRepairRepository struct {
 	Repository
 	pending *Manifest
@@ -243,29 +270,6 @@ func (r *pendingRepairRepository) FindByExecutionKey(context.Context, string) (*
 	return nil, false, nil
 }
 
-func (r *deleteResumeRepository) Get(context.Context, int64) (*Manifest, error) {
-	return r.manifest, nil
-}
-
-func (r *deleteResumeRepository) CompleteWithOldObjectDeletion(
-	_ context.Context,
-	_ int64,
-	outcome string,
-	deleteObject DeleteOldObject,
-) (*Manifest, error) {
-	r.completeCalls++
-	if err := deleteObject(r.manifest); err != nil {
-		return nil, err
-	}
-	if r.failNextComplete {
-		r.failNextComplete = false
-		return nil, xerrors.New("database completion unavailable")
-	}
-	r.manifest.State = StateCompleted
-	r.manifest.Outcome = outcome
-	return r.manifest, nil
-}
-
 func executionKey(seed string) string {
 	value := make([]byte, 64)
 	for i := range value {
@@ -274,40 +278,311 @@ func executionKey(seed string) string {
 	return string(value)
 }
 
-type deleteResumeObjectStore struct {
+type pendingObjectStore struct{ retirement.ObjectStore }
+
+type preparationRepository struct {
+	Repository
+	candidate          *Manifest
+	manifest           *Manifest
+	executionKey       string
+	fenced             bool
+	bound              bool
+	inspectionRecorded bool
+	alreadyClean       bool
+	fenceCalls         int
+}
+
+func (r *preparationRepository) FindByExecutionKey(_ context.Context, executionKey string) (*Manifest, bool, error) {
+	if r.bound && executionKey == r.executionKey {
+		return r.manifest, true, nil
+	}
+	return nil, false, nil
+}
+
+func (r *preparationRepository) FindPending(context.Context, uint32) (*Manifest, error) {
+	return nil, nil
+}
+
+func (r *preparationRepository) FindNextCandidate(context.Context, uint32, uint64, uint64) (*Manifest, error) {
+	return r.candidate, nil
+}
+
+func (r *preparationRepository) FenceCandidate(_ context.Context, manifest *Manifest) (*Manifest, error) {
+	r.fenceCalls++
+	r.fenced = true
+	copy := *manifest
+	copy.ID = 41
+	copy.Blocks = append([]Block(nil), manifest.Blocks...)
+	r.manifest = &copy
+	return r.manifest, nil
+}
+
+func (r *preparationRepository) BindExecutionKey(_ context.Context, executionKey string, repairID int64) (*Manifest, error) {
+	if !r.fenced || r.manifest == nil || repairID != r.manifest.ID {
+		return nil, errors.New("execution bound before durable fence")
+	}
+	r.bound = true
+	r.executionKey = executionKey
+	return r.manifest, nil
+}
+
+func (r *preparationRepository) RecordInspection(
+	_ context.Context,
+	repairID int64,
+	oldObject ObjectVersion,
+	blocks []Block,
+	alreadyClean bool,
+) (*Manifest, error) {
+	if !r.bound || r.manifest == nil || repairID != r.manifest.ID {
+		return nil, errors.New("inspection recorded before durable execution binding")
+	}
+	r.inspectionRecorded = true
+	r.alreadyClean = alreadyClean
+	r.manifest.OldConsolidatedObjectVersion = oldObject
+	r.manifest.Blocks = append([]Block(nil), blocks...)
+	if alreadyClean {
+		now := time.Now().UTC()
+		r.manifest.State = StateCompleted
+		r.manifest.Outcome = alreadyCleanOutcome
+		r.manifest.VerifiedAt = &now
+		r.manifest.CompletedAt = &now
+	} else {
+		r.manifest.State = StatePrepared
+	}
+	return r.manifest, nil
+}
+
+func (r *preparationRepository) Get(context.Context, int64) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+type preparationObjectStore struct {
 	retirement.ObjectStore
-	oldKey      string
-	newKey      string
-	oldTopology retirement.ObjectVersionTopology
-	newTopology retirement.ObjectVersionTopology
-	deleteCalls int
+	repository *preparationRepository
+	listErr    error
+	listCalls  int
+	topologies map[string]retirement.ObjectVersionTopology
+	objects    map[string][]byte
 }
 
-func (s *deleteResumeObjectStore) ListObjectVersions(_ context.Context, _ string, key string) (retirement.ObjectVersionTopology, error) {
-	switch key {
-	case s.oldKey:
-		return s.oldTopology, nil
-	case s.newKey:
-		return s.newTopology, nil
-	default:
-		return retirement.ObjectVersionTopology{}, xerrors.Errorf("unexpected object key %q", key)
+func (s *preparationObjectStore) ListObjectVersions(
+	_ context.Context,
+	_ string,
+	key string,
+) (retirement.ObjectVersionTopology, error) {
+	s.listCalls++
+	if s.repository == nil || !s.repository.fenced || !s.repository.bound {
+		return retirement.ObjectVersionTopology{}, errors.New("S3 inspected before durable repair fence")
+	}
+	if s.listErr != nil {
+		return retirement.ObjectVersionTopology{}, s.listErr
+	}
+	return s.topologies[key], nil
+}
+
+func (s *preparationObjectStore) ReadObjectVersion(
+	_ context.Context,
+	_ string,
+	key string,
+	_ string,
+) ([]byte, error) {
+	object, ok := s.objects[key]
+	if !ok {
+		return nil, errors.New("object not found")
+	}
+	return object, nil
+}
+
+func (s *preparationObjectStore) ReadObjectVersionRange(
+	_ context.Context,
+	_ string,
+	key string,
+	_ string,
+	offset uint64,
+	length uint64,
+) ([]byte, error) {
+	object, ok := s.objects[key]
+	if !ok {
+		return nil, errors.New("object not found")
+	}
+	end := offset + length
+	if end < offset || offset > uint64(len(object)) {
+		return nil, errors.New("object range out of bounds")
+	}
+	if end > uint64(len(object)) {
+		end = uint64(len(object))
+	}
+	return append([]byte(nil), object[offset:end]...), nil
+}
+
+type completionRepository struct {
+	Repository
+	manifest       *Manifest
+	completeErr    error
+	completeCalled bool
+	committed      bool
+}
+
+func (r *completionRepository) Get(context.Context, int64) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+func (r *completionRepository) GetRebuilt(context.Context, int64) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+func (r *completionRepository) CompleteRetainingOldObject(
+	_ context.Context,
+	_ int64,
+	_ string,
+) (*Manifest, error) {
+	r.completeCalled = true
+	if r.completeErr != nil {
+		return nil, r.completeErr
+	}
+	r.committed = true
+	return r.manifest, nil
+}
+
+type completionObjectStore struct {
+	retirement.ObjectStore
+	topologies map[string]retirement.ObjectVersionTopology
+	objects    map[string][]byte
+}
+
+func (s *completionObjectStore) ListObjectVersions(
+	_ context.Context,
+	_ string,
+	key string,
+) (retirement.ObjectVersionTopology, error) {
+	return s.topologies[key], nil
+}
+
+func (s *completionObjectStore) ReadObjectVersion(
+	_ context.Context,
+	_ string,
+	key string,
+	_ string,
+) ([]byte, error) {
+	return s.objects[key], nil
+}
+
+func completionManifest(t *testing.T) *Manifest {
+	t.Helper()
+	block := Block{
+		BlockMetadataID:          1,
+		Canonical:                false,
+		Tag:                      2,
+		Height:                   1000,
+		Hash:                     "block-hash",
+		SingleBlockObjectKey:     "single/1000.gzip",
+		SingleBlockObjectVersion: ObjectVersion{VersionID: "single-version", ETag: "single-etag", Bytes: 100},
+	}
+	raw := &api.Block{Metadata: &api.BlockMetadata{Tag: block.Tag, Height: block.Height, Hash: block.Hash}}
+	normalized, err := (proto.MarshalOptions{Deterministic: true}).Marshal(storageutils.CloneBlockWithoutStoragePlacement(raw))
+	require.NoError(t, err)
+	digest := sha256.Sum256(normalized)
+	block.PayloadSHA256 = hex.EncodeToString(digest[:])
+	return &Manifest{
+		ID:                           7,
+		State:                        StateRestored,
+		Bucket:                       "repair-bucket",
+		OldConsolidatedObjectKey:     "consolidated/dirty.cscb.zstd",
+		OldConsolidatedObjectVersion: ObjectVersion{VersionID: "old-version", ETag: "old-etag", Bytes: 200},
+		CanonicalBlockCount:          0,
+		TotalBlockCount:              1,
+		Blocks:                       []Block{block},
 	}
 }
 
-func (s *deleteResumeObjectStore) DeleteObjectVersion(_ context.Context, _ string, key string, versionID string) error {
-	s.deleteCalls++
-	if key != s.oldKey || len(s.oldTopology.Versions) != 1 || s.oldTopology.Versions[0].VersionID != versionID {
-		return xerrors.New("unexpected version deletion")
-	}
-	s.oldTopology = retirement.ObjectVersionTopology{}
-	return nil
+func completionSingleBlockPayload(t *testing.T, block Block) []byte {
+	t.Helper()
+	payload, err := proto.Marshal(&api.Block{Metadata: &api.BlockMetadata{
+		Tag:    block.Tag,
+		Height: block.Height,
+		Hash:   block.Hash,
+	}})
+	require.NoError(t, err)
+	compressed, err := storageutils.Compress(payload, api.Compression_GZIP)
+	require.NoError(t, err)
+	return compressed
 }
 
-func topologyFor(object ObjectVersion) retirement.ObjectVersionTopology {
-	return retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{{
-		VersionID: object.VersionID,
-		ETag:      object.ETag,
-		Bytes:     object.Bytes,
+func buildRepairSingleBlockCSCB(t *testing.T, candidate retirement.Candidate, payload []byte) []byte {
+	t.Helper()
+	compressed := gzipRepairPayload(t, payload)
+	envelope := make([]byte, cscb.EnvelopeHeaderSize+cscb.BlockIndexRecordSize+cscb.ChunkIndexRecordSize)
+	copy(envelope[0:4], []byte("ENV1"))
+	binary.LittleEndian.PutUint64(envelope[8:16], 1)
+	binary.LittleEndian.PutUint64(envelope[16:24], 1)
+	binary.LittleEndian.PutUint64(envelope[24:32], candidate.Height)
+	binary.LittleEndian.PutUint64(envelope[32:40], candidate.Height+1)
+	binary.LittleEndian.PutUint64(envelope[40:48], cscb.EnvelopeHeaderSize)
+	binary.LittleEndian.PutUint64(envelope[48:56], cscb.BlockIndexRecordSize)
+	chunkOffset := cscb.EnvelopeHeaderSize + cscb.BlockIndexRecordSize
+	binary.LittleEndian.PutUint64(envelope[56:64], uint64(chunkOffset))
+	binary.LittleEndian.PutUint64(envelope[64:72], cscb.ChunkIndexRecordSize)
+
+	blockRecord := envelope[cscb.EnvelopeHeaderSize:chunkOffset]
+	binary.LittleEndian.PutUint64(blockRecord[0:8], candidate.Height)
+	binary.LittleEndian.PutUint64(blockRecord[8:16], candidate.ByteOffset)
+	binary.LittleEndian.PutUint64(blockRecord[16:24], uint64(len(payload)))
+	binary.LittleEndian.PutUint32(blockRecord[24:28], crc32.ChecksumIEEE(payload))
+	hash := sha256.Sum256([]byte(candidate.Hash))
+	copy(blockRecord[48:80], hash[:])
+	binary.LittleEndian.PutUint64(blockRecord[80:88], uint64(candidate.BlockMetadataID))
+
+	payloadOffset := uint64(cscb.HeaderSize + len(envelope))
+	chunkRecord := envelope[chunkOffset:]
+	binary.LittleEndian.PutUint64(chunkRecord[8:16], candidate.Height)
+	binary.LittleEndian.PutUint64(chunkRecord[16:24], candidate.Height+1)
+	binary.LittleEndian.PutUint64(chunkRecord[24:32], payloadOffset)
+	binary.LittleEndian.PutUint64(chunkRecord[32:40], uint64(len(compressed)))
+	binary.LittleEndian.PutUint64(chunkRecord[48:56], uint64(len(payload)))
+	binary.LittleEndian.PutUint32(chunkRecord[56:60], crc32.ChecksumIEEE(payload))
+	binary.LittleEndian.PutUint32(chunkRecord[60:64], 1)
+
+	header := make([]byte, cscb.HeaderSize)
+	copy(header[0:4], []byte("CSCB"))
+	header[4] = 1
+	header[5] = 1
+	header[6] = 2
+	binary.LittleEndian.PutUint32(header[8:12], 1)
+	binary.LittleEndian.PutUint32(header[12:16], 1)
+	binary.LittleEndian.PutUint64(header[16:24], candidate.Height)
+	binary.LittleEndian.PutUint64(header[24:32], candidate.Height+1)
+	binary.LittleEndian.PutUint64(header[32:40], cscb.HeaderSize)
+	binary.LittleEndian.PutUint64(header[40:48], uint64(len(envelope)))
+	binary.LittleEndian.PutUint32(header[48:52], crc32.ChecksumIEEE(envelope))
+	binary.LittleEndian.PutUint32(header[52:56], cscb.BlockIndexRecordSize)
+	binary.LittleEndian.PutUint32(header[56:60], cscb.ChunkIndexRecordSize)
+	binary.LittleEndian.PutUint64(header[60:68], payloadOffset)
+	binary.LittleEndian.PutUint64(header[68:76], uint64(len(compressed)))
+	binary.LittleEndian.PutUint64(header[76:84], uint64(len(payload)))
+	binary.LittleEndian.PutUint32(header[84:88], crc32.ChecksumIEEE(payload))
+
+	object := make([]byte, 0, len(header)+len(envelope)+len(compressed))
+	object = append(object, header...)
+	object = append(object, envelope...)
+	object = append(object, compressed...)
+	return object
+}
+
+func gzipRepairPayload(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := gzip.NewWriter(&buffer)
+	_, err := writer.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return buffer.Bytes()
+}
+
+func objectTopologyVersion(version ObjectVersion) retirement.ObjectVersion {
+	return retirement.ObjectVersion{
+		VersionID: version.VersionID,
+		ETag:      version.ETag,
+		Bytes:     version.Bytes,
 		IsLatest:  true,
-	}}}
+	}
 }

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -63,7 +63,8 @@ func TestDeleteOldObjectRejectsVersionTopologyDrift(t *testing.T) {
 	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
 	require.ErrorContains(t, err, "topology changed before deletion")
 	require.Zero(t, store.deleteCalls)
-	require.Zero(t, repository.completeCalls)
+	require.Equal(t, 1, repository.completeCalls)
+	require.Equal(t, StateVerified, repository.manifest.State)
 }
 
 func TestDeleteOldObjectRejectsRebuiltVersionTopologyDrift(t *testing.T) {
@@ -85,7 +86,24 @@ func TestDeleteOldObjectRejectsRebuiltVersionTopologyDrift(t *testing.T) {
 	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
 	require.ErrorContains(t, err, "rebuilt CSCB changed before old-object deletion")
 	require.Zero(t, store.deleteCalls)
-	require.Zero(t, repository.completeCalls)
+	require.Equal(t, 1, repository.completeCalls)
+	require.Equal(t, StateVerified, repository.manifest.State)
+}
+
+func TestDeleteOldObjectRejectsMissingRebuiltObjectDuringDeletionRecovery(t *testing.T) {
+	manifest := verifiedRepairManifest()
+	repository := &deleteResumeRepository{manifest: manifest}
+	store := &deleteResumeObjectStore{
+		oldKey: manifest.OldConsolidatedObjectKey,
+		newKey: manifest.NewConsolidatedObjectKey,
+	}
+	repairer := NewRepairer(repository, store, manifest.Bucket)
+
+	_, err := repairer.DeleteOldObject(context.Background(), manifest.ID)
+	require.ErrorContains(t, err, "rebuilt CSCB changed before old-object deletion")
+	require.Zero(t, store.deleteCalls)
+	require.Equal(t, 1, repository.completeCalls)
+	require.Equal(t, StateVerified, repository.manifest.State)
 }
 
 func TestValidateCandidateRejectsUnsafeSingleBlockState(t *testing.T) {
@@ -113,7 +131,7 @@ func TestPrepareNextRejectsPendingRepairOutsideApprovedRange(t *testing.T) {
 	repository := &pendingRepairRepository{pending: pending}
 	repairer := NewRepairer(repository, &deleteResumeObjectStore{}, "repair-bucket")
 
-	_, err := repairer.PrepareNext(context.Background(), 2, 2000, 2001, 1, nil)
+	_, err := repairer.PrepareNext(context.Background(), executionKey("outside-range"), 2, 2000, 2001, 1, nil)
 	require.ErrorContains(t, err, "pending CSCB repair does not fit the approved request")
 	require.ErrorContains(t, err, "exceeds approved range")
 }
@@ -221,12 +239,24 @@ func (r *pendingRepairRepository) FindPending(context.Context, uint32) (*Manifes
 	return r.pending, nil
 }
 
+func (r *pendingRepairRepository) FindByExecutionKey(context.Context, string) (*Manifest, bool, error) {
+	return nil, false, nil
+}
+
 func (r *deleteResumeRepository) Get(context.Context, int64) (*Manifest, error) {
 	return r.manifest, nil
 }
 
-func (r *deleteResumeRepository) Complete(_ context.Context, _ int64, outcome string) (*Manifest, error) {
+func (r *deleteResumeRepository) CompleteWithOldObjectDeletion(
+	_ context.Context,
+	_ int64,
+	outcome string,
+	deleteObject DeleteOldObject,
+) (*Manifest, error) {
 	r.completeCalls++
+	if err := deleteObject(r.manifest); err != nil {
+		return nil, err
+	}
 	if r.failNextComplete {
 		r.failNextComplete = false
 		return nil, xerrors.New("database completion unavailable")
@@ -234,6 +264,14 @@ func (r *deleteResumeRepository) Complete(_ context.Context, _ int64, outcome st
 	r.manifest.State = StateCompleted
 	r.manifest.Outcome = outcome
 	return r.manifest, nil
+}
+
+func executionKey(seed string) string {
+	value := make([]byte, 64)
+	for i := range value {
+		value[i] = "0123456789abcdef"[(i+len(seed))%16]
+	}
+	return string(value)
 }
 
 type deleteResumeObjectStore struct {

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -1,0 +1,101 @@
+package cscbrepair
+
+import (
+	"context"
+	"time"
+)
+
+type (
+	State string
+
+	Progress func(stage string, completed int, total int, height uint64)
+
+	ObjectVersion struct {
+		VersionID string
+		ETag      string
+		Bytes     uint64
+	}
+
+	Block struct {
+		BlockMetadataID           int64
+		Canonical                 bool
+		Tag                       uint32
+		Height                    uint64
+		Hash                      string
+		Skipped                   bool
+		RetirementFenced          bool
+		RetirementManifestExists  bool
+		SingleBlockObjectKey      string
+		SingleBlockObjectDeleted  bool
+		SingleBlockObjectVersion  ObjectVersion
+		PayloadSHA256             string
+		OldConsolidatedObjectKey  string
+		OldByteOffset             uint64
+		OldByteLength             uint64
+		OldUncompressedLength     uint64
+		ActiveObjectKey           string
+		ActiveObjectFormat        int32
+		NewConsolidatedObjectKey  string
+		NewByteOffset             uint64
+		NewByteLength             uint64
+		NewUncompressedLength     uint64
+		NewValidatedAt            *time.Time
+		NewRetentionStartedAt     *time.Time
+		NewSingleBlockDeleteAfter *time.Time
+	}
+
+	Manifest struct {
+		ID                           int64
+		Tag                          uint32
+		State                        State
+		Bucket                       string
+		OldConsolidatedObjectKey     string
+		OldConsolidatedObjectVersion ObjectVersion
+		StartHeight                  uint64
+		EndHeight                    uint64
+		CanonicalBlockCount          uint64
+		TotalBlockCount              uint64
+		RowSetSHA256                 string
+		NewConsolidatedObjectKey     string
+		NewConsolidatedObjectVersion ObjectVersion
+		Outcome                      string
+		PreparedAt                   time.Time
+		RestoredAt                   *time.Time
+		VerifiedAt                   *time.Time
+		OldObjectDeletedAt           *time.Time
+		CompletedAt                  *time.Time
+		Blocks                       []Block
+	}
+
+	Repository interface {
+		FindPending(ctx context.Context, tag uint32) (*Manifest, error)
+		FindNextCandidate(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
+		Prepare(ctx context.Context, manifest *Manifest) (*Manifest, error)
+		Get(ctx context.Context, repairID int64) (*Manifest, error)
+		RestoreToSingleBlock(ctx context.Context, repairID int64, validate func(*Manifest) error) (*Manifest, error)
+		GetRebuilt(ctx context.Context, repairID int64) (*Manifest, error)
+		RecordVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion) (*Manifest, error)
+		Complete(ctx context.Context, repairID int64, outcome string) (*Manifest, error)
+	}
+
+	Repairer interface {
+		PrepareNext(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, maxBlocks uint64, progress Progress) (*Manifest, error)
+		Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
+		Get(ctx context.Context, repairID int64) (*Manifest, error)
+		VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
+		DeleteOldObject(ctx context.Context, repairID int64) (*Manifest, error)
+	}
+)
+
+const (
+	StatePrepared  State = "prepared"
+	StateRestored  State = "restored"
+	StateVerified  State = "verified"
+	StateCompleted State = "completed"
+)
+
+func reportProgress(progress Progress, stage string, completed int, total int, height uint64) {
+	if progress != nil {
+		progress(stage, completed, total, height)
+	}
+}

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -8,7 +8,8 @@ import (
 type (
 	State string
 
-	Progress func(stage string, completed int, total int, height uint64)
+	Progress        func(stage string, completed int, total int, height uint64)
+	DeleteOldObject func(manifest *Manifest) error
 
 	ObjectVersion struct {
 		VersionID string
@@ -68,18 +69,21 @@ type (
 	}
 
 	Repository interface {
+		FindByExecutionKey(ctx context.Context, executionKey string) (*Manifest, bool, error)
 		FindPending(ctx context.Context, tag uint32) (*Manifest, error)
 		FindNextCandidate(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
 		Prepare(ctx context.Context, manifest *Manifest) (*Manifest, error)
+		BindExecutionKey(ctx context.Context, executionKey string, repairID int64) (*Manifest, error)
+		BindNoCandidateExecution(ctx context.Context, executionKey string) (*Manifest, error)
 		Get(ctx context.Context, repairID int64) (*Manifest, error)
 		RestoreToSingleBlock(ctx context.Context, repairID int64, validate func(*Manifest) error) (*Manifest, error)
 		GetRebuilt(ctx context.Context, repairID int64) (*Manifest, error)
 		RecordVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion) (*Manifest, error)
-		Complete(ctx context.Context, repairID int64, outcome string) (*Manifest, error)
+		CompleteWithOldObjectDeletion(ctx context.Context, repairID int64, outcome string, deleteObject DeleteOldObject) (*Manifest, error)
 	}
 
 	Repairer interface {
-		PrepareNext(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, maxBlocks uint64, progress Progress) (*Manifest, error)
+		PrepareNext(ctx context.Context, executionKey string, tag uint32, startHeight uint64, endHeight uint64, maxBlocks uint64, progress Progress) (*Manifest, error)
 		Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
 		Get(ctx context.Context, repairID int64) (*Manifest, error)
 		VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -8,8 +8,7 @@ import (
 type (
 	State string
 
-	Progress        func(stage string, completed int, total int, height uint64)
-	DeleteOldObject func(manifest *Manifest) error
+	Progress func(stage string, completed int, total int, height uint64)
 
 	ObjectVersion struct {
 		VersionID string
@@ -18,31 +17,32 @@ type (
 	}
 
 	Block struct {
-		BlockMetadataID           int64
-		Canonical                 bool
-		Tag                       uint32
-		Height                    uint64
-		Hash                      string
-		Skipped                   bool
-		RetirementFenced          bool
-		RetirementManifestExists  bool
-		SingleBlockObjectKey      string
-		SingleBlockObjectDeleted  bool
-		SingleBlockObjectVersion  ObjectVersion
-		PayloadSHA256             string
-		OldConsolidatedObjectKey  string
-		OldByteOffset             uint64
-		OldByteLength             uint64
-		OldUncompressedLength     uint64
-		ActiveObjectKey           string
-		ActiveObjectFormat        int32
-		NewConsolidatedObjectKey  string
-		NewByteOffset             uint64
-		NewByteLength             uint64
-		NewUncompressedLength     uint64
-		NewValidatedAt            *time.Time
-		NewRetentionStartedAt     *time.Time
-		NewSingleBlockDeleteAfter *time.Time
+		BlockMetadataID            int64
+		Canonical                  bool
+		Tag                        uint32
+		Height                     uint64
+		Hash                       string
+		Skipped                    bool
+		RetirementFenced           bool
+		RetirementManifestExists   bool
+		SingleBlockObjectKey       string
+		SingleBlockObjectKeySHA256 string
+		SingleBlockObjectDeleted   bool
+		SingleBlockObjectVersion   ObjectVersion
+		PayloadSHA256              string
+		OldConsolidatedObjectKey   string
+		OldByteOffset              uint64
+		OldByteLength              uint64
+		OldUncompressedLength      uint64
+		ActiveObjectKey            string
+		ActiveObjectFormat         int32
+		NewConsolidatedObjectKey   string
+		NewByteOffset              uint64
+		NewByteLength              uint64
+		NewUncompressedLength      uint64
+		NewValidatedAt             *time.Time
+		NewRetentionStartedAt      *time.Time
+		NewSingleBlockDeleteAfter  *time.Time
 	}
 
 	Manifest struct {
@@ -63,7 +63,6 @@ type (
 		PreparedAt                   time.Time
 		RestoredAt                   *time.Time
 		VerifiedAt                   *time.Time
-		OldObjectDeletedAt           *time.Time
 		CompletedAt                  *time.Time
 		Blocks                       []Block
 	}
@@ -72,14 +71,15 @@ type (
 		FindByExecutionKey(ctx context.Context, executionKey string) (*Manifest, bool, error)
 		FindPending(ctx context.Context, tag uint32) (*Manifest, error)
 		FindNextCandidate(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
-		Prepare(ctx context.Context, manifest *Manifest) (*Manifest, error)
+		FenceCandidate(ctx context.Context, manifest *Manifest) (*Manifest, error)
+		RecordInspection(ctx context.Context, repairID int64, oldObject ObjectVersion, blocks []Block, alreadyClean bool) (*Manifest, error)
 		BindExecutionKey(ctx context.Context, executionKey string, repairID int64) (*Manifest, error)
-		BindNoCandidateExecution(ctx context.Context, executionKey string) (*Manifest, error)
+		BindNoCandidateExecution(ctx context.Context, executionKey string, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
 		Get(ctx context.Context, repairID int64) (*Manifest, error)
-		RestoreToSingleBlock(ctx context.Context, repairID int64, validate func(*Manifest) error) (*Manifest, error)
+		RestoreToSingleBlock(ctx context.Context, repairID int64) (*Manifest, error)
 		GetRebuilt(ctx context.Context, repairID int64) (*Manifest, error)
 		RecordVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion) (*Manifest, error)
-		CompleteWithOldObjectDeletion(ctx context.Context, repairID int64, outcome string, deleteObject DeleteOldObject) (*Manifest, error)
+		CompleteRetainingOldObject(ctx context.Context, repairID int64, outcome string) (*Manifest, error)
 	}
 
 	Repairer interface {
@@ -87,15 +87,18 @@ type (
 		Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
 		Get(ctx context.Context, repairID int64) (*Manifest, error)
 		VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
-		DeleteOldObject(ctx context.Context, repairID int64) (*Manifest, error)
+		Complete(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
 	}
 )
 
 const (
+	StatePreparing State = "preparing"
 	StatePrepared  State = "prepared"
 	StateRestored  State = "restored"
 	StateVerified  State = "verified"
 	StateCompleted State = "completed"
+
+	OutcomeAlreadyCleanStorageNeutral = "already_clean_storage_neutral"
 )
 
 func reportProgress(progress Progress, stage string, completed int, total int, height uint64) {

--- a/internal/storage/cscbrepairlock/lock.go
+++ b/internal/storage/cscbrepairlock/lock.go
@@ -1,0 +1,39 @@
+package cscbrepairlock
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+)
+
+// AcquireTag serializes repair transitions with metadata placement writers.
+// All callers must acquire this lock before locking block metadata or shadow rows.
+func AcquireTag(ctx context.Context, tx *sql.Tx, tag uint32) error {
+	key := fmt.Sprintf("cscb_repair_tag/%d", tag)
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 2))`, key); err != nil {
+		return fmt.Errorf("failed to acquire CSCB repair tag lock: %w", err)
+	}
+	return nil
+}
+
+// AcquireTags locks tags in ascending order so transactions spanning multiple
+// tags cannot invert their advisory-lock order.
+func AcquireTags(ctx context.Context, tx *sql.Tx, tags []uint32) error {
+	unique := make(map[uint32]struct{}, len(tags))
+	ordered := make([]uint32, 0, len(tags))
+	for _, tag := range tags {
+		if _, ok := unique[tag]; ok {
+			continue
+		}
+		unique[tag] = struct{}{}
+		ordered = append(ordered, tag)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i] < ordered[j] })
+	for _, tag := range ordered {
+		if err := AcquireTag(ctx, tx, tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -101,15 +101,23 @@ func (b *blockStorageImpl) AcquireSingleBlockUploadGuard(
 		_ = conn.Close()
 		return nil, err
 	}
-	var retirementFencedAt sql.NullTime
+	var singleBlockWriteFenced bool
 	err = tx.QueryRowContext(ctx, `
-		SELECT single_block_retention_fenced_at
-		FROM block_metadata
-		WHERE tag = $1
-			AND height = $2
-			AND hash IS NOT DISTINCT FROM NULLIF($3, '')
-			AND skipped = FALSE
-		FOR UPDATE`, tag, height, hash).Scan(&retirementFencedAt)
+		SELECT
+			bm.single_block_retention_fenced_at IS NOT NULL
+			OR EXISTS (
+				SELECT 1
+				FROM cscb_repair_block repair_block
+				JOIN cscb_repair_manifest repair ON repair.id = repair_block.repair_id
+				WHERE repair_block.block_metadata_id = bm.id
+					AND repair.state <> 'completed'
+			)
+		FROM block_metadata bm
+		WHERE bm.tag = $1
+			AND bm.height = $2
+			AND bm.hash IS NOT DISTINCT FROM NULLIF($3, '')
+			AND bm.skipped = FALSE
+		FOR UPDATE`, tag, height, hash).Scan(&singleBlockWriteFenced)
 	if err != nil && err != sql.ErrNoRows {
 		_ = tx.Rollback()
 		_ = conn.Close()
@@ -118,7 +126,7 @@ func (b *blockStorageImpl) AcquireSingleBlockUploadGuard(
 	return &singleBlockUploadGuard{
 		conn:   conn,
 		tx:     tx,
-		fenced: err == nil && retirementFencedAt.Valid,
+		fenced: err == nil && singleBlockWriteFenced,
 	}, nil
 }
 
@@ -1113,9 +1121,6 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(
 	if err := b.validateHeight(startHeight); err != nil {
 		return nil, err
 	}
-	singleBlockObjectRetiredAt := time.Now().UTC()
-	singleBlockObjectRetireAfter := singleBlockObjectRetiredAt.Add(singleBlockObjectRetention)
-
 	tx, err := b.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to begin consolidation promotion transaction: %w", err)
@@ -1173,7 +1178,9 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(
 	}
 
 	const promoteQuery = `
-		WITH candidates AS (
+		WITH database_clock AS (
+			SELECT clock_timestamp() AS retention_started_at
+		), candidates AS (
 			SELECT
 				bm.id AS block_metadata_id,
 				bm.tag,
@@ -1232,9 +1239,9 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(
 		retired AS (
 			UPDATE block_consolidation_shadow shadow
 			SET
-				single_block_retention_started_at = $6,
-				single_block_delete_after = $7
-			FROM candidates
+				single_block_retention_started_at = database_clock.retention_started_at,
+				single_block_delete_after = database_clock.retention_started_at + ($6 * INTERVAL '1 microsecond')
+			FROM candidates, database_clock
 			WHERE shadow.block_metadata_id = candidates.block_metadata_id
 				AND shadow.tag = candidates.tag
 				AND shadow.height = candidates.height
@@ -1256,8 +1263,7 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(
 		endHeight,
 		limit,
 		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
-		singleBlockObjectRetiredAt,
-		singleBlockObjectRetireAfter,
+		singleBlockObjectRetention.Microseconds(),
 	).Scan(&candidates, &promoted, &retired); err != nil {
 		return nil, xerrors.Errorf("failed to promote consolidation shadows: %w", err)
 	}

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepairlock"
 	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/internal"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/postgres/model"
@@ -200,6 +201,16 @@ func (b *blockStorageImpl) PersistBlockMetas(
 			}
 		}()
 
+		tags := make([]uint32, 0, len(blocks))
+		for _, block := range blocks {
+			if block != nil {
+				tags = append(tags, block.Tag)
+			}
+		}
+		if err := cscbrepairlock.AcquireTags(txCtx, tx, tags); err != nil {
+			return err
+		}
+
 		// Different queries for skipped vs non-skipped blocks due to different conflict resolution
 		blockMetadataSkippedQuery := `
 			INSERT INTO block_metadata (
@@ -230,25 +241,45 @@ func (b *blockStorageImpl) PersistBlockMetas(
 				parent_hash = EXCLUDED.parent_hash,
 				parent_height = EXCLUDED.parent_height,
 				object_key_main = CASE
-					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL THEN block_metadata.object_key_main
+					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL
+						OR EXISTS (
+							SELECT 1 FROM cscb_repair_block repair_block
+							WHERE repair_block.block_metadata_id = block_metadata.id
+						) THEN block_metadata.object_key_main
 					ELSE EXCLUDED.object_key_main
 				END,
 				timestamp = EXCLUDED.timestamp,
 				skipped = EXCLUDED.skipped,
 				object_format = CASE
-					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL THEN block_metadata.object_format
+					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL
+						OR EXISTS (
+							SELECT 1 FROM cscb_repair_block repair_block
+							WHERE repair_block.block_metadata_id = block_metadata.id
+						) THEN block_metadata.object_format
 					ELSE EXCLUDED.object_format
 				END,
 				byte_offset = CASE
-					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL THEN block_metadata.byte_offset
+					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL
+						OR EXISTS (
+							SELECT 1 FROM cscb_repair_block repair_block
+							WHERE repair_block.block_metadata_id = block_metadata.id
+						) THEN block_metadata.byte_offset
 					ELSE EXCLUDED.byte_offset
 				END,
 				byte_length = CASE
-					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL THEN block_metadata.byte_length
+					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL
+						OR EXISTS (
+							SELECT 1 FROM cscb_repair_block repair_block
+							WHERE repair_block.block_metadata_id = block_metadata.id
+						) THEN block_metadata.byte_length
 					ELSE EXCLUDED.byte_length
 				END,
 				uncompressed_length = CASE
-					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL THEN block_metadata.uncompressed_length
+					WHEN block_metadata.single_block_retention_fenced_at IS NOT NULL
+						OR EXISTS (
+							SELECT 1 FROM cscb_repair_block repair_block
+							WHERE repair_block.block_metadata_id = block_metadata.id
+						) THEN block_metadata.uncompressed_length
 					ELSE EXCLUDED.uncompressed_length
 				END
 			RETURNING id`
@@ -1038,6 +1069,15 @@ func (b *blockStorageImpl) PersistBlockConsolidationShadows(ctx context.Context,
 			_ = tx.Rollback()
 		}
 	}()
+	tags := make([]uint32, 0, len(placements))
+	for _, placement := range placements {
+		if placement != nil {
+			tags = append(tags, placement.Tag)
+		}
+	}
+	if err := cscbrepairlock.AcquireTags(ctx, tx, tags); err != nil {
+		return err
+	}
 
 	const query = `
 		INSERT INTO block_consolidation_shadow (
@@ -1131,6 +1171,9 @@ func (b *blockStorageImpl) PromoteBlockConsolidationShadows(
 			_ = tx.Rollback()
 		}
 	}()
+	if err := cscbrepairlock.AcquireTag(ctx, tx, tag); err != nil {
+		return nil, err
+	}
 
 	const invalidShadowQuery = `
 		SELECT shadow.block_metadata_id, shadow.height

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000001_add_cscb_repair_manifest.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000001_add_cscb_repair_manifest.sql
@@ -115,12 +115,77 @@ CREATE TABLE cscb_repair_block (
     UNIQUE (block_metadata_id)
 );
 
+CREATE TABLE cscb_repair_execution (
+    execution_key CHAR(64) PRIMARY KEY CHECK (execution_key ~ '^[0-9a-f]{64}$'),
+    -- NULL is a durable "no candidate" result. This prevents a lost Temporal
+    -- activity response from selecting newly appeared work on retry.
+    repair_id BIGINT REFERENCES cscb_repair_manifest (id) ON DELETE RESTRICT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE INDEX idx_cscb_repair_manifest_pending
     ON cscb_repair_manifest (tag, end_height DESC, id)
     WHERE state <> 'completed';
 
 CREATE INDEX idx_cscb_repair_block_repair_height
     ON cscb_repair_block (repair_id, height, block_metadata_id);
+
+CREATE INDEX idx_cscb_repair_execution_repair
+    ON cscb_repair_execution (repair_id);
+
+-- Once a repair pins an old consolidated object, no database writer may
+-- reintroduce that object key. Existing references are removed by the repair
+-- transaction; these triggers close the race between the final reference
+-- check and exact-version deletion from S3.
+-- +goose StatementBegin
+CREATE FUNCTION prevent_cscb_repair_old_block_metadata_reference()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.object_key_main IS NOT NULL AND NEW.object_format = 1 THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.object_key_main, 1));
+    END IF;
+    IF NEW.object_key_main IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM cscb_repair_manifest repair
+            WHERE repair.old_consolidated_object_key_main = NEW.object_key_main
+        ) THEN
+        RAISE EXCEPTION 'cannot reference a pinned old CSCB object from block_metadata id %', NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER cscb_repair_old_block_metadata_reference_trigger
+BEFORE INSERT OR UPDATE OF object_key_main ON block_metadata
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_old_block_metadata_reference();
+
+-- +goose StatementBegin
+CREATE FUNCTION prevent_cscb_repair_old_shadow_reference()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.consolidated_object_key_main IS NOT NULL AND NEW.object_format = 1 THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.consolidated_object_key_main, 1));
+    END IF;
+    IF NEW.consolidated_object_key_main IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM cscb_repair_manifest repair
+            WHERE repair.old_consolidated_object_key_main = NEW.consolidated_object_key_main
+        ) THEN
+        RAISE EXCEPTION 'cannot reference a pinned old CSCB object from consolidation shadow for block_metadata id %', NEW.block_metadata_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER cscb_repair_old_shadow_reference_trigger
+BEFORE INSERT OR UPDATE OF consolidated_object_key_main ON block_consolidation_shadow
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_old_shadow_reference();
 
 -- +goose StatementBegin
 CREATE FUNCTION enforce_cscb_repair_manifest_transition()
@@ -213,6 +278,16 @@ BEFORE DELETE ON cscb_repair_block
 FOR EACH ROW
 EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
 
+CREATE TRIGGER cscb_repair_execution_update_trigger
+BEFORE UPDATE ON cscb_repair_execution
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
+
+CREATE TRIGGER cscb_repair_execution_delete_trigger
+BEFORE DELETE ON cscb_repair_execution
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
+
 CREATE TRIGGER cscb_repair_manifest_delete_trigger
 BEFORE DELETE ON cscb_repair_manifest
 FOR EACH ROW
@@ -229,14 +304,24 @@ END $$;
 -- +goose StatementEnd
 
 DROP TRIGGER IF EXISTS cscb_repair_manifest_delete_trigger ON cscb_repair_manifest;
+DROP TRIGGER IF EXISTS cscb_repair_execution_delete_trigger ON cscb_repair_execution;
+DROP TRIGGER IF EXISTS cscb_repair_execution_update_trigger ON cscb_repair_execution;
 DROP TRIGGER IF EXISTS cscb_repair_block_delete_trigger ON cscb_repair_block;
 DROP TRIGGER IF EXISTS cscb_repair_block_update_trigger ON cscb_repair_block;
 DROP FUNCTION IF EXISTS prevent_cscb_repair_audit_mutation();
 
+DROP TRIGGER IF EXISTS cscb_repair_old_shadow_reference_trigger ON block_consolidation_shadow;
+DROP FUNCTION IF EXISTS prevent_cscb_repair_old_shadow_reference();
+
+DROP TRIGGER IF EXISTS cscb_repair_old_block_metadata_reference_trigger ON block_metadata;
+DROP FUNCTION IF EXISTS prevent_cscb_repair_old_block_metadata_reference();
+
 DROP TRIGGER IF EXISTS cscb_repair_manifest_transition_trigger ON cscb_repair_manifest;
 DROP FUNCTION IF EXISTS enforce_cscb_repair_manifest_transition();
 
+DROP INDEX IF EXISTS idx_cscb_repair_execution_repair;
 DROP INDEX IF EXISTS idx_cscb_repair_block_repair_height;
 DROP INDEX IF EXISTS idx_cscb_repair_manifest_pending;
+DROP TABLE IF EXISTS cscb_repair_execution;
 DROP TABLE IF EXISTS cscb_repair_block;
 DROP TABLE IF EXISTS cscb_repair_manifest;

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000001_add_cscb_repair_manifest.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000001_add_cscb_repair_manifest.sql
@@ -1,0 +1,242 @@
+-- +goose Up
+CREATE TABLE cscb_repair_manifest (
+    id BIGSERIAL PRIMARY KEY,
+    tag INTEGER NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('prepared', 'restored', 'verified', 'completed')),
+    bucket TEXT NOT NULL CHECK (bucket <> ''),
+    old_consolidated_object_key_main TEXT NOT NULL CHECK (old_consolidated_object_key_main <> ''),
+    old_consolidated_object_version_id TEXT NOT NULL CHECK (
+        BTRIM(old_consolidated_object_version_id) <> ''
+        AND LOWER(BTRIM(old_consolidated_object_version_id)) <> 'null'
+    ),
+    old_consolidated_object_etag TEXT NOT NULL CHECK (old_consolidated_object_etag <> ''),
+    old_consolidated_object_bytes BIGINT NOT NULL CHECK (old_consolidated_object_bytes > 0),
+    start_height BIGINT NOT NULL CHECK (start_height >= 0),
+    end_height BIGINT NOT NULL CHECK (end_height > start_height),
+    canonical_block_count BIGINT NOT NULL CHECK (canonical_block_count > 0),
+    total_block_count BIGINT NOT NULL CHECK (total_block_count >= canonical_block_count),
+    row_set_sha256 CHAR(64) NOT NULL CHECK (row_set_sha256 ~ '^[0-9a-f]{64}$'),
+    new_consolidated_object_key_main TEXT,
+    new_consolidated_object_version_id TEXT,
+    new_consolidated_object_etag TEXT,
+    new_consolidated_object_bytes BIGINT,
+    outcome TEXT NOT NULL DEFAULT '',
+    prepared_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    restored_at TIMESTAMPTZ,
+    verified_at TIMESTAMPTZ,
+    old_object_deleted_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tag, old_consolidated_object_key_main),
+    CHECK (
+        (
+            state = 'prepared'
+            AND restored_at IS NULL
+            AND verified_at IS NULL
+            AND old_object_deleted_at IS NULL
+            AND completed_at IS NULL
+            AND new_consolidated_object_key_main IS NULL
+            AND new_consolidated_object_version_id IS NULL
+            AND new_consolidated_object_etag IS NULL
+            AND new_consolidated_object_bytes IS NULL
+        )
+        OR (
+            state = 'restored'
+            AND restored_at IS NOT NULL
+            AND verified_at IS NULL
+            AND old_object_deleted_at IS NULL
+            AND completed_at IS NULL
+            AND new_consolidated_object_key_main IS NULL
+            AND new_consolidated_object_version_id IS NULL
+            AND new_consolidated_object_etag IS NULL
+            AND new_consolidated_object_bytes IS NULL
+        )
+        OR (
+            state = 'verified'
+            AND restored_at IS NOT NULL
+            AND verified_at IS NOT NULL
+            AND verified_at >= restored_at
+            AND old_object_deleted_at IS NULL
+            AND completed_at IS NULL
+            AND new_consolidated_object_key_main IS NOT NULL
+            AND new_consolidated_object_key_main <> ''
+            AND new_consolidated_object_key_main <> old_consolidated_object_key_main
+            AND new_consolidated_object_version_id IS NOT NULL
+            AND BTRIM(new_consolidated_object_version_id) <> ''
+            AND LOWER(BTRIM(new_consolidated_object_version_id)) <> 'null'
+            AND new_consolidated_object_etag IS NOT NULL
+            AND new_consolidated_object_etag <> ''
+            AND new_consolidated_object_bytes IS NOT NULL
+            AND new_consolidated_object_bytes > 0
+        )
+        OR (
+            state = 'completed'
+            AND restored_at IS NOT NULL
+            AND verified_at IS NOT NULL
+            AND verified_at >= restored_at
+            AND old_object_deleted_at IS NOT NULL
+            AND old_object_deleted_at >= verified_at
+            AND completed_at IS NOT NULL
+            AND completed_at >= old_object_deleted_at
+            AND new_consolidated_object_key_main IS NOT NULL
+            AND new_consolidated_object_key_main <> ''
+            AND new_consolidated_object_key_main <> old_consolidated_object_key_main
+            AND new_consolidated_object_version_id IS NOT NULL
+            AND BTRIM(new_consolidated_object_version_id) <> ''
+            AND LOWER(BTRIM(new_consolidated_object_version_id)) <> 'null'
+            AND new_consolidated_object_etag IS NOT NULL
+            AND new_consolidated_object_etag <> ''
+            AND new_consolidated_object_bytes IS NOT NULL
+            AND new_consolidated_object_bytes > 0
+            AND outcome <> ''
+        )
+    )
+);
+
+CREATE TABLE cscb_repair_block (
+    repair_id BIGINT NOT NULL REFERENCES cscb_repair_manifest (id) ON DELETE RESTRICT,
+    block_metadata_id BIGINT NOT NULL REFERENCES block_metadata (id) ON DELETE RESTRICT,
+    canonical BOOLEAN NOT NULL,
+    tag INTEGER NOT NULL,
+    height BIGINT NOT NULL CHECK (height >= 0),
+    hash VARCHAR(66),
+    single_block_object_key_main TEXT NOT NULL CHECK (single_block_object_key_main <> ''),
+    single_block_object_version_id TEXT NOT NULL CHECK (
+        BTRIM(single_block_object_version_id) <> ''
+        AND LOWER(BTRIM(single_block_object_version_id)) <> 'null'
+    ),
+    single_block_object_etag TEXT NOT NULL CHECK (single_block_object_etag <> ''),
+    single_block_object_bytes BIGINT NOT NULL CHECK (single_block_object_bytes > 0),
+    payload_sha256 CHAR(64) NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    old_byte_offset BIGINT NOT NULL CHECK (old_byte_offset >= 0),
+    old_byte_length BIGINT NOT NULL CHECK (old_byte_length > 0),
+    old_uncompressed_length BIGINT NOT NULL CHECK (old_uncompressed_length > 0),
+    PRIMARY KEY (repair_id, block_metadata_id),
+    UNIQUE (block_metadata_id)
+);
+
+CREATE INDEX idx_cscb_repair_manifest_pending
+    ON cscb_repair_manifest (tag, end_height DESC, id)
+    WHERE state <> 'completed';
+
+CREATE INDEX idx_cscb_repair_block_repair_height
+    ON cscb_repair_block (repair_id, height, block_metadata_id);
+
+-- +goose StatementBegin
+CREATE FUNCTION enforce_cscb_repair_manifest_transition()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.id IS DISTINCT FROM OLD.id
+        OR NEW.tag IS DISTINCT FROM OLD.tag
+        OR NEW.bucket IS DISTINCT FROM OLD.bucket
+        OR NEW.old_consolidated_object_key_main IS DISTINCT FROM OLD.old_consolidated_object_key_main
+        OR NEW.old_consolidated_object_version_id IS DISTINCT FROM OLD.old_consolidated_object_version_id
+        OR NEW.old_consolidated_object_etag IS DISTINCT FROM OLD.old_consolidated_object_etag
+        OR NEW.old_consolidated_object_bytes IS DISTINCT FROM OLD.old_consolidated_object_bytes
+        OR NEW.start_height IS DISTINCT FROM OLD.start_height
+        OR NEW.end_height IS DISTINCT FROM OLD.end_height
+        OR NEW.canonical_block_count IS DISTINCT FROM OLD.canonical_block_count
+        OR NEW.total_block_count IS DISTINCT FROM OLD.total_block_count
+        OR NEW.row_set_sha256 IS DISTINCT FROM OLD.row_set_sha256
+        OR NEW.prepared_at IS DISTINCT FROM OLD.prepared_at THEN
+        RAISE EXCEPTION 'cannot change pinned CSCB repair manifest fields for repair id %', OLD.id;
+    END IF;
+
+    IF NOT (
+        (OLD.state = 'prepared' AND NEW.state IN ('prepared', 'restored'))
+        OR (OLD.state = 'restored' AND NEW.state IN ('restored', 'verified'))
+        OR (OLD.state = 'verified' AND NEW.state IN ('verified', 'completed'))
+        OR (OLD.state = 'completed' AND NEW.state = 'completed')
+    ) THEN
+        RAISE EXCEPTION 'invalid CSCB repair transition from % to % for repair id %', OLD.state, NEW.state, OLD.id;
+    END IF;
+
+    IF OLD.new_consolidated_object_key_main IS NOT NULL
+        AND (
+            NEW.new_consolidated_object_key_main IS DISTINCT FROM OLD.new_consolidated_object_key_main
+            OR NEW.new_consolidated_object_version_id IS DISTINCT FROM OLD.new_consolidated_object_version_id
+            OR NEW.new_consolidated_object_etag IS DISTINCT FROM OLD.new_consolidated_object_etag
+            OR NEW.new_consolidated_object_bytes IS DISTINCT FROM OLD.new_consolidated_object_bytes
+            OR NEW.verified_at IS DISTINCT FROM OLD.verified_at
+        ) THEN
+        RAISE EXCEPTION 'cannot change verified CSCB repair target for repair id %', OLD.id;
+    END IF;
+
+    IF OLD.restored_at IS NOT NULL
+        AND NEW.restored_at IS DISTINCT FROM OLD.restored_at THEN
+        RAISE EXCEPTION 'cannot change CSCB repair restore timestamp for repair id %', OLD.id;
+    END IF;
+
+    IF NEW.outcome IS DISTINCT FROM OLD.outcome
+        AND NOT (
+            OLD.state = 'verified'
+            AND NEW.state = 'completed'
+            AND OLD.outcome = ''
+            AND NEW.outcome <> ''
+        ) THEN
+        RAISE EXCEPTION 'cannot change CSCB repair outcome outside completion for repair id %', OLD.id;
+    END IF;
+
+    IF OLD.old_object_deleted_at IS NOT NULL
+        AND (
+            NEW.old_object_deleted_at IS DISTINCT FROM OLD.old_object_deleted_at
+            OR NEW.completed_at IS DISTINCT FROM OLD.completed_at
+        ) THEN
+        RAISE EXCEPTION 'cannot change completed CSCB repair timestamps for repair id %', OLD.id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER cscb_repair_manifest_transition_trigger
+BEFORE UPDATE ON cscb_repair_manifest
+FOR EACH ROW
+EXECUTE FUNCTION enforce_cscb_repair_manifest_transition();
+
+-- +goose StatementBegin
+CREATE FUNCTION prevent_cscb_repair_audit_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'CSCB repair audit rows are immutable';
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER cscb_repair_block_update_trigger
+BEFORE UPDATE ON cscb_repair_block
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
+
+CREATE TRIGGER cscb_repair_block_delete_trigger
+BEFORE DELETE ON cscb_repair_block
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
+
+CREATE TRIGGER cscb_repair_manifest_delete_trigger
+BEFORE DELETE ON cscb_repair_manifest
+FOR EACH ROW
+EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM cscb_repair_manifest) THEN
+        RAISE EXCEPTION 'cannot roll back CSCB repair migration while repair manifests exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS cscb_repair_manifest_delete_trigger ON cscb_repair_manifest;
+DROP TRIGGER IF EXISTS cscb_repair_block_delete_trigger ON cscb_repair_block;
+DROP TRIGGER IF EXISTS cscb_repair_block_update_trigger ON cscb_repair_block;
+DROP FUNCTION IF EXISTS prevent_cscb_repair_audit_mutation();
+
+DROP TRIGGER IF EXISTS cscb_repair_manifest_transition_trigger ON cscb_repair_manifest;
+DROP FUNCTION IF EXISTS enforce_cscb_repair_manifest_transition();
+
+DROP INDEX IF EXISTS idx_cscb_repair_block_repair_height;
+DROP INDEX IF EXISTS idx_cscb_repair_manifest_pending;
+DROP TABLE IF EXISTS cscb_repair_block;
+DROP TABLE IF EXISTS cscb_repair_manifest;

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000001_add_cscb_repair_manifest.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000001_add_cscb_repair_manifest.sql
@@ -2,18 +2,15 @@
 CREATE TABLE cscb_repair_manifest (
     id BIGSERIAL PRIMARY KEY,
     tag INTEGER NOT NULL,
-    state TEXT NOT NULL CHECK (state IN ('prepared', 'restored', 'verified', 'completed')),
+    state TEXT NOT NULL CHECK (state IN ('preparing', 'prepared', 'restored', 'verified', 'completed')),
     bucket TEXT NOT NULL CHECK (bucket <> ''),
     old_consolidated_object_key_main TEXT NOT NULL CHECK (old_consolidated_object_key_main <> ''),
-    old_consolidated_object_version_id TEXT NOT NULL CHECK (
-        BTRIM(old_consolidated_object_version_id) <> ''
-        AND LOWER(BTRIM(old_consolidated_object_version_id)) <> 'null'
-    ),
-    old_consolidated_object_etag TEXT NOT NULL CHECK (old_consolidated_object_etag <> ''),
-    old_consolidated_object_bytes BIGINT NOT NULL CHECK (old_consolidated_object_bytes > 0),
+    old_consolidated_object_version_id TEXT,
+    old_consolidated_object_etag TEXT,
+    old_consolidated_object_bytes BIGINT,
     start_height BIGINT NOT NULL CHECK (start_height >= 0),
     end_height BIGINT NOT NULL CHECK (end_height > start_height),
-    canonical_block_count BIGINT NOT NULL CHECK (canonical_block_count > 0),
+    canonical_block_count BIGINT NOT NULL CHECK (canonical_block_count >= 0),
     total_block_count BIGINT NOT NULL CHECK (total_block_count >= canonical_block_count),
     row_set_sha256 CHAR(64) NOT NULL CHECK (row_set_sha256 ~ '^[0-9a-f]{64}$'),
     new_consolidated_object_key_main TEXT,
@@ -24,16 +21,33 @@ CREATE TABLE cscb_repair_manifest (
     prepared_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     restored_at TIMESTAMPTZ,
     verified_at TIMESTAMPTZ,
-    old_object_deleted_at TIMESTAMPTZ,
     completed_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (tag, old_consolidated_object_key_main),
     CHECK (
         (
-            state = 'prepared'
+            state = 'preparing'
+            AND old_consolidated_object_version_id IS NULL
+            AND old_consolidated_object_etag IS NULL
+            AND old_consolidated_object_bytes IS NULL
+        )
+        OR (
+            state <> 'preparing'
+            AND old_consolidated_object_version_id IS NOT NULL
+            AND BTRIM(old_consolidated_object_version_id) <> ''
+            AND LOWER(BTRIM(old_consolidated_object_version_id)) <> 'null'
+            AND old_consolidated_object_etag IS NOT NULL
+            AND old_consolidated_object_etag <> ''
+            AND old_consolidated_object_bytes IS NOT NULL
+            AND old_consolidated_object_bytes > 0
+        )
+    ),
+    CHECK (
+        (
+            state IN ('preparing', 'prepared')
+            AND outcome = ''
             AND restored_at IS NULL
             AND verified_at IS NULL
-            AND old_object_deleted_at IS NULL
             AND completed_at IS NULL
             AND new_consolidated_object_key_main IS NULL
             AND new_consolidated_object_version_id IS NULL
@@ -42,9 +56,9 @@ CREATE TABLE cscb_repair_manifest (
         )
         OR (
             state = 'restored'
+            AND outcome = ''
             AND restored_at IS NOT NULL
             AND verified_at IS NULL
-            AND old_object_deleted_at IS NULL
             AND completed_at IS NULL
             AND new_consolidated_object_key_main IS NULL
             AND new_consolidated_object_version_id IS NULL
@@ -53,11 +67,12 @@ CREATE TABLE cscb_repair_manifest (
         )
         OR (
             state = 'verified'
+            AND outcome = ''
             AND restored_at IS NOT NULL
             AND verified_at IS NOT NULL
             AND verified_at >= restored_at
-            AND old_object_deleted_at IS NULL
             AND completed_at IS NULL
+            AND canonical_block_count > 0
             AND new_consolidated_object_key_main IS NOT NULL
             AND new_consolidated_object_key_main <> ''
             AND new_consolidated_object_key_main <> old_consolidated_object_key_main
@@ -71,24 +86,49 @@ CREATE TABLE cscb_repair_manifest (
         )
         OR (
             state = 'completed'
-            AND restored_at IS NOT NULL
+            AND outcome = 'already_clean_storage_neutral'
+            AND restored_at IS NULL
             AND verified_at IS NOT NULL
-            AND verified_at >= restored_at
-            AND old_object_deleted_at IS NOT NULL
-            AND old_object_deleted_at >= verified_at
             AND completed_at IS NOT NULL
-            AND completed_at >= old_object_deleted_at
-            AND new_consolidated_object_key_main IS NOT NULL
-            AND new_consolidated_object_key_main <> ''
-            AND new_consolidated_object_key_main <> old_consolidated_object_key_main
-            AND new_consolidated_object_version_id IS NOT NULL
-            AND BTRIM(new_consolidated_object_version_id) <> ''
-            AND LOWER(BTRIM(new_consolidated_object_version_id)) <> 'null'
-            AND new_consolidated_object_etag IS NOT NULL
-            AND new_consolidated_object_etag <> ''
-            AND new_consolidated_object_bytes IS NOT NULL
-            AND new_consolidated_object_bytes > 0
+            AND completed_at >= verified_at
+            AND new_consolidated_object_key_main IS NULL
+            AND new_consolidated_object_version_id IS NULL
+            AND new_consolidated_object_etag IS NULL
+            AND new_consolidated_object_bytes IS NULL
+        )
+        OR (
+            state = 'completed'
             AND outcome <> ''
+            AND outcome <> 'already_clean_storage_neutral'
+            AND restored_at IS NOT NULL
+            AND completed_at IS NOT NULL
+            AND completed_at >= restored_at
+            AND (
+                (
+                    canonical_block_count > 0
+                    AND verified_at IS NOT NULL
+                    AND verified_at >= restored_at
+                    AND completed_at >= verified_at
+                    AND new_consolidated_object_key_main IS NOT NULL
+                    AND new_consolidated_object_key_main <> ''
+                    AND new_consolidated_object_key_main <> old_consolidated_object_key_main
+                    AND new_consolidated_object_version_id IS NOT NULL
+                    AND BTRIM(new_consolidated_object_version_id) <> ''
+                    AND LOWER(BTRIM(new_consolidated_object_version_id)) <> 'null'
+                    AND new_consolidated_object_etag IS NOT NULL
+                    AND new_consolidated_object_etag <> ''
+                    AND new_consolidated_object_bytes IS NOT NULL
+                    AND new_consolidated_object_bytes > 0
+                )
+                OR (
+                    canonical_block_count = 0
+                    AND verified_at IS NULL
+                    AND new_consolidated_object_key_main IS NULL
+                    AND new_consolidated_object_version_id IS NULL
+                    AND new_consolidated_object_etag IS NULL
+                    AND new_consolidated_object_bytes IS NULL
+                )
+            )
         )
     )
 );
@@ -100,19 +140,36 @@ CREATE TABLE cscb_repair_block (
     tag INTEGER NOT NULL,
     height BIGINT NOT NULL CHECK (height >= 0),
     hash VARCHAR(66),
-    single_block_object_key_main TEXT NOT NULL CHECK (single_block_object_key_main <> ''),
-    single_block_object_version_id TEXT NOT NULL CHECK (
-        BTRIM(single_block_object_version_id) <> ''
-        AND LOWER(BTRIM(single_block_object_version_id)) <> 'null'
-    ),
-    single_block_object_etag TEXT NOT NULL CHECK (single_block_object_etag <> ''),
-    single_block_object_bytes BIGINT NOT NULL CHECK (single_block_object_bytes > 0),
-    payload_sha256 CHAR(64) NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    single_block_object_key_main TEXT CHECK (single_block_object_key_main IS NULL OR single_block_object_key_main <> ''),
+    single_block_object_key_sha256 CHAR(64) NOT NULL CHECK (single_block_object_key_sha256 ~ '^[0-9a-f]{64}$'),
+    single_block_object_version_id TEXT,
+    single_block_object_etag TEXT,
+    single_block_object_bytes BIGINT,
+    payload_sha256 CHAR(64),
     old_byte_offset BIGINT NOT NULL CHECK (old_byte_offset >= 0),
     old_byte_length BIGINT NOT NULL CHECK (old_byte_length > 0),
     old_uncompressed_length BIGINT NOT NULL CHECK (old_uncompressed_length > 0),
     PRIMARY KEY (repair_id, block_metadata_id),
-    UNIQUE (block_metadata_id)
+    UNIQUE (block_metadata_id),
+    CHECK (
+        (
+            single_block_object_version_id IS NULL
+            AND single_block_object_etag IS NULL
+            AND single_block_object_bytes IS NULL
+            AND payload_sha256 IS NULL
+        )
+        OR (
+            single_block_object_version_id IS NOT NULL
+            AND BTRIM(single_block_object_version_id) <> ''
+            AND LOWER(BTRIM(single_block_object_version_id)) <> 'null'
+            AND single_block_object_etag IS NOT NULL
+            AND single_block_object_etag <> ''
+            AND single_block_object_bytes IS NOT NULL
+            AND single_block_object_bytes > 0
+            AND payload_sha256 IS NOT NULL
+            AND payload_sha256 ~ '^[0-9a-f]{64}$'
+        )
+    )
 );
 
 CREATE TABLE cscb_repair_execution (
@@ -127,29 +184,61 @@ CREATE INDEX idx_cscb_repair_manifest_pending
     ON cscb_repair_manifest (tag, end_height DESC, id)
     WHERE state <> 'completed';
 
+CREATE INDEX idx_cscb_repair_manifest_old_object
+    ON cscb_repair_manifest (old_consolidated_object_key_main);
+
 CREATE INDEX idx_cscb_repair_block_repair_height
     ON cscb_repair_block (repair_id, height, block_metadata_id);
+
+CREATE INDEX idx_cscb_repair_block_metadata
+    ON cscb_repair_block (block_metadata_id);
 
 CREATE INDEX idx_cscb_repair_execution_repair
     ON cscb_repair_execution (repair_id);
 
--- Once a repair pins an old consolidated object, no database writer may
--- reintroduce that object key. Existing references are removed by the repair
--- transaction; these triggers close the race between the final reference
--- check and exact-version deletion from S3.
+-- Application writers acquire the repair tag lock before touching rows. These
+-- triggers independently prevent any pinned old object key from being
+-- reintroduced, including callers that claim a non-CSCB format.
 -- +goose StatementBegin
 CREATE FUNCTION prevent_cscb_repair_old_block_metadata_reference()
 RETURNS TRIGGER AS $$
+DECLARE
+    pinned_old BOOLEAN;
 BEGIN
-    IF NEW.object_key_main IS NOT NULL AND NEW.object_format = 1 THEN
-        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.object_key_main, 1));
+    IF NEW.object_key_main IS NULL THEN
+        RETURN NEW;
     END IF;
-    IF NEW.object_key_main IS NOT NULL
-        AND EXISTS (
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM cscb_repair_manifest repair
+        WHERE repair.old_consolidated_object_key_main = NEW.object_key_main
+            AND NOT (
+                repair.state = 'completed'
+                AND repair.outcome = 'already_clean_storage_neutral'
+            )
+    ) INTO pinned_old;
+    IF NEW.object_format = 1 OR pinned_old THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.object_key_main, 1));
+        SELECT EXISTS (
             SELECT 1
             FROM cscb_repair_manifest repair
             WHERE repair.old_consolidated_object_key_main = NEW.object_key_main
-        ) THEN
+                AND NOT (
+                    repair.state = 'completed'
+                    AND repair.outcome = 'already_clean_storage_neutral'
+                )
+        ) INTO pinned_old;
+    END IF;
+    IF pinned_old THEN
+        IF TG_OP = 'UPDATE'
+            AND OLD.object_key_main IS NOT DISTINCT FROM NEW.object_key_main
+            AND OLD.object_format IS NOT DISTINCT FROM NEW.object_format
+            AND OLD.byte_offset IS NOT DISTINCT FROM NEW.byte_offset
+            AND OLD.byte_length IS NOT DISTINCT FROM NEW.byte_length
+            AND OLD.uncompressed_length IS NOT DISTINCT FROM NEW.uncompressed_length THEN
+            RETURN NEW;
+        END IF;
         RAISE EXCEPTION 'cannot reference a pinned old CSCB object from block_metadata id %', NEW.id;
     END IF;
     RETURN NEW;
@@ -158,23 +247,50 @@ $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
 
 CREATE TRIGGER cscb_repair_old_block_metadata_reference_trigger
-BEFORE INSERT OR UPDATE OF object_key_main ON block_metadata
+BEFORE INSERT OR UPDATE OF object_key_main, object_format, byte_offset, byte_length, uncompressed_length ON block_metadata
 FOR EACH ROW
 EXECUTE FUNCTION prevent_cscb_repair_old_block_metadata_reference();
 
 -- +goose StatementBegin
 CREATE FUNCTION prevent_cscb_repair_old_shadow_reference()
 RETURNS TRIGGER AS $$
+DECLARE
+    pinned_old BOOLEAN;
 BEGIN
-    IF NEW.consolidated_object_key_main IS NOT NULL AND NEW.object_format = 1 THEN
-        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.consolidated_object_key_main, 1));
+    IF NEW.consolidated_object_key_main IS NULL THEN
+        RETURN NEW;
     END IF;
-    IF NEW.consolidated_object_key_main IS NOT NULL
-        AND EXISTS (
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM cscb_repair_manifest repair
+        WHERE repair.old_consolidated_object_key_main = NEW.consolidated_object_key_main
+            AND NOT (
+                repair.state = 'completed'
+                AND repair.outcome = 'already_clean_storage_neutral'
+            )
+    ) INTO pinned_old;
+    IF NEW.object_format = 1 OR pinned_old THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.consolidated_object_key_main, 1));
+        SELECT EXISTS (
             SELECT 1
             FROM cscb_repair_manifest repair
             WHERE repair.old_consolidated_object_key_main = NEW.consolidated_object_key_main
-        ) THEN
+                AND NOT (
+                    repair.state = 'completed'
+                    AND repair.outcome = 'already_clean_storage_neutral'
+                )
+        ) INTO pinned_old;
+    END IF;
+    IF pinned_old THEN
+        IF TG_OP = 'UPDATE'
+            AND OLD.consolidated_object_key_main IS NOT DISTINCT FROM NEW.consolidated_object_key_main
+            AND OLD.object_format IS NOT DISTINCT FROM NEW.object_format
+            AND OLD.byte_offset IS NOT DISTINCT FROM NEW.byte_offset
+            AND OLD.byte_length IS NOT DISTINCT FROM NEW.byte_length
+            AND OLD.uncompressed_length IS NOT DISTINCT FROM NEW.uncompressed_length THEN
+            RETURN NEW;
+        END IF;
         RAISE EXCEPTION 'cannot reference a pinned old CSCB object from consolidation shadow for block_metadata id %', NEW.block_metadata_id;
     END IF;
     RETURN NEW;
@@ -183,7 +299,7 @@ $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
 
 CREATE TRIGGER cscb_repair_old_shadow_reference_trigger
-BEFORE INSERT OR UPDATE OF consolidated_object_key_main ON block_consolidation_shadow
+BEFORE INSERT OR UPDATE OF consolidated_object_key_main, object_format, byte_offset, byte_length, uncompressed_length ON block_consolidation_shadow
 FOR EACH ROW
 EXECUTE FUNCTION prevent_cscb_repair_old_shadow_reference();
 
@@ -195,21 +311,36 @@ BEGIN
         OR NEW.tag IS DISTINCT FROM OLD.tag
         OR NEW.bucket IS DISTINCT FROM OLD.bucket
         OR NEW.old_consolidated_object_key_main IS DISTINCT FROM OLD.old_consolidated_object_key_main
-        OR NEW.old_consolidated_object_version_id IS DISTINCT FROM OLD.old_consolidated_object_version_id
-        OR NEW.old_consolidated_object_etag IS DISTINCT FROM OLD.old_consolidated_object_etag
-        OR NEW.old_consolidated_object_bytes IS DISTINCT FROM OLD.old_consolidated_object_bytes
         OR NEW.start_height IS DISTINCT FROM OLD.start_height
         OR NEW.end_height IS DISTINCT FROM OLD.end_height
         OR NEW.canonical_block_count IS DISTINCT FROM OLD.canonical_block_count
         OR NEW.total_block_count IS DISTINCT FROM OLD.total_block_count
         OR NEW.row_set_sha256 IS DISTINCT FROM OLD.row_set_sha256
         OR NEW.prepared_at IS DISTINCT FROM OLD.prepared_at THEN
-        RAISE EXCEPTION 'cannot change pinned CSCB repair manifest fields for repair id %', OLD.id;
+        RAISE EXCEPTION 'cannot change fenced CSCB repair manifest fields for repair id %', OLD.id;
+    END IF;
+
+    IF OLD.state = 'preparing' THEN
+        IF NOT (
+            OLD.old_consolidated_object_version_id IS NULL
+            AND OLD.old_consolidated_object_etag IS NULL
+            AND OLD.old_consolidated_object_bytes IS NULL
+            AND NEW.old_consolidated_object_version_id IS NOT NULL
+            AND NEW.old_consolidated_object_etag IS NOT NULL
+            AND NEW.old_consolidated_object_bytes IS NOT NULL
+        ) THEN
+            RAISE EXCEPTION 'invalid CSCB repair source inspection for repair id %', OLD.id;
+        END IF;
+    ELSIF NEW.old_consolidated_object_version_id IS DISTINCT FROM OLD.old_consolidated_object_version_id
+        OR NEW.old_consolidated_object_etag IS DISTINCT FROM OLD.old_consolidated_object_etag
+        OR NEW.old_consolidated_object_bytes IS DISTINCT FROM OLD.old_consolidated_object_bytes THEN
+        RAISE EXCEPTION 'cannot change inspected CSCB repair source for repair id %', OLD.id;
     END IF;
 
     IF NOT (
-        (OLD.state = 'prepared' AND NEW.state IN ('prepared', 'restored'))
-        OR (OLD.state = 'restored' AND NEW.state IN ('restored', 'verified'))
+        (OLD.state = 'preparing' AND NEW.state IN ('prepared', 'completed'))
+        OR (OLD.state = 'prepared' AND NEW.state IN ('prepared', 'restored'))
+        OR (OLD.state = 'restored' AND NEW.state IN ('restored', 'verified', 'completed'))
         OR (OLD.state = 'verified' AND NEW.state IN ('verified', 'completed'))
         OR (OLD.state = 'completed' AND NEW.state = 'completed')
     ) THEN
@@ -227,27 +358,22 @@ BEGIN
         RAISE EXCEPTION 'cannot change verified CSCB repair target for repair id %', OLD.id;
     END IF;
 
-    IF OLD.restored_at IS NOT NULL
-        AND NEW.restored_at IS DISTINCT FROM OLD.restored_at THEN
+    IF OLD.restored_at IS NOT NULL AND NEW.restored_at IS DISTINCT FROM OLD.restored_at THEN
         RAISE EXCEPTION 'cannot change CSCB repair restore timestamp for repair id %', OLD.id;
     END IF;
 
     IF NEW.outcome IS DISTINCT FROM OLD.outcome
         AND NOT (
-            OLD.state = 'verified'
-            AND NEW.state = 'completed'
-            AND OLD.outcome = ''
-            AND NEW.outcome <> ''
+            (OLD.state = 'preparing' AND NEW.state = 'completed'
+                AND NEW.outcome = 'already_clean_storage_neutral')
+            OR ((OLD.state = 'verified' OR (OLD.state = 'restored' AND OLD.canonical_block_count = 0))
+                AND NEW.state = 'completed' AND OLD.outcome = '' AND NEW.outcome <> '')
         ) THEN
         RAISE EXCEPTION 'cannot change CSCB repair outcome outside completion for repair id %', OLD.id;
     END IF;
 
-    IF OLD.old_object_deleted_at IS NOT NULL
-        AND (
-            NEW.old_object_deleted_at IS DISTINCT FROM OLD.old_object_deleted_at
-            OR NEW.completed_at IS DISTINCT FROM OLD.completed_at
-        ) THEN
-        RAISE EXCEPTION 'cannot change completed CSCB repair timestamps for repair id %', OLD.id;
+    IF OLD.completed_at IS NOT NULL AND NEW.completed_at IS DISTINCT FROM OLD.completed_at THEN
+        RAISE EXCEPTION 'cannot change completed CSCB repair timestamp for repair id %', OLD.id;
     END IF;
     RETURN NEW;
 END;
@@ -259,6 +385,79 @@ BEFORE UPDATE ON cscb_repair_manifest
 FOR EACH ROW
 EXECUTE FUNCTION enforce_cscb_repair_manifest_transition();
 
+-- Inspection fills S3 observations exactly once. Retirement may later scrub
+-- the exact single-block path, retaining its hash and immutable object audit.
+-- +goose StatementBegin
+CREATE FUNCTION enforce_cscb_repair_block_audit_update()
+RETURNS TRIGGER AS $$
+DECLARE
+    repair_state TEXT;
+    retirement_deleted BOOLEAN;
+BEGIN
+    SELECT state INTO repair_state FROM cscb_repair_manifest WHERE id = OLD.repair_id;
+
+    IF repair_state = 'preparing'
+        AND NEW.repair_id IS NOT DISTINCT FROM OLD.repair_id
+        AND NEW.block_metadata_id IS NOT DISTINCT FROM OLD.block_metadata_id
+        AND NEW.canonical IS NOT DISTINCT FROM OLD.canonical
+        AND NEW.tag IS NOT DISTINCT FROM OLD.tag
+        AND NEW.height IS NOT DISTINCT FROM OLD.height
+        AND NEW.hash IS NOT DISTINCT FROM OLD.hash
+        AND NEW.single_block_object_key_main IS NOT DISTINCT FROM OLD.single_block_object_key_main
+        AND NEW.single_block_object_key_sha256 IS NOT DISTINCT FROM OLD.single_block_object_key_sha256
+        AND OLD.single_block_object_version_id IS NULL
+        AND OLD.single_block_object_etag IS NULL
+        AND OLD.single_block_object_bytes IS NULL
+        AND OLD.payload_sha256 IS NULL
+        AND NEW.single_block_object_version_id IS NOT NULL
+        AND NEW.single_block_object_etag IS NOT NULL
+        AND NEW.single_block_object_bytes IS NOT NULL
+        AND NEW.payload_sha256 IS NOT NULL
+        AND NEW.old_byte_offset IS NOT DISTINCT FROM OLD.old_byte_offset
+        AND NEW.old_byte_length IS NOT DISTINCT FROM OLD.old_byte_length
+        AND NEW.old_uncompressed_length IS NOT DISTINCT FROM OLD.old_uncompressed_length THEN
+        RETURN NEW;
+    END IF;
+
+    IF repair_state = 'completed'
+        AND OLD.single_block_object_key_main IS NOT NULL
+        AND NEW.single_block_object_key_main IS NULL
+        AND NEW.repair_id IS NOT DISTINCT FROM OLD.repair_id
+        AND NEW.block_metadata_id IS NOT DISTINCT FROM OLD.block_metadata_id
+        AND NEW.canonical IS NOT DISTINCT FROM OLD.canonical
+        AND NEW.tag IS NOT DISTINCT FROM OLD.tag
+        AND NEW.height IS NOT DISTINCT FROM OLD.height
+        AND NEW.hash IS NOT DISTINCT FROM OLD.hash
+        AND NEW.single_block_object_key_sha256 IS NOT DISTINCT FROM OLD.single_block_object_key_sha256
+        AND NEW.single_block_object_version_id IS NOT DISTINCT FROM OLD.single_block_object_version_id
+        AND NEW.single_block_object_etag IS NOT DISTINCT FROM OLD.single_block_object_etag
+        AND NEW.single_block_object_bytes IS NOT DISTINCT FROM OLD.single_block_object_bytes
+        AND NEW.payload_sha256 IS NOT DISTINCT FROM OLD.payload_sha256
+        AND NEW.old_byte_offset IS NOT DISTINCT FROM OLD.old_byte_offset
+        AND NEW.old_byte_length IS NOT DISTINCT FROM OLD.old_byte_length
+        AND NEW.old_uncompressed_length IS NOT DISTINCT FROM OLD.old_uncompressed_length THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM block_single_block_retention retirement
+            WHERE retirement.block_metadata_id = OLD.block_metadata_id
+                AND retirement.state IN ('deleted_pending_verification', 'completed')
+                AND retirement.deleted_at IS NOT NULL
+        ) INTO retirement_deleted;
+        IF retirement_deleted THEN
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    RAISE EXCEPTION 'cannot mutate CSCB repair block audit for metadata id %', OLD.block_metadata_id;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER cscb_repair_block_update_trigger
+BEFORE UPDATE ON cscb_repair_block
+FOR EACH ROW
+EXECUTE FUNCTION enforce_cscb_repair_block_audit_update();
+
 -- +goose StatementBegin
 CREATE FUNCTION prevent_cscb_repair_audit_mutation()
 RETURNS TRIGGER AS $$
@@ -267,11 +466,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
-
-CREATE TRIGGER cscb_repair_block_update_trigger
-BEFORE UPDATE ON cscb_repair_block
-FOR EACH ROW
-EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
 
 CREATE TRIGGER cscb_repair_block_delete_trigger
 BEFORE DELETE ON cscb_repair_block
@@ -297,8 +491,11 @@ EXECUTE FUNCTION prevent_cscb_repair_audit_mutation();
 -- +goose StatementBegin
 DO $$
 BEGIN
-    IF EXISTS (SELECT 1 FROM cscb_repair_manifest) THEN
-        RAISE EXCEPTION 'cannot roll back CSCB repair migration while repair manifests exist';
+    LOCK TABLE cscb_repair_execution, cscb_repair_block, cscb_repair_manifest
+        IN ACCESS EXCLUSIVE MODE;
+    IF EXISTS (SELECT 1 FROM cscb_repair_manifest)
+        OR EXISTS (SELECT 1 FROM cscb_repair_execution) THEN
+        RAISE EXCEPTION 'cannot roll back CSCB repair migration while repair manifests or execution bindings exist';
     END IF;
 END $$;
 -- +goose StatementEnd
@@ -307,8 +504,10 @@ DROP TRIGGER IF EXISTS cscb_repair_manifest_delete_trigger ON cscb_repair_manife
 DROP TRIGGER IF EXISTS cscb_repair_execution_delete_trigger ON cscb_repair_execution;
 DROP TRIGGER IF EXISTS cscb_repair_execution_update_trigger ON cscb_repair_execution;
 DROP TRIGGER IF EXISTS cscb_repair_block_delete_trigger ON cscb_repair_block;
-DROP TRIGGER IF EXISTS cscb_repair_block_update_trigger ON cscb_repair_block;
 DROP FUNCTION IF EXISTS prevent_cscb_repair_audit_mutation();
+
+DROP TRIGGER IF EXISTS cscb_repair_block_update_trigger ON cscb_repair_block;
+DROP FUNCTION IF EXISTS enforce_cscb_repair_block_audit_update();
 
 DROP TRIGGER IF EXISTS cscb_repair_old_shadow_reference_trigger ON block_consolidation_shadow;
 DROP FUNCTION IF EXISTS prevent_cscb_repair_old_shadow_reference();
@@ -321,6 +520,7 @@ DROP FUNCTION IF EXISTS enforce_cscb_repair_manifest_transition();
 
 DROP INDEX IF EXISTS idx_cscb_repair_execution_repair;
 DROP INDEX IF EXISTS idx_cscb_repair_block_repair_height;
+DROP INDEX IF EXISTS idx_cscb_repair_manifest_old_object;
 DROP INDEX IF EXISTS idx_cscb_repair_manifest_pending;
 DROP TABLE IF EXISTS cscb_repair_execution;
 DROP TABLE IF EXISTS cscb_repair_block;

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
@@ -1,0 +1,23 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_cscb_repair_candidate
+    ON block_metadata (tag, height DESC, object_key_main, id)
+    WHERE object_format = 1
+        AND object_key_main IS NOT NULL
+        AND object_key_main <> '';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_object_key_reference
+    ON block_metadata (object_key_main, id)
+    WHERE object_key_main IS NOT NULL
+        AND object_key_main <> '';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_object_key_reference
+    ON block_consolidation_shadow (consolidated_object_key_main, block_metadata_id)
+    WHERE consolidated_object_key_main IS NOT NULL
+        AND consolidated_object_key_main <> '';
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate;

--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -22,6 +22,18 @@ type blockPayloadVerifier interface {
 	VerifyConsolidated(ctx context.Context, candidate Candidate) (string, error)
 }
 
+type (
+	PinnedPayloadInspection struct {
+		CanonicalSHA256     string
+		HasStoragePlacement bool
+	}
+
+	PinnedPayloadVerifier interface {
+		InspectSingleBlock(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error)
+		InspectConsolidated(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error)
+	}
+)
+
 type payloadVerifier struct {
 	store ObjectStore
 
@@ -37,64 +49,81 @@ func newPayloadVerifier(store ObjectStore) *payloadVerifier {
 	}
 }
 
+func NewPinnedPayloadVerifier(store ObjectStore) PinnedPayloadVerifier {
+	return newPayloadVerifier(store)
+}
+
 func (v *payloadVerifier) Verify(ctx context.Context, candidate Candidate) (string, error) {
-	singleBlockCompressed, err := v.store.ReadObjectVersion(ctx, candidate.Bucket, candidate.Key, candidate.VersionID)
+	singleBlockInspection, err := v.InspectSingleBlock(ctx, candidate)
 	if err != nil {
 		return "", err
+	}
+	consolidatedInspection, err := v.InspectConsolidated(ctx, candidate)
+	if err != nil {
+		return "", err
+	}
+	if consolidatedInspection.HasStoragePlacement {
+		return "", xerrors.Errorf("pinned CSCB block payload retains storage placement metadata at height %d", candidate.Height)
+	}
+	if singleBlockInspection.CanonicalSHA256 != consolidatedInspection.CanonicalSHA256 {
+		return "", xerrors.Errorf("single-block and CSCB block payloads differ at height %d", candidate.Height)
+	}
+	return singleBlockInspection.CanonicalSHA256, nil
+}
+
+func (v *payloadVerifier) InspectSingleBlock(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error) {
+	singleBlockCompressed, err := v.store.ReadObjectVersion(ctx, candidate.Bucket, candidate.Key, candidate.VersionID)
+	if err != nil {
+		return PinnedPayloadInspection{}, err
 	}
 	singleBlockPayload, err := storageutils.Decompress(singleBlockCompressed, storageutils.GetCompressionType(candidate.Key))
 	if err != nil {
-		return "", xerrors.Errorf("failed to decompress pinned single-block object: %w", err)
+		return PinnedPayloadInspection{}, xerrors.Errorf("failed to decompress pinned single-block object: %w", err)
 	}
 	var singleBlockBlock api.Block
 	if err := proto.Unmarshal(singleBlockPayload, &singleBlockBlock); err != nil {
-		return "", xerrors.Errorf("failed to parse pinned single-block block payload: %w", err)
+		return PinnedPayloadInspection{}, xerrors.Errorf("failed to parse pinned single-block block payload: %w", err)
 	}
 	if err := validatePayloadIdentity(&singleBlockBlock, candidate); err != nil {
-		return "", xerrors.Errorf("pinned single-block block identity mismatch: %w", err)
+		return PinnedPayloadInspection{}, xerrors.Errorf("pinned single-block block identity mismatch: %w", err)
 	}
+	digest, err := canonicalBlockDigest(storageutils.CloneBlockWithoutStoragePlacement(&singleBlockBlock))
+	if err != nil {
+		return PinnedPayloadInspection{}, err
+	}
+	return PinnedPayloadInspection{
+		CanonicalSHA256:     digest,
+		HasStoragePlacement: storageutils.HasBlockStoragePlacement(&singleBlockBlock),
+	}, nil
+}
 
+func (v *payloadVerifier) InspectConsolidated(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error) {
 	_, cscbBlock, err := v.readConsolidatedPayload(ctx, candidate)
 	if err != nil {
-		return "", err
+		return PinnedPayloadInspection{}, err
 	}
 	if err := validatePayloadIdentity(cscbBlock, candidate); err != nil {
-		return "", xerrors.Errorf("pinned CSCB block identity mismatch: %w", err)
+		return PinnedPayloadInspection{}, xerrors.Errorf("pinned CSCB block identity mismatch: %w", err)
 	}
-	if storageutils.HasBlockStoragePlacement(cscbBlock) {
-		return "", xerrors.Errorf("pinned CSCB block payload retains storage placement metadata at height %d", candidate.Height)
-	}
-	singleBlockComparable := storageutils.CloneBlockWithoutStoragePlacement(&singleBlockBlock)
-	cscbComparable := storageutils.CloneBlockWithoutStoragePlacement(cscbBlock)
-	if !proto.Equal(singleBlockComparable, cscbComparable) {
-		return "", xerrors.Errorf("single-block and CSCB block payloads differ at height %d", candidate.Height)
-	}
-	singleBlockDigest, err := canonicalBlockDigest(singleBlockComparable)
+	digest, err := canonicalBlockDigest(storageutils.CloneBlockWithoutStoragePlacement(cscbBlock))
 	if err != nil {
-		return "", err
+		return PinnedPayloadInspection{}, err
 	}
-	cscbDigest, err := canonicalBlockDigest(cscbComparable)
-	if err != nil {
-		return "", err
-	}
-	if singleBlockDigest != cscbDigest {
-		return "", xerrors.Errorf("single-block and CSCB canonical payload digests differ at height %d", candidate.Height)
-	}
-	return singleBlockDigest, nil
+	return PinnedPayloadInspection{
+		CanonicalSHA256:     digest,
+		HasStoragePlacement: storageutils.HasBlockStoragePlacement(cscbBlock),
+	}, nil
 }
 
 func (v *payloadVerifier) VerifyConsolidated(ctx context.Context, candidate Candidate) (string, error) {
-	_, block, err := v.readConsolidatedPayload(ctx, candidate)
+	inspection, err := v.InspectConsolidated(ctx, candidate)
 	if err != nil {
 		return "", err
 	}
-	if err := validatePayloadIdentity(block, candidate); err != nil {
-		return "", xerrors.Errorf("pinned CSCB block identity mismatch: %w", err)
-	}
-	if storageutils.HasBlockStoragePlacement(block) {
+	if inspection.HasStoragePlacement {
 		return "", xerrors.Errorf("pinned CSCB block payload retains storage placement metadata at height %d", candidate.Height)
 	}
-	return canonicalBlockDigest(storageutils.CloneBlockWithoutStoragePlacement(block))
+	return inspection.CanonicalSHA256, nil
 }
 
 func canonicalBlockDigest(block *api.Block) (string, error) {

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -173,6 +173,13 @@ func (r *PostgresRepository) PrepareRetirement(ctx context.Context, manifest Ret
 			AND shadow.single_block_delete_after IS NOT NULL
 			AND shadow.single_block_delete_after <= CURRENT_TIMESTAMP
 			AND shadow.single_block_object_deleted_at IS NULL
+			AND NOT EXISTS (
+				SELECT 1
+				FROM cscb_repair_block repair_block
+				JOIN cscb_repair_manifest repair ON repair.id = repair_block.repair_id
+				WHERE repair_block.block_metadata_id = bm.id
+					AND repair.state <> 'completed'
+			)
 		FOR UPDATE OF cb, bm, shadow`
 	var lockedID int64
 	var databasePreparedAt time.Time

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -500,6 +500,9 @@ func (r *PostgresRepository) RecordRetirementObjectDeleted(
 			!metadata.shadowDeletedAt.Time.Equal(*manifest.DeletedAt) {
 			return time.Time{}, xerrors.Errorf("pending-verification retirement metadata is inconsistent: block_metadata_id=%d", blockMetadataID)
 		}
+		if err := clearCompletedRepairSingleBlockPath(ctx, tx, blockMetadataID, ""); err != nil {
+			return time.Time{}, err
+		}
 		if err := tx.Commit(); err != nil {
 			return time.Time{}, xerrors.Errorf("failed to commit idempotent retirement object deletion: %w", err)
 		}
@@ -570,10 +573,38 @@ func (r *PostgresRepository) RecordRetirementObjectDeleted(
 	if rows, err := result.RowsAffected(); err != nil || rows != 1 {
 		return time.Time{}, xerrors.Errorf("%w: block_metadata_id=%d rows=%d err=%v", ErrRetirementClaimUnavailable, blockMetadataID, rows, err)
 	}
+	if err := clearCompletedRepairSingleBlockPath(ctx, tx, blockMetadataID, manifest.SingleBlockObjectKey); err != nil {
+		return time.Time{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return time.Time{}, xerrors.Errorf("failed to commit retirement object deletion: %w", err)
 	}
 	return databaseDeletedAt, nil
+}
+
+func clearCompletedRepairSingleBlockPath(
+	ctx context.Context,
+	tx *sql.Tx,
+	blockMetadataID int64,
+	expectedObjectKey string,
+) error {
+	result, err := tx.ExecContext(ctx, `
+		UPDATE cscb_repair_block
+		SET single_block_object_key_main = NULL
+		WHERE block_metadata_id = $1
+			AND single_block_object_key_main IS NOT NULL
+			AND ($2 = '' OR single_block_object_key_main = $2)`, blockMetadataID, expectedObjectKey)
+	if err != nil {
+		return xerrors.Errorf("failed to clear retired CSCB repair single-block path: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return xerrors.Errorf("failed to inspect retired CSCB repair path clear: %w", err)
+	}
+	if rows > 1 {
+		return xerrors.Errorf("retired CSCB repair path clear guard failed: block_metadata_id=%d rows=%d", blockMetadataID, rows)
+	}
+	return nil
 }
 
 func (r *PostgresRepository) FinalizeRetirement(

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -53,12 +53,13 @@ type (
 	}
 
 	BatchConsolidatorRequest struct {
-		Mode             config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill repair_existing_cscb"`
-		Tag              uint32
-		StartHeight      uint64
-		EndHeight        uint64 `validate:"gtfield=StartHeight"`
-		MaxBlocks        uint64 `validate:"required"`
-		DeleteOldObjects bool
+		Mode               config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill repair_existing_cscb"`
+		Tag                uint32
+		StartHeight        uint64
+		EndHeight          uint64 `validate:"gtfield=StartHeight"`
+		MaxBlocks          uint64 `validate:"required"`
+		DeleteOldObjects   bool
+		RepairExecutionKey string
 	}
 
 	BatchConsolidatorResponse struct {
@@ -290,6 +291,7 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 	}
 	manifest, err := repairer.PrepareNext(
 		ctx,
+		request.RepairExecutionKey,
 		request.Tag,
 		request.StartHeight,
 		request.EndHeight,

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	sdkactivity "go.temporal.io/sdk/activity"
@@ -16,8 +17,12 @@ import (
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
+	chains3 "github.com/coinbase/chainstorage/internal/s3"
 	"github.com/coinbase/chainstorage/internal/storage/blobstorage"
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepair"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	metapostgres "github.com/coinbase/chainstorage/internal/storage/metastorage/postgres"
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
 	storageutils "github.com/coinbase/chainstorage/internal/storage/utils"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
@@ -33,6 +38,9 @@ type (
 		config              *config.Config
 		metaStorage         metastorage.MetaStorage
 		blobStorage         blobstorage.BlobStorage
+		s3Client            chains3.Client
+		repairerMu          sync.Mutex
+		repairer            cscbrepair.Repairer
 	}
 
 	BatchConsolidatorParams struct {
@@ -41,14 +49,16 @@ type (
 		Runtime     cadence.Runtime
 		MetaStorage metastorage.MetaStorage
 		BlobStorage blobstorage.BlobStorage
+		S3Client    chains3.Client `optional:"true"`
 	}
 
 	BatchConsolidatorRequest struct {
-		Mode        config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill"`
-		Tag         uint32
-		StartHeight uint64
-		EndHeight   uint64 `validate:"gtfield=StartHeight"`
-		MaxBlocks   uint64 `validate:"required"`
+		Mode             config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill repair_existing_cscb"`
+		Tag              uint32
+		StartHeight      uint64
+		EndHeight        uint64 `validate:"gtfield=StartHeight"`
+		MaxBlocks        uint64 `validate:"required"`
+		DeleteOldObjects bool
 	}
 
 	BatchConsolidatorResponse struct {
@@ -58,6 +68,9 @@ type (
 		ConsolidatedBlocks uint64
 		PromotedBlocks     uint64
 		ObjectKey          string
+		OldObjectKey       string
+		RepairedObjects    uint64
+		PendingOldDeletion bool
 	}
 
 	BatchConsolidatorStatsRequest struct {
@@ -118,6 +131,7 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 		config:              params.Config,
 		metaStorage:         params.MetaStorage,
 		blobStorage:         params.BlobStorage,
+		s3Client:            params.S3Client,
 	}
 	a.register(a.execute)
 	a.statsActivity.register(a.executeStats)
@@ -237,6 +251,9 @@ func (a *BatchConsolidator) execute(ctx context.Context, request *BatchConsolida
 	if mode == "" {
 		mode = a.config.AWS.Storage.Consolidation.Mode
 	}
+	if mode.IsRepairExistingCSCB() {
+		return a.executeRepairExistingCSCB(ctx, request)
+	}
 	if mode.IsShadowWrite() {
 		return a.executeShadowDualWrite(ctx, request)
 	}
@@ -255,6 +272,140 @@ func (a *BatchConsolidator) execute(ctx context.Context, request *BatchConsolida
 			mode,
 		)
 	}
+}
+
+func (a *BatchConsolidator) executeRepairExistingCSCB(
+	ctx context.Context,
+	request *BatchConsolidatorRequest,
+) (*BatchConsolidatorResponse, error) {
+	if err := a.validateConsolidationEnabled(); err != nil {
+		return nil, err
+	}
+	repairer, err := a.getCSCBRepairer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	progress := func(stage string, completed int, total int, height uint64) {
+		sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.repair."+stage, completed, total, height)
+	}
+	manifest, err := repairer.PrepareNext(
+		ctx,
+		request.Tag,
+		request.StartHeight,
+		request.EndHeight,
+		request.MaxBlocks,
+		progress,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to prepare next CSCB repair: %w", err)
+	}
+	if manifest == nil {
+		return &BatchConsolidatorResponse{
+			StartHeight: request.StartHeight,
+			EndHeight:   request.EndHeight,
+		}, nil
+	}
+
+	logger := a.getLogger(ctx).With(
+		zap.Int64("repair_id", manifest.ID),
+		zap.String("repair_state", string(manifest.State)),
+		zap.String("old_object_key", manifest.OldConsolidatedObjectKey),
+		zap.Uint64("repair_start_height", manifest.StartHeight),
+		zap.Uint64("repair_end_height", manifest.EndHeight),
+		zap.Uint64("repair_blocks", manifest.TotalBlockCount),
+		zap.Uint64("repair_canonical_blocks", manifest.CanonicalBlockCount),
+	)
+	logger.Info("resuming CSCB repair")
+
+	if manifest.State == cscbrepair.StatePrepared {
+		manifest, err = repairer.Restore(ctx, manifest.ID, progress)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore CSCB repair to single-block metadata: %w", err)
+		}
+	}
+	if manifest.State == cscbrepair.StateRestored {
+		normalResponse, err := a.executeShadowDualWrite(ctx, &BatchConsolidatorRequest{
+			Mode:        config.ConsolidationModeHistoricalBackfill,
+			Tag:         manifest.Tag,
+			StartHeight: manifest.StartHeight,
+			EndHeight:   manifest.EndHeight,
+			MaxBlocks:   request.MaxBlocks,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to rebuild normalized CSCB: %w", err)
+		}
+		if normalResponse.ScannedBlocks != 0 && normalResponse.ScannedBlocks != manifest.CanonicalBlockCount {
+			return nil, xerrors.Errorf(
+				"CSCB repair rebuilt unexpected canonical row count: expected=%d actual=%d",
+				manifest.CanonicalBlockCount,
+				normalResponse.ScannedBlocks,
+			)
+		}
+		manifest, err = repairer.VerifyRebuilt(ctx, manifest.ID, progress)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to verify rebuilt CSCB: %w", err)
+		}
+	}
+	pendingOldDeletion := manifest.State == cscbrepair.StateVerified && !request.DeleteOldObjects
+	if manifest.State == cscbrepair.StateVerified && request.DeleteOldObjects {
+		manifest, err = repairer.DeleteOldObject(ctx, manifest.ID)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to delete pinned dirty CSCB: %w", err)
+		}
+	}
+	if manifest.State != cscbrepair.StateCompleted && !pendingOldDeletion {
+		return nil, xerrors.Errorf("CSCB repair made no terminal progress: id=%d state=%s", manifest.ID, manifest.State)
+	}
+
+	logger.Info(
+		"processed CSCB repair",
+		zap.String("final_state", string(manifest.State)),
+		zap.String("new_object_key", manifest.NewConsolidatedObjectKey),
+		zap.Bool("pending_old_deletion", pendingOldDeletion),
+	)
+	return &BatchConsolidatorResponse{
+		StartHeight:        manifest.StartHeight,
+		EndHeight:          manifest.EndHeight,
+		ScannedBlocks:      manifest.TotalBlockCount,
+		ConsolidatedBlocks: manifest.CanonicalBlockCount,
+		PromotedBlocks:     manifest.CanonicalBlockCount,
+		ObjectKey:          manifest.NewConsolidatedObjectKey,
+		OldObjectKey:       manifest.OldConsolidatedObjectKey,
+		RepairedObjects:    1,
+		PendingOldDeletion: pendingOldDeletion,
+	}, nil
+}
+
+func (a *BatchConsolidator) getCSCBRepairer(ctx context.Context) (cscbrepair.Repairer, error) {
+	a.repairerMu.Lock()
+	defer a.repairerMu.Unlock()
+	if a.repairer != nil {
+		return a.repairer, nil
+	}
+	if a.config.StorageType.MetaStorageType != config.MetaStorageType_POSTGRES || a.config.AWS.Postgres == nil {
+		return nil, xerrors.New("repair_existing_cscb requires Postgres meta storage")
+	}
+	if a.config.StorageType.BlobStorageType != config.BlobStorageType_UNSPECIFIED &&
+		a.config.StorageType.BlobStorageType != config.BlobStorageType_S3 {
+		return nil, xerrors.New("repair_existing_cscb requires S3 blob storage")
+	}
+	if a.s3Client == nil {
+		return nil, xerrors.New("repair_existing_cscb requires an S3 client")
+	}
+	pool, err := metapostgres.GetConnectionPool(ctx, a.config.AWS.Postgres)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get CSCB repair Postgres pool: %w", err)
+	}
+	db := pool.DB()
+	if db == nil {
+		return nil, xerrors.New("CSCB repair Postgres pool returned a nil database")
+	}
+	a.repairer = cscbrepair.NewRepairer(
+		cscbrepair.NewPostgresRepository(db),
+		retirement.NewS3ObjectStore(a.s3Client),
+		a.config.AWS.Bucket,
+	)
+	return a.repairer, nil
 }
 
 func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -58,7 +58,6 @@ type (
 		StartHeight        uint64
 		EndHeight          uint64 `validate:"gtfield=StartHeight"`
 		MaxBlocks          uint64 `validate:"required"`
-		DeleteOldObjects   bool
 		RepairExecutionKey string
 	}
 
@@ -71,7 +70,6 @@ type (
 		ObjectKey          string
 		OldObjectKey       string
 		RepairedObjects    uint64
-		PendingOldDeletion bool
 	}
 
 	BatchConsolidatorStatsRequest struct {
@@ -325,14 +323,20 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 			return nil, xerrors.Errorf("failed to restore CSCB repair to single-block metadata: %w", err)
 		}
 	}
-	if manifest.State == cscbrepair.StateRestored {
-		normalResponse, err := a.executeShadowDualWrite(ctx, &BatchConsolidatorRequest{
+	if manifest.State == cscbrepair.StateRestored && manifest.CanonicalBlockCount > 0 {
+		expectedRecords := make(map[int64]cscbrepair.Block, manifest.CanonicalBlockCount)
+		for _, block := range manifest.Blocks {
+			if block.Canonical {
+				expectedRecords[block.BlockMetadataID] = block
+			}
+		}
+		normalResponse, err := a.executeShadowDualWriteWithExpected(ctx, &BatchConsolidatorRequest{
 			Mode:        config.ConsolidationModeHistoricalBackfill,
 			Tag:         manifest.Tag,
 			StartHeight: manifest.StartHeight,
 			EndHeight:   manifest.EndHeight,
 			MaxBlocks:   request.MaxBlocks,
-		})
+		}, expectedRecords)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to rebuild normalized CSCB: %w", err)
 		}
@@ -348,14 +352,13 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 			return nil, xerrors.Errorf("failed to verify rebuilt CSCB: %w", err)
 		}
 	}
-	pendingOldDeletion := manifest.State == cscbrepair.StateVerified && !request.DeleteOldObjects
-	if manifest.State == cscbrepair.StateVerified && request.DeleteOldObjects {
-		manifest, err = repairer.DeleteOldObject(ctx, manifest.ID)
+	if manifest.State == cscbrepair.StateRestored || manifest.State == cscbrepair.StateVerified {
+		manifest, err = repairer.Complete(ctx, manifest.ID, progress)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to delete pinned dirty CSCB: %w", err)
+			return nil, xerrors.Errorf("failed to complete CSCB repair: %w", err)
 		}
 	}
-	if manifest.State != cscbrepair.StateCompleted && !pendingOldDeletion {
+	if manifest.State != cscbrepair.StateCompleted {
 		return nil, xerrors.Errorf("CSCB repair made no terminal progress: id=%d state=%s", manifest.ID, manifest.State)
 	}
 
@@ -363,18 +366,25 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 		"processed CSCB repair",
 		zap.String("final_state", string(manifest.State)),
 		zap.String("new_object_key", manifest.NewConsolidatedObjectKey),
-		zap.Bool("pending_old_deletion", pendingOldDeletion),
+		zap.String("old_object_outcome", manifest.Outcome),
 	)
+	consolidatedBlocks := manifest.CanonicalBlockCount
+	promotedBlocks := manifest.CanonicalBlockCount
+	objectKey := manifest.NewConsolidatedObjectKey
+	if manifest.Outcome == cscbrepair.OutcomeAlreadyCleanStorageNeutral {
+		consolidatedBlocks = 0
+		promotedBlocks = 0
+		objectKey = manifest.OldConsolidatedObjectKey
+	}
 	return &BatchConsolidatorResponse{
 		StartHeight:        manifest.StartHeight,
 		EndHeight:          manifest.EndHeight,
 		ScannedBlocks:      manifest.TotalBlockCount,
-		ConsolidatedBlocks: manifest.CanonicalBlockCount,
-		PromotedBlocks:     manifest.CanonicalBlockCount,
-		ObjectKey:          manifest.NewConsolidatedObjectKey,
+		ConsolidatedBlocks: consolidatedBlocks,
+		PromotedBlocks:     promotedBlocks,
+		ObjectKey:          objectKey,
 		OldObjectKey:       manifest.OldConsolidatedObjectKey,
 		RepairedObjects:    1,
-		PendingOldDeletion: pendingOldDeletion,
 	}, nil
 }
 
@@ -411,6 +421,14 @@ func (a *BatchConsolidator) getCSCBRepairer(ctx context.Context) (cscbrepair.Rep
 }
 
 func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {
+	return a.executeShadowDualWriteWithExpected(ctx, request, nil)
+}
+
+func (a *BatchConsolidator) executeShadowDualWriteWithExpected(
+	ctx context.Context,
+	request *BatchConsolidatorRequest,
+	expectedRecords map[int64]cscbrepair.Block,
+) (*BatchConsolidatorResponse, error) {
 	if err := a.validateShadowWriteMode(request.Mode); err != nil {
 		return nil, err
 	}
@@ -435,9 +453,13 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 			return nil, err
 		}
 	}
-	prePromotedBlocks, err := a.promoteConsolidatedBlocks(ctx, mode, request)
-	if err != nil {
-		return nil, err
+	var prePromotedBlocks uint64
+	if expectedRecords == nil {
+		var err error
+		prePromotedBlocks, err = a.promoteConsolidatedBlocks(ctx, mode, request)
+		if err != nil {
+			return nil, err
+		}
 	}
 	scanStart := time.Now()
 	records, err := a.metaStorage.GetBlocksMissingConsolidationShadow(ctx, request.Tag, request.StartHeight, request.EndHeight, request.MaxBlocks)
@@ -447,11 +469,23 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 	scanDuration := time.Since(scanStart)
 	logger.Info("scanned missing consolidation shadows", zap.Int("records", len(records)), zap.Duration("duration", scanDuration))
 	if len(records) == 0 {
+		if expectedRecords != nil {
+			postPromotedBlocks, err := a.promoteConsolidatedBlocks(ctx, mode, request)
+			if err != nil {
+				return nil, err
+			}
+			prePromotedBlocks += postPromotedBlocks
+		}
 		return &BatchConsolidatorResponse{
 			StartHeight:    request.StartHeight,
 			EndHeight:      request.EndHeight,
 			PromotedBlocks: prePromotedBlocks,
 		}, nil
+	}
+	if expectedRecords != nil {
+		if err := validateExactRepairRecords(records, expectedRecords); err != nil {
+			return nil, err
+		}
 	}
 
 	buildStart := time.Now()
@@ -516,6 +550,48 @@ func (a *BatchConsolidator) executeShadowDualWrite(ctx context.Context, request 
 		zap.Duration("total_duration", time.Since(totalStart)),
 	)
 	return response, nil
+}
+
+func validateExactRepairRecords(
+	records []*metastorage.BlockMetadataRecord,
+	expected map[int64]cscbrepair.Block,
+) error {
+	if len(records) != len(expected) {
+		return xerrors.Errorf("CSCB repair rebuild row count mismatch before upload: expected=%d actual=%d", len(expected), len(records))
+	}
+	seen := make(map[int64]struct{}, len(records))
+	for _, record := range records {
+		if record == nil || record.Metadata == nil {
+			return xerrors.New("CSCB repair rebuild returned missing block metadata record")
+		}
+		block, ok := expected[record.ID]
+		if !ok {
+			return xerrors.Errorf("CSCB repair rebuild returned unexpected metadata_id=%d", record.ID)
+		}
+		if _, ok := seen[record.ID]; ok {
+			return xerrors.Errorf("CSCB repair rebuild returned duplicate metadata_id=%d", record.ID)
+		}
+		seen[record.ID] = struct{}{}
+		metadata := record.Metadata
+		if metadata.GetTag() != block.Tag || metadata.GetHeight() != block.Height || metadata.GetHash() != block.Hash {
+			return xerrors.Errorf(
+				"CSCB repair rebuild identity changed for metadata_id=%d: expected=(%d,%d,%q) actual=(%d,%d,%q)",
+				record.ID,
+				block.Tag,
+				block.Height,
+				block.Hash,
+				metadata.GetTag(),
+				metadata.GetHeight(),
+				metadata.GetHash(),
+			)
+		}
+		if metadata.GetObjectKeyMain() != block.SingleBlockObjectKey ||
+			metadata.GetObjectFormat() != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK ||
+			metadata.GetByteOffset() != 0 || metadata.GetByteLength() != 0 || metadata.GetUncompressedLength() != 0 {
+			return xerrors.Errorf("CSCB repair rebuild metadata is not restored to the pinned single-block placement for metadata_id=%d", record.ID)
+		}
+	}
+	return nil
 }
 
 func (a *BatchConsolidator) executePromoteFinalized(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {

--- a/internal/workflow/activity/batch_consolidator_repair_test.go
+++ b/internal/workflow/activity/batch_consolidator_repair_test.go
@@ -15,11 +15,12 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVe
 	require := testutil.Require(s.T())
 	records, blocks := makeConsolidatorFixture(1, 1000)
 	request := &BatchConsolidatorRequest{
-		Mode:        config.ConsolidationModeRepairExistingCSCB,
-		Tag:         2,
-		StartHeight: 900,
-		EndHeight:   1200,
-		MaxBlocks:   100,
+		Mode:               config.ConsolidationModeRepairExistingCSCB,
+		Tag:                2,
+		StartHeight:        900,
+		EndHeight:          1200,
+		MaxBlocks:          100,
+		RepairExecutionKey: testRepairExecutionKey,
 	}
 	oldKey := "consolidated/dirty.cscb.zstd"
 	newKey := "consolidated/clean.cscb.zstd"
@@ -65,6 +66,7 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVe
 		PendingOldDeletion: true,
 	}, response)
 	require.Equal([]string{"prepare", "restore", "verify"}, fake.calls)
+	require.Equal(testRepairExecutionKey, fake.executionKey)
 }
 
 func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBDeletesOnlyAfterVerified() {
@@ -77,17 +79,19 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBDeletesOnlyAfterVerif
 	s.batchConsolidator.repairer = fake
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
-		Mode:             config.ConsolidationModeRepairExistingCSCB,
-		Tag:              2,
-		StartHeight:      900,
-		EndHeight:        1200,
-		MaxBlocks:        100,
-		DeleteOldObjects: true,
+		Mode:               config.ConsolidationModeRepairExistingCSCB,
+		Tag:                2,
+		StartHeight:        900,
+		EndHeight:          1200,
+		MaxBlocks:          100,
+		DeleteOldObjects:   true,
+		RepairExecutionKey: testRepairExecutionKey,
 	})
 	require.NoError(err)
 	require.Equal(uint64(1), response.RepairedObjects)
 	require.False(response.PendingOldDeletion)
 	require.Equal([]string{"prepare", "delete"}, fake.calls)
+	require.Equal(testRepairExecutionKey, fake.executionKey)
 }
 
 func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string) *cscbrepair.Manifest {
@@ -106,15 +110,17 @@ func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string
 
 type repairActivityFake struct {
 	cscbrepair.Repairer
-	prepared  *cscbrepair.Manifest
-	restored  *cscbrepair.Manifest
-	verified  *cscbrepair.Manifest
-	completed *cscbrepair.Manifest
-	calls     []string
+	prepared     *cscbrepair.Manifest
+	restored     *cscbrepair.Manifest
+	verified     *cscbrepair.Manifest
+	completed    *cscbrepair.Manifest
+	calls        []string
+	executionKey string
 }
 
-func (f *repairActivityFake) PrepareNext(context.Context, uint32, uint64, uint64, uint64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {
+func (f *repairActivityFake) PrepareNext(_ context.Context, executionKey string, _ uint32, _ uint64, _ uint64, _ uint64, _ cscbrepair.Progress) (*cscbrepair.Manifest, error) {
 	f.calls = append(f.calls, "prepare")
+	f.executionKey = executionKey
 	return f.prepared, nil
 }
 
@@ -132,3 +138,5 @@ func (f *repairActivityFake) DeleteOldObject(context.Context, int64) (*cscbrepai
 	f.calls = append(f.calls, "delete")
 	return f.completed, nil
 }
+
+const testRepairExecutionKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"

--- a/internal/workflow/activity/batch_consolidator_repair_test.go
+++ b/internal/workflow/activity/batch_consolidator_repair_test.go
@@ -27,18 +27,17 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVe
 	prepared := repairActivityManifest(cscbrepair.StatePrepared, oldKey, "")
 	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
 	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
+	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
 	fake := &repairActivityFake{
-		prepared: prepared,
-		restored: restored,
-		verified: verified,
+		prepared:  prepared,
+		restored:  restored,
+		verified:  verified,
+		completed: completed,
 	}
 	s.batchConsolidator.repairer = fake
 	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
 
 	gomock.InOrder(
-		s.metaStorage.EXPECT().
-			PromoteBlockConsolidationShadows(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100), config.DefaultSingleBlockObjectRetention).
-			Return(&metastorage.ConsolidationPromotionResult{}, nil),
 		s.metaStorage.EXPECT().
 			GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
 			Return(records, nil),
@@ -63,19 +62,78 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVe
 		ObjectKey:          newKey,
 		OldObjectKey:       oldKey,
 		RepairedObjects:    1,
-		PendingOldDeletion: true,
 	}, response)
-	require.Equal([]string{"prepare", "restore", "verify"}, fake.calls)
+	require.Equal([]string{"prepare", "restore", "verify", "complete"}, fake.calls)
 	require.Equal(testRepairExecutionKey, fake.executionKey)
 }
 
-func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBDeletesOnlyAfterVerified() {
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRejectsNonExactRebuildBeforeUpload() {
+	require := testutil.Require(s.T())
+	records, _ := makeConsolidatorFixture(1, 1000)
+	oldKey := "consolidated/dirty.cscb.zstd"
+	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
+	restored.Blocks[0].BlockMetadataID = 999
+	fake := &repairActivityFake{prepared: restored}
+	s.batchConsolidator.repairer = fake
+
+	s.metaStorage.EXPECT().
+		GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
+		Return(records, nil)
+
+	_, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
+		Mode:               config.ConsolidationModeRepairExistingCSCB,
+		Tag:                2,
+		StartHeight:        900,
+		EndHeight:          1200,
+		MaxBlocks:          100,
+		RepairExecutionKey: testRepairExecutionKey,
+	})
+	require.ErrorContains(err, "unexpected metadata_id=10")
+	require.Equal([]string{"prepare"}, fake.calls)
+}
+
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBResumesAfterShadowsPersisted() {
 	require := testutil.Require(s.T())
 	oldKey := "consolidated/dirty.cscb.zstd"
 	newKey := "consolidated/clean.cscb.zstd"
+	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
 	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
 	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
-	fake := &repairActivityFake{prepared: verified, completed: completed}
+	fake := &repairActivityFake{prepared: restored, verified: verified, completed: completed}
+	s.batchConsolidator.repairer = fake
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().
+			GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
+			Return(nil, nil),
+		s.metaStorage.EXPECT().
+			PromoteBlockConsolidationShadows(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100), config.DefaultSingleBlockObjectRetention).
+			Return(&metastorage.ConsolidationPromotionResult{Blocks: 1}, nil),
+	)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
+		Mode:               config.ConsolidationModeRepairExistingCSCB,
+		Tag:                2,
+		StartHeight:        900,
+		EndHeight:          1200,
+		MaxBlocks:          100,
+		RepairExecutionKey: testRepairExecutionKey,
+	})
+	require.NoError(err)
+	require.Equal(uint64(1), response.RepairedObjects)
+	require.Equal([]string{"prepare", "verify", "complete"}, fake.calls)
+}
+
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBCompletesAllNonCanonicalObjectWithoutRebuild() {
+	require := testutil.Require(s.T())
+	oldKey := "consolidated/dirty.cscb.zstd"
+	prepared := repairActivityManifest(cscbrepair.StatePrepared, oldKey, "")
+	prepared.CanonicalBlockCount = 0
+	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
+	restored.CanonicalBlockCount = 0
+	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, "")
+	completed.CanonicalBlockCount = 0
+	fake := &repairActivityFake{prepared: prepared, restored: restored, completed: completed}
 	s.batchConsolidator.repairer = fake
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
@@ -84,14 +142,39 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBDeletesOnlyAfterVerif
 		StartHeight:        900,
 		EndHeight:          1200,
 		MaxBlocks:          100,
-		DeleteOldObjects:   true,
 		RepairExecutionKey: testRepairExecutionKey,
 	})
 	require.NoError(err)
 	require.Equal(uint64(1), response.RepairedObjects)
-	require.False(response.PendingOldDeletion)
-	require.Equal([]string{"prepare", "delete"}, fake.calls)
+	require.Zero(response.ConsolidatedBlocks)
+	require.Empty(response.ObjectKey)
+	require.Equal([]string{"prepare", "restore", "complete"}, fake.calls)
 	require.Equal(testRepairExecutionKey, fake.executionKey)
+}
+
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRecordsAlreadyCleanObjectWithoutRebuild() {
+	require := testutil.Require(s.T())
+	oldKey := "consolidated/already-clean.cscb.zstd"
+	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, "")
+	completed.Outcome = cscbrepair.OutcomeAlreadyCleanStorageNeutral
+	fake := &repairActivityFake{prepared: completed}
+	s.batchConsolidator.repairer = fake
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
+		Mode:               config.ConsolidationModeRepairExistingCSCB,
+		Tag:                2,
+		StartHeight:        900,
+		EndHeight:          1200,
+		MaxBlocks:          100,
+		RepairExecutionKey: testRepairExecutionKey,
+	})
+	require.NoError(err)
+	require.Equal(uint64(1), response.RepairedObjects)
+	require.Equal(uint64(1), response.ScannedBlocks)
+	require.Zero(response.ConsolidatedBlocks)
+	require.Zero(response.PromotedBlocks)
+	require.Equal(oldKey, response.ObjectKey)
+	require.Equal([]string{"prepare"}, fake.calls)
 }
 
 func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string) *cscbrepair.Manifest {
@@ -105,6 +188,14 @@ func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string
 		TotalBlockCount:          1,
 		OldConsolidatedObjectKey: oldKey,
 		NewConsolidatedObjectKey: newKey,
+		Blocks: []cscbrepair.Block{{
+			BlockMetadataID:      10,
+			Canonical:            true,
+			Tag:                  2,
+			Height:               1000,
+			Hash:                 "hash-1000",
+			SingleBlockObjectKey: "single-block/1000.gzip",
+		}},
 	}
 }
 
@@ -134,8 +225,8 @@ func (f *repairActivityFake) VerifyRebuilt(context.Context, int64, cscbrepair.Pr
 	return f.verified, nil
 }
 
-func (f *repairActivityFake) DeleteOldObject(context.Context, int64) (*cscbrepair.Manifest, error) {
-	f.calls = append(f.calls, "delete")
+func (f *repairActivityFake) Complete(context.Context, int64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "complete")
 	return f.completed, nil
 }
 

--- a/internal/workflow/activity/batch_consolidator_repair_test.go
+++ b/internal/workflow/activity/batch_consolidator_repair_test.go
@@ -1,0 +1,134 @@
+package activity
+
+import (
+	"context"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepair"
+	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	"github.com/coinbase/chainstorage/internal/utils/testutil"
+)
+
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVerifies() {
+	require := testutil.Require(s.T())
+	records, blocks := makeConsolidatorFixture(1, 1000)
+	request := &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeRepairExistingCSCB,
+		Tag:         2,
+		StartHeight: 900,
+		EndHeight:   1200,
+		MaxBlocks:   100,
+	}
+	oldKey := "consolidated/dirty.cscb.zstd"
+	newKey := "consolidated/clean.cscb.zstd"
+	prepared := repairActivityManifest(cscbrepair.StatePrepared, oldKey, "")
+	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
+	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
+	fake := &repairActivityFake{
+		prepared: prepared,
+		restored: restored,
+		verified: verified,
+	}
+	s.batchConsolidator.repairer = fake
+	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
+
+	gomock.InOrder(
+		s.metaStorage.EXPECT().
+			PromoteBlockConsolidationShadows(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100), config.DefaultSingleBlockObjectRetention).
+			Return(&metastorage.ConsolidationPromotionResult{}, nil),
+		s.metaStorage.EXPECT().
+			GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
+			Return(records, nil),
+		s.blobStorage.EXPECT().Download(gomock.Any(), records[0].Metadata).Return(blocks[0], nil),
+		s.blobStorage.EXPECT().
+			UploadConsolidated(gomock.Any(), gomock.Any()).
+			Return(newKey, makeConsolidatorPlacements(records), nil),
+		s.metaStorage.EXPECT().PersistBlockConsolidationShadows(gomock.Any(), gomock.Any()).Return(nil),
+		s.metaStorage.EXPECT().
+			PromoteBlockConsolidationShadows(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100), config.DefaultSingleBlockObjectRetention).
+			Return(&metastorage.ConsolidationPromotionResult{Blocks: 1}, nil),
+	)
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
+	require.NoError(err)
+	require.Equal(&BatchConsolidatorResponse{
+		StartHeight:        1000,
+		EndHeight:          1001,
+		ScannedBlocks:      1,
+		ConsolidatedBlocks: 1,
+		PromotedBlocks:     1,
+		ObjectKey:          newKey,
+		OldObjectKey:       oldKey,
+		RepairedObjects:    1,
+		PendingOldDeletion: true,
+	}, response)
+	require.Equal([]string{"prepare", "restore", "verify"}, fake.calls)
+}
+
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBDeletesOnlyAfterVerified() {
+	require := testutil.Require(s.T())
+	oldKey := "consolidated/dirty.cscb.zstd"
+	newKey := "consolidated/clean.cscb.zstd"
+	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
+	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
+	fake := &repairActivityFake{prepared: verified, completed: completed}
+	s.batchConsolidator.repairer = fake
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
+		Mode:             config.ConsolidationModeRepairExistingCSCB,
+		Tag:              2,
+		StartHeight:      900,
+		EndHeight:        1200,
+		MaxBlocks:        100,
+		DeleteOldObjects: true,
+	})
+	require.NoError(err)
+	require.Equal(uint64(1), response.RepairedObjects)
+	require.False(response.PendingOldDeletion)
+	require.Equal([]string{"prepare", "delete"}, fake.calls)
+}
+
+func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string) *cscbrepair.Manifest {
+	return &cscbrepair.Manifest{
+		ID:                       42,
+		Tag:                      2,
+		State:                    state,
+		StartHeight:              1000,
+		EndHeight:                1001,
+		CanonicalBlockCount:      1,
+		TotalBlockCount:          1,
+		OldConsolidatedObjectKey: oldKey,
+		NewConsolidatedObjectKey: newKey,
+	}
+}
+
+type repairActivityFake struct {
+	cscbrepair.Repairer
+	prepared  *cscbrepair.Manifest
+	restored  *cscbrepair.Manifest
+	verified  *cscbrepair.Manifest
+	completed *cscbrepair.Manifest
+	calls     []string
+}
+
+func (f *repairActivityFake) PrepareNext(context.Context, uint32, uint64, uint64, uint64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "prepare")
+	return f.prepared, nil
+}
+
+func (f *repairActivityFake) Restore(context.Context, int64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "restore")
+	return f.restored, nil
+}
+
+func (f *repairActivityFake) VerifyRebuilt(context.Context, int64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "verify")
+	return f.verified, nil
+}
+
+func (f *repairActivityFake) DeleteOldObject(context.Context, int64) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "delete")
+	return f.completed, nil
+}

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -31,14 +31,15 @@ type (
 	}
 
 	BatchConsolidatorRequest struct {
-		Mode           config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill"`
-		Tag            uint32
-		StartHeight    uint64
-		EndHeight      uint64 `validate:"gtfield=StartHeight"`
-		BatchSize      uint64
-		CheckpointSize uint64
-		MaxBlocks      uint64
-		Parallelism    int `validate:"omitempty,gt=0"`
+		Mode             config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill repair_existing_cscb"`
+		Tag              uint32
+		StartHeight      uint64
+		EndHeight        uint64 `validate:"gtfield=StartHeight"`
+		BatchSize        uint64
+		CheckpointSize   uint64
+		MaxBlocks        uint64
+		Parallelism      int `validate:"omitempty,gt=0"`
+		DeleteOldObjects bool
 	}
 
 	batchConsolidatorPendingActivity struct {
@@ -164,6 +165,23 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		ctx = w.withActivityOptions(ctx)
 		statsCtx := w.withShadowStatsActivityOptions(ctx, cfg)
 		cursorCtx := w.withCursorActivityOptions(ctx, cfg)
+		if mode.IsRepairExistingCSCB() {
+			if parallelism != 1 {
+				return xerrors.Errorf("repair_existing_cscb requires parallelism=1, got %d", parallelism)
+			}
+			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
+				return err
+			}
+			return w.executeRepairExistingCSCB(
+				ctx,
+				logger,
+				metrics,
+				request,
+				tag,
+				checkpointSize,
+				maxBlocks,
+			)
+		}
 		usePersistedShadowStats := workflow.GetVersion(
 			ctx,
 			batchConsolidatorShadowStatsChangeID,
@@ -464,6 +482,74 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		logger.Info("workflow finished")
 		return nil
 	})
+}
+
+func (w *BatchConsolidator) executeRepairExistingCSCB(
+	ctx workflow.Context,
+	logger *zap.Logger,
+	metrics client.MetricsHandler,
+	request *BatchConsolidatorRequest,
+	tag uint32,
+	checkpointSize uint64,
+	maxBlocks uint64,
+) error {
+	processedBlocks := uint64(0)
+	for {
+		response, err := w.batchConsolidator.Execute(ctx, &activity.BatchConsolidatorRequest{
+			Mode:             config.ConsolidationModeRepairExistingCSCB,
+			Tag:              tag,
+			StartHeight:      request.StartHeight,
+			EndHeight:        request.EndHeight,
+			MaxBlocks:        maxBlocks,
+			DeleteOldObjects: request.DeleteOldObjects,
+		})
+		if err != nil {
+			return xerrors.Errorf(
+				"failed to repair existing CSCB range [%d, %d): %w",
+				request.StartHeight,
+				request.EndHeight,
+				err,
+			)
+		}
+		if response.RepairedObjects == 0 {
+			metrics.Counter(batchConsolidatorEmptyBatchCounter).Inc(1)
+			logger.Info("CSCB repair range is complete")
+			return nil
+		}
+		if response.ScannedBlocks == 0 || response.ConsolidatedBlocks == 0 {
+			return xerrors.Errorf(
+				"repair_existing_cscb made no block progress for old object %q",
+				response.OldObjectKey,
+			)
+		}
+		processedBlocks += response.ScannedBlocks
+		metrics.Counter(batchConsolidatorObjectCounter).Inc(int64(response.RepairedObjects))
+		metrics.Counter(batchConsolidatorConsolidatedBlockCounter).Inc(int64(response.ConsolidatedBlocks))
+		metrics.Gauge(batchConsolidatorHeightGauge).Update(float64(response.EndHeight - 1))
+		logger.Info(
+			"repaired existing CSCB object",
+			zap.String("old_object_key", response.OldObjectKey),
+			zap.String("new_object_key", response.ObjectKey),
+			zap.Uint64("start_height", response.StartHeight),
+			zap.Uint64("end_height", response.EndHeight),
+			zap.Uint64("blocks", response.ScannedBlocks),
+			zap.Uint64("canonical_blocks", response.ConsolidatedBlocks),
+			zap.Bool("pending_old_deletion", response.PendingOldDeletion),
+		)
+		if response.PendingOldDeletion {
+			logger.Info("CSCB repair stopped after verification because old-object deletion was not enabled")
+			return nil
+		}
+		if processedBlocks >= checkpointSize {
+			newRequest := *request
+			logger.Info(
+				"CSCB repair checkpoint reached",
+				zap.Uint64("processed_blocks", processedBlocks),
+				zap.Reflect("new_request", newRequest),
+			)
+			return w.continueAsNew(ctx, &newRequest)
+		}
+	}
 }
 
 func (w *BatchConsolidator) processAutoConsolidateBatchParallel(
@@ -789,15 +875,17 @@ func batchConsolidatorMode(
 	case config.ConsolidationModeShadowDualWrite,
 		config.ConsolidationModeAutoConsolidate,
 		config.ConsolidationModeHistoricalBackfill,
-		config.ConsolidationModePromoteFinalized:
+		config.ConsolidationModePromoteFinalized,
+		config.ConsolidationModeRepairExistingCSCB:
 		return mode, nil
 	default:
 		return "", xerrors.Errorf(
-			"batch_consolidator requires mode %q, %q, %q, or %q, got %q",
+			"batch_consolidator requires mode %q, %q, %q, %q, or %q, got %q",
 			config.ConsolidationModeShadowDualWrite,
 			config.ConsolidationModeAutoConsolidate,
 			config.ConsolidationModeHistoricalBackfill,
 			config.ConsolidationModePromoteFinalized,
+			config.ConsolidationModeRepairExistingCSCB,
 			mode,
 		)
 	}

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -33,15 +33,14 @@ type (
 	}
 
 	BatchConsolidatorRequest struct {
-		Mode             config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill repair_existing_cscb"`
-		Tag              uint32
-		StartHeight      uint64
-		EndHeight        uint64 `validate:"gtfield=StartHeight"`
-		BatchSize        uint64
-		CheckpointSize   uint64
-		MaxBlocks        uint64
-		Parallelism      int `validate:"omitempty,gt=0"`
-		DeleteOldObjects bool
+		Mode           config.ConsolidationMode `validate:"omitempty,oneof=shadow_dual_write auto_consolidate historical_backfill repair_existing_cscb"`
+		Tag            uint32
+		StartHeight    uint64
+		EndHeight      uint64 `validate:"gtfield=StartHeight"`
+		BatchSize      uint64
+		CheckpointSize uint64
+		MaxBlocks      uint64
+		Parallelism    int `validate:"omitempty,gt=0"`
 	}
 
 	batchConsolidatorPendingActivity struct {
@@ -504,7 +503,6 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 			StartHeight:        request.StartHeight,
 			EndHeight:          request.EndHeight,
 			MaxBlocks:          maxBlocks,
-			DeleteOldObjects:   request.DeleteOldObjects,
 			RepairExecutionKey: makeRepairExecutionKey(ctx, repairIteration),
 		})
 		if err != nil {
@@ -520,7 +518,7 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 			logger.Info("CSCB repair range is complete")
 			return nil
 		}
-		if response.ScannedBlocks == 0 || response.ConsolidatedBlocks == 0 {
+		if response.ScannedBlocks == 0 {
 			return xerrors.Errorf(
 				"repair_existing_cscb made no block progress for old object %q",
 				response.OldObjectKey,
@@ -538,12 +536,8 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 			zap.Uint64("end_height", response.EndHeight),
 			zap.Uint64("blocks", response.ScannedBlocks),
 			zap.Uint64("canonical_blocks", response.ConsolidatedBlocks),
-			zap.Bool("pending_old_deletion", response.PendingOldDeletion),
+			zap.Bool("rebuilt_cscb", response.ObjectKey != "" && response.ObjectKey != response.OldObjectKey),
 		)
-		if response.PendingOldDeletion {
-			logger.Info("CSCB repair stopped after verification because old-object deletion was not enabled")
-			return nil
-		}
 		repairIteration++
 		if processedBlocks >= checkpointSize {
 			newRequest := *request

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"strconv"
 
 	"go.temporal.io/sdk/client"
@@ -494,14 +496,16 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 	maxBlocks uint64,
 ) error {
 	processedBlocks := uint64(0)
+	repairIteration := uint64(0)
 	for {
 		response, err := w.batchConsolidator.Execute(ctx, &activity.BatchConsolidatorRequest{
-			Mode:             config.ConsolidationModeRepairExistingCSCB,
-			Tag:              tag,
-			StartHeight:      request.StartHeight,
-			EndHeight:        request.EndHeight,
-			MaxBlocks:        maxBlocks,
-			DeleteOldObjects: request.DeleteOldObjects,
+			Mode:               config.ConsolidationModeRepairExistingCSCB,
+			Tag:                tag,
+			StartHeight:        request.StartHeight,
+			EndHeight:          request.EndHeight,
+			MaxBlocks:          maxBlocks,
+			DeleteOldObjects:   request.DeleteOldObjects,
+			RepairExecutionKey: makeRepairExecutionKey(ctx, repairIteration),
 		})
 		if err != nil {
 			return xerrors.Errorf(
@@ -540,6 +544,7 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 			logger.Info("CSCB repair stopped after verification because old-object deletion was not enabled")
 			return nil
 		}
+		repairIteration++
 		if processedBlocks >= checkpointSize {
 			newRequest := *request
 			logger.Info(
@@ -550,6 +555,15 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 			return w.continueAsNew(ctx, &newRequest)
 		}
 	}
+}
+
+func makeRepairExecutionKey(ctx workflow.Context, iteration uint64) string {
+	info := workflow.GetInfo(ctx)
+	payload := info.WorkflowExecution.ID + "\x00" +
+		info.WorkflowExecution.RunID + "\x00" +
+		strconv.FormatUint(iteration, 10)
+	digest := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(digest[:])
 }
 
 func (w *BatchConsolidator) processAutoConsolidateBatchParallel(

--- a/internal/workflow/batch_consolidator_repair_test.go
+++ b/internal/workflow/batch_consolidator_repair_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/coinbase/chainstorage/internal/workflow/activity"
 )
 
-func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBStopsAfterVerifiedCanary() {
+func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBCompletesThenChecksForNextObject() {
 	require := testutil.Require(s.T())
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
 	s.mockAutoConsolidateLatestHeight(2000)
@@ -19,6 +19,12 @@ func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBStopsAfterVerifiedCan
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
 			requests = append(requests, request)
+			if len(requests) > 1 {
+				return &activity.BatchConsolidatorResponse{
+					StartHeight: request.StartHeight,
+					EndHeight:   request.EndHeight,
+				}, nil
+			}
 			return &activity.BatchConsolidatorResponse{
 				StartHeight:        1000,
 				EndHeight:          1100,
@@ -27,9 +33,8 @@ func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBStopsAfterVerifiedCan
 				ObjectKey:          "consolidated/clean.cscb.zstd",
 				OldObjectKey:       "consolidated/dirty.cscb.zstd",
 				RepairedObjects:    1,
-				PendingOldDeletion: true,
 			}, nil
-		}).Once()
+		}).Twice()
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeRepairExistingCSCB,
@@ -39,57 +44,13 @@ func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBStopsAfterVerifiedCan
 		MaxBlocks:   100,
 	})
 	require.NoError(err)
-	require.Len(requests, 1)
-	require.Equal(config.ConsolidationModeRepairExistingCSCB, requests[0].Mode)
-	require.Equal(uint32(2), requests[0].Tag)
-	require.Equal(uint64(1000), requests[0].StartHeight)
-	require.Equal(uint64(1100), requests[0].EndHeight)
-	require.Equal(uint64(100), requests[0].MaxBlocks)
-	require.True(isRepairExecutionKey(requests[0].RepairExecutionKey))
-}
-
-func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBDeletesThenFindsNextExactObject() {
-	require := testutil.Require(s.T())
-	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
-	s.mockAutoConsolidateLatestHeight(2000)
-	var requests []*activity.BatchConsolidatorRequest
-	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
-		Return(func(_ context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
-			requests = append(requests, request)
-			if len(requests) == 1 {
-				return &activity.BatchConsolidatorResponse{
-					StartHeight:        1000,
-					EndHeight:          1100,
-					ScannedBlocks:      100,
-					ConsolidatedBlocks: 100,
-					ObjectKey:          "consolidated/clean.cscb.zstd",
-					OldObjectKey:       "consolidated/dirty.cscb.zstd",
-					RepairedObjects:    1,
-				}, nil
-			}
-			return &activity.BatchConsolidatorResponse{
-				StartHeight: request.StartHeight,
-				EndHeight:   request.EndHeight,
-			}, nil
-		}).Twice()
-
-	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
-		Mode:             config.ConsolidationModeRepairExistingCSCB,
-		Tag:              2,
-		StartHeight:      900,
-		EndHeight:        1200,
-		MaxBlocks:        100,
-		DeleteOldObjects: true,
-	})
-	require.NoError(err)
 	require.Len(requests, 2)
 	for _, request := range requests {
 		require.Equal(config.ConsolidationModeRepairExistingCSCB, request.Mode)
 		require.Equal(uint32(2), request.Tag)
-		require.Equal(uint64(900), request.StartHeight)
-		require.Equal(uint64(1200), request.EndHeight)
+		require.Equal(uint64(1000), request.StartHeight)
+		require.Equal(uint64(1100), request.EndHeight)
 		require.Equal(uint64(100), request.MaxBlocks)
-		require.True(request.DeleteOldObjects)
 		require.True(isRepairExecutionKey(request.RepairExecutionKey))
 	}
 	require.NotEqual(requests[0].RepairExecutionKey, requests[1].RepairExecutionKey)

--- a/internal/workflow/batch_consolidator_repair_test.go
+++ b/internal/workflow/batch_consolidator_repair_test.go
@@ -1,0 +1,110 @@
+package workflow
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/utils/testutil"
+	"github.com/coinbase/chainstorage/internal/workflow/activity"
+)
+
+func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBStopsAfterVerifiedCanary() {
+	require := testutil.Require(s.T())
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.mockAutoConsolidateLatestHeight(2000)
+	var requests []*activity.BatchConsolidatorRequest
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        1000,
+				EndHeight:          1100,
+				ScannedBlocks:      100,
+				ConsolidatedBlocks: 100,
+				ObjectKey:          "consolidated/clean.cscb.zstd",
+				OldObjectKey:       "consolidated/dirty.cscb.zstd",
+				RepairedObjects:    1,
+				PendingOldDeletion: true,
+			}, nil
+		}).Once()
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeRepairExistingCSCB,
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1100,
+		MaxBlocks:   100,
+	})
+	require.NoError(err)
+	require.Equal([]*activity.BatchConsolidatorRequest{{
+		Mode:        config.ConsolidationModeRepairExistingCSCB,
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1100,
+		MaxBlocks:   100,
+	}}, requests)
+}
+
+func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBDeletesThenFindsNextExactObject() {
+	require := testutil.Require(s.T())
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.mockAutoConsolidateLatestHeight(2000)
+	var requests []*activity.BatchConsolidatorRequest
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requests = append(requests, request)
+			if len(requests) == 1 {
+				return &activity.BatchConsolidatorResponse{
+					StartHeight:        1000,
+					EndHeight:          1100,
+					ScannedBlocks:      100,
+					ConsolidatedBlocks: 100,
+					ObjectKey:          "consolidated/clean.cscb.zstd",
+					OldObjectKey:       "consolidated/dirty.cscb.zstd",
+					RepairedObjects:    1,
+				}, nil
+			}
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		}).Twice()
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:             config.ConsolidationModeRepairExistingCSCB,
+		Tag:              2,
+		StartHeight:      900,
+		EndHeight:        1200,
+		MaxBlocks:        100,
+		DeleteOldObjects: true,
+	})
+	require.NoError(err)
+	require.Len(requests, 2)
+	for _, request := range requests {
+		require.Equal(&activity.BatchConsolidatorRequest{
+			Mode:             config.ConsolidationModeRepairExistingCSCB,
+			Tag:              2,
+			StartHeight:      900,
+			EndHeight:        1200,
+			MaxBlocks:        100,
+			DeleteOldObjects: true,
+		}, request)
+	}
+}
+
+func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBRequiresSerialExecution() {
+	require := testutil.Require(s.T())
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeRepairExistingCSCB,
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1100,
+		MaxBlocks:   100,
+		Parallelism: 2,
+	})
+	require.Error(err)
+	require.Contains(err.Error(), "repair_existing_cscb requires parallelism=1")
+}

--- a/internal/workflow/batch_consolidator_repair_test.go
+++ b/internal/workflow/batch_consolidator_repair_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"encoding/hex"
 
 	"github.com/stretchr/testify/mock"
 
@@ -38,13 +39,13 @@ func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBStopsAfterVerifiedCan
 		MaxBlocks:   100,
 	})
 	require.NoError(err)
-	require.Equal([]*activity.BatchConsolidatorRequest{{
-		Mode:        config.ConsolidationModeRepairExistingCSCB,
-		Tag:         2,
-		StartHeight: 1000,
-		EndHeight:   1100,
-		MaxBlocks:   100,
-	}}, requests)
+	require.Len(requests, 1)
+	require.Equal(config.ConsolidationModeRepairExistingCSCB, requests[0].Mode)
+	require.Equal(uint32(2), requests[0].Tag)
+	require.Equal(uint64(1000), requests[0].StartHeight)
+	require.Equal(uint64(1100), requests[0].EndHeight)
+	require.Equal(uint64(100), requests[0].MaxBlocks)
+	require.True(isRepairExecutionKey(requests[0].RepairExecutionKey))
 }
 
 func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBDeletesThenFindsNextExactObject() {
@@ -83,15 +84,20 @@ func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBDeletesThenFindsNextE
 	require.NoError(err)
 	require.Len(requests, 2)
 	for _, request := range requests {
-		require.Equal(&activity.BatchConsolidatorRequest{
-			Mode:             config.ConsolidationModeRepairExistingCSCB,
-			Tag:              2,
-			StartHeight:      900,
-			EndHeight:        1200,
-			MaxBlocks:        100,
-			DeleteOldObjects: true,
-		}, request)
+		require.Equal(config.ConsolidationModeRepairExistingCSCB, request.Mode)
+		require.Equal(uint32(2), request.Tag)
+		require.Equal(uint64(900), request.StartHeight)
+		require.Equal(uint64(1200), request.EndHeight)
+		require.Equal(uint64(100), request.MaxBlocks)
+		require.True(request.DeleteOldObjects)
+		require.True(isRepairExecutionKey(request.RepairExecutionKey))
 	}
+	require.NotEqual(requests[0].RepairExecutionKey, requests[1].RepairExecutionKey)
+}
+
+func isRepairExecutionKey(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 32
 }
 
 func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBRequiresSerialExecution() {


### PR DESCRIPTION
## Summary
- add a durable PostgreSQL state machine and per-block audit for CSCBs created before #166 with embedded storage placement
- fence the exact active row set before any S3 inspection, restore it to pinned single-block objects, and reuse normal consolidation to build and promote a storage-neutral CSCB
- classify already-clean CSCBs as a terminal no-op instead of repeatedly trying to repair them
- retain the old consolidated object as immutable, unreferenced evidence; repair contains no S3 delete operation or delete flag
- expose request-only `repair_existing_cscb` mode; execution is serial and PostgreSQL-only

## Safety and recovery
- persist a `preparing` manifest before remote inspection, plus an immutable Temporal execution binding so retries resume the same object or the same no-candidate result
- pin exact version ID, ETag, size, row identity, single-block key hash, and canonical payload digest
- serialize repair and normal metadata writers with an ordered per-tag advisory lock, then use existing per-block retirement locks and consolidated-key locks
- perform all S3 reads outside database transactions; locked transactions only compare-and-swap metadata and durable state
- reject retirement, upload overwrite, shadow mutation, and reintroduction of a pinned old CSCB key while repair is active
- require exact one-version/no-delete-marker topology for source, single-block, and rebuilt objects at every destructive metadata transition
- verify rebuilt payload identity, absence of embedded storage placement, exact metadata references, and a fresh 72-hour single-block retention interval
- retain the old CSCB and require zero database references at completion; it is never deleted by repair
- after the existing retirement executor later verifies and deletes a single-block version, atomically clear its plaintext path from both shadow metadata and the repair audit while retaining the key hash and immutable version evidence
- add concurrent production indexes for candidate and exact-object-reference queries
- keep DynamoDB and Firestore unsupported; no production mutation was performed by this change

## Verification
- `PATH="$HOME/go/bin:$PATH" make test`
- fresh Docker PostgreSQL/LocalStack run: `TEST_TYPE=integration go test ./... -p=1 -parallel=1 -timeout=15m -failfast -run=TestIntegration`
- `PATH="$HOME/go/bin:$PATH" make docker-build`
- `git diff --check`
- independent adversarial review found no P0/P1 blocker and confirmed no old-CSCB deletion path remains

The Docker lifecycle test applies migrations through `20260714000002`, creates versioned single-block and dirty CSCB objects, persists the repair fence before S3 inspection, restores single-block reads, rebuilds a clean CSCB, verifies the exact fresh 72-hour retention window, rejects upload/retirement/reference races, proves retry recovery, retains the old CSCB with zero references, and then exercises the real guarded single-block retirement executor. It verifies lifecycle/policy quiescence, exact-version deletion, repair-audit path scrubbing, and successful reads from the rebuilt CSCB after the single-block object is gone.

## Rollout gates
- **Apply and verify migrations `20260714000001` and `20260714000002` on every PostgreSQL chain database before deploying this image.** Image-first rollout is unsafe because normal writer and retirement paths depend on the new repair schema.
- Deploy the new image to every PostgreSQL metadata writer before invoking repair. Mixed old/new writers do not share the new tag-lock protocol.
- Keep automatic consolidation disabled during the dirty-range repair.
- First production execution must target one explicitly approved CSCB object/range. Inspect the durable manifest, pinned versions, metadata references, rebuilt raw payloads, fresh retention timestamps, and normal reads before continuing.
- Do not delete old dirty CSCBs. Any future orphan cleanup requires a separate design and approval.

Linear: https://linear.app/cipherowl/issue/INF-1133/cscb-repair-pre-normalization-consolidated-objects
