### PR TITLE
fix(INF-1046): stop runtime Postgres migrations

### DIFF
--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -49,7 +49,7 @@ func (s *blockStorageTestSuite) SetupSuite() {
 	require := testutil.Require(s.T())
 	cfg, err := config.New()
 	require.NoError(err)
-	if cfg.AWS.Postgres == nil {
+	if !cfg.IsIntegrationTest() || cfg.AWS.Postgres == nil {
 		return
 	}
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -45,6 +45,20 @@ type blockStorageTestSuite struct {
 	db       *sql.DB
 }
 
+func (s *blockStorageTestSuite) SetupSuite() {
+	require := testutil.Require(s.T())
+	cfg, err := config.New()
+	require.NoError(err)
+	if cfg.AWS.Postgres == nil {
+		return
+	}
+
+	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(runMigrations(context.Background(), db))
+}
+
 func (s *blockStorageTestSuite) SetupTest() {
 	require := testutil.Require(s.T())
 
@@ -75,7 +89,6 @@ func (s *blockStorageTestSuite) SetupTest() {
 	// Get database connection for cleanup
 	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
 	require.NoError(err)
-	require.NoError(runMigrations(context.Background(), db))
 	s.db = db
 }
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -75,6 +75,7 @@ func (s *blockStorageTestSuite) SetupTest() {
 	// Get database connection for cleanup
 	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
 	require.NoError(err)
+	require.NoError(runMigrations(context.Background(), db))
 	s.db = db
 }
 

--- a/internal/storage/metastorage/postgres/connection.go
+++ b/internal/storage/metastorage/postgres/connection.go
@@ -60,13 +60,8 @@ func newDBConnection(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, 
 		}
 	}
 
-	// Always run migrations - goose will check which migrations have been applied
-	// and only run new ones. This ensures incremental migrations work properly.
-	logger.Debug("Running database migrations")
-	if err := runMigrations(ctx, db); err != nil {
-		return nil, xerrors.Errorf("failed to run migrations: %w", err)
-	}
-	logger.Debug("Migrations completed successfully")
-
+	// Do not run schema migrations from runtime service connections.
+	// Server pods may connect through read replicas, and worker users may not own
+	// existing tables. Run migrations explicitly through admin db-init/db-migrate.
 	return db, nil
 }

--- a/internal/storage/metastorage/postgres/event_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/event_storage_integration_test.go
@@ -55,6 +55,7 @@ func (s *eventStorageTestSuite) SetupTest() {
 	// Get database connection for cleanup
 	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
 	require.NoError(err)
+	require.NoError(runMigrations(context.Background(), db))
 	s.db = db
 }
 

--- a/internal/storage/metastorage/postgres/event_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/event_storage_integration_test.go
@@ -32,7 +32,7 @@ func (s *eventStorageTestSuite) SetupSuite() {
 	require := testutil.Require(s.T())
 	cfg, err := config.New()
 	require.NoError(err)
-	if cfg.AWS.Postgres == nil {
+	if !cfg.IsIntegrationTest() || cfg.AWS.Postgres == nil {
 		return
 	}
 

--- a/internal/storage/metastorage/postgres/event_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/event_storage_integration_test.go
@@ -28,6 +28,20 @@ type eventStorageTestSuite struct {
 	db       *sql.DB
 }
 
+func (s *eventStorageTestSuite) SetupSuite() {
+	require := testutil.Require(s.T())
+	cfg, err := config.New()
+	require.NoError(err)
+	if cfg.AWS.Postgres == nil {
+		return
+	}
+
+	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(runMigrations(context.Background(), db))
+}
+
 func (s *eventStorageTestSuite) SetupTest() {
 	require := testutil.Require(s.T())
 	var accessor internal.MetaStorage
@@ -55,7 +69,6 @@ func (s *eventStorageTestSuite) SetupTest() {
 	// Get database connection for cleanup
 	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
 	require.NoError(err)
-	require.NoError(runMigrations(context.Background(), db))
 	s.db = db
 }
 


### PR DESCRIPTION
Emergency crash-loop fix. Runtime services no longer run Goose migrations when opening PostgreSQL connections; explicit admin db-init and db-migrate remain available. PostgreSQL integration suites now migrate during setup. No migration SQL files are deleted. Focused unit tests and Docker-backed block/event metadata integration suites pass. Linear: https://linear.app/cipherowl/issue/INF-1046