### PR TITLE
fix(INF-1133): use hash indexes for CSCB repair references

### DIFF
--- a/internal/storage/cscbrepair/migration_integration_test.go
+++ b/internal/storage/cscbrepair/migration_integration_test.go
@@ -39,6 +39,7 @@ func TestIntegrationCSCBRepairReferenceIndexMigration(t *testing.T) {
 	require.NoError(goose.SetDialect("postgres"))
 	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
 	requireReferenceIndexes(t, db, "hash")
+	requireNoTemporaryReferenceIndexes(t, db)
 	requireReferenceIndexPlans(t, db)
 
 	// Rewind only the index migration and recreate the shape left by the
@@ -58,7 +59,24 @@ func TestIntegrationCSCBRepairReferenceIndexMigration(t *testing.T) {
 
 	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
 	requireReferenceIndexes(t, db, "hash")
+	requireNoTemporaryReferenceIndexes(t, db)
 	requireReferenceIndexPlans(t, db)
+}
+
+func requireNoTemporaryReferenceIndexes(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var count int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM pg_class index_class
+		JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
+		WHERE index_namespace.nspname = current_schema()
+			AND index_class.relname IN (
+				'idx_block_metadata_object_key_reference_hash_new',
+				'idx_block_consolidation_shadow_object_key_reference_hash_new'
+			)`).Scan(&count)
+	require.NoError(t, err)
+	require.Zero(t, count)
 }
 
 func requireReferenceIndexes(t *testing.T, db *sql.DB, expectedMethod string) {

--- a/internal/storage/cscbrepair/migration_integration_test.go
+++ b/internal/storage/cscbrepair/migration_integration_test.go
@@ -44,58 +44,10 @@ func TestIntegrationCSCBRepairReferenceIndexMigration(t *testing.T) {
 	requireNoTemporaryIndexes(t, db)
 	requireIndexPlans(t, db)
 
-	// Rewind only the index migration and recreate the shape left by the
-	// original B-tree migration. Applying the migration again must replace it,
-	// just as it replaces an invalid concurrent index left by a failed build.
+	// Production rolls this migration down before applying the corrected index
+	// definitions. Exercise that exact clean down/up path.
 	require.NoError(goose.DownToContext(ctx, db, "db/migrations", 20260714000001))
-	_, err = db.ExecContext(ctx, `
-		CREATE INDEX idx_block_metadata_cscb_repair_candidate
-		ON block_metadata (tag, height DESC, object_key_main, id)
-		WHERE object_format = 1 AND object_key_main IS NOT NULL AND object_key_main <> '';
-
-		CREATE INDEX idx_block_metadata_object_key_reference
-		ON block_metadata (object_key_main, id)
-		WHERE object_key_main IS NOT NULL AND object_key_main <> '';
-
-		CREATE INDEX idx_block_consolidation_shadow_object_key_reference
-		ON block_consolidation_shadow (consolidated_object_key_main, block_metadata_id)
-		WHERE consolidated_object_key_main IS NOT NULL AND consolidated_object_key_main <> '';
-
-		CREATE INDEX idx_block_metadata_cscb_repair_candidate_new
-		ON block_metadata (tag, height DESC, object_key_main, id)
-		WHERE object_format = 1 AND object_key_main IS NOT NULL AND object_key_main <> '';
-
-		CREATE INDEX idx_block_metadata_object_key_reference_hash_new
-		ON block_metadata USING HASH (object_key_main)
-		WHERE object_key_main IS NOT NULL AND object_key_main <> '';
-
-		CREATE INDEX idx_block_consolidation_shadow_object_key_reference_hash_new
-		ON block_consolidation_shadow USING HASH (consolidated_object_key_main)
-		WHERE consolidated_object_key_main IS NOT NULL AND consolidated_object_key_main <> ''`)
-	require.NoError(err)
-
-	// Only the isolated local test superuser may emulate catalog state from an
-	// interrupted concurrent build. Migrations still run as the application
-	// owner so this test does not alter normal object ownership or privileges.
-	superuserConfig := *cfg.AWS.Postgres
-	superuserConfig.User = "postgres"
-	superuserConfig.Password = "postgres"
-	catalogDB, err := openRepairDB(ctx, &superuserConfig)
-	require.NoError(err)
-	defer func() { _ = catalogDB.Close() }()
-	_, err = catalogDB.ExecContext(ctx, `
-		UPDATE pg_index
-		SET indisvalid = FALSE, indisready = FALSE
-		WHERE indexrelid IN (
-			'idx_block_metadata_cscb_repair_candidate'::regclass,
-			'idx_block_metadata_object_key_reference'::regclass,
-			'idx_block_consolidation_shadow_object_key_reference'::regclass,
-			'idx_block_metadata_cscb_repair_candidate_new'::regclass,
-			'idx_block_metadata_object_key_reference_hash_new'::regclass,
-			'idx_block_consolidation_shadow_object_key_reference_hash_new'::regclass
-		)`)
-	require.NoError(err)
-	requireInvalidIndexes(t, db, 6)
+	requireNoRepairIndexes(t, db)
 
 	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
 	requireCandidateIndex(t, db)
@@ -130,13 +82,12 @@ func requireCandidateIndex(t *testing.T, db *sql.DB) {
 	require.Contains(t, definition, "object_format = 1")
 }
 
-func requireInvalidIndexes(t *testing.T, db *sql.DB, expected int) {
+func requireNoRepairIndexes(t *testing.T, db *sql.DB) {
 	t.Helper()
 	var count int
 	err := db.QueryRow(`
 		SELECT COUNT(*)
-		FROM pg_index index_state
-		JOIN pg_class index_class ON index_class.oid = index_state.indexrelid
+		FROM pg_class index_class
 		JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
 		WHERE index_namespace.nspname = current_schema()
 			AND index_class.relname IN (
@@ -146,10 +97,9 @@ func requireInvalidIndexes(t *testing.T, db *sql.DB, expected int) {
 				'idx_block_metadata_cscb_repair_candidate_new',
 				'idx_block_metadata_object_key_reference_hash_new',
 				'idx_block_consolidation_shadow_object_key_reference_hash_new'
-			)
-			AND (NOT index_state.indisvalid OR NOT index_state.indisready)`).Scan(&count)
+			)`).Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, expected, count)
+	require.Zero(t, count)
 }
 
 func requireNoTemporaryIndexes(t *testing.T, db *sql.DB) {

--- a/internal/storage/cscbrepair/migration_integration_test.go
+++ b/internal/storage/cscbrepair/migration_integration_test.go
@@ -1,0 +1,142 @@
+package cscbrepair_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coinbase/chainstorage/internal/config"
+	metapostgres "github.com/coinbase/chainstorage/internal/storage/metastorage/postgres"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
+)
+
+func TestIntegrationCSCBRepairReferenceIndexMigration(t *testing.T) {
+	if os.Getenv("TEST_TYPE") != "integration" {
+		t.Skip("integration test")
+	}
+	require := require.New(t)
+	ctx := context.Background()
+
+	cfg, err := config.New(
+		config.WithEnvironment(config.EnvLocal),
+		config.WithBlockchain(common.Blockchain_BLOCKCHAIN_SOLANA),
+		config.WithNetwork(common.Network_NETWORK_SOLANA_MAINNET),
+	)
+	require.NoError(err)
+	require.NotNil(cfg.AWS.Postgres)
+	configureRepairTestEnvironment(t, cfg.AWS.Postgres)
+
+	db, err := openRepairDB(ctx, cfg.AWS.Postgres)
+	require.NoError(err)
+	defer func() { _ = db.Close() }()
+
+	goose.SetBaseFS(metapostgres.GetEmbeddedMigrations())
+	require.NoError(goose.SetDialect("postgres"))
+	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+	requireReferenceIndexes(t, db, "hash")
+	requireReferenceIndexPlans(t, db)
+
+	// Rewind only the index migration and recreate the shape left by the
+	// original B-tree migration. Applying the migration again must replace it,
+	// just as it replaces an invalid concurrent index left by a failed build.
+	require.NoError(goose.DownToContext(ctx, db, "db/migrations", 20260714000001))
+	_, err = db.ExecContext(ctx, `
+		CREATE INDEX idx_block_metadata_object_key_reference
+		ON block_metadata (object_key_main, id)
+		WHERE object_key_main IS NOT NULL AND object_key_main <> '';
+
+		CREATE INDEX idx_block_consolidation_shadow_object_key_reference
+		ON block_consolidation_shadow (consolidated_object_key_main, block_metadata_id)
+		WHERE consolidated_object_key_main IS NOT NULL AND consolidated_object_key_main <> ''`)
+	require.NoError(err)
+	requireReferenceIndexes(t, db, "btree")
+
+	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+	requireReferenceIndexes(t, db, "hash")
+	requireReferenceIndexPlans(t, db)
+}
+
+func requireReferenceIndexes(t *testing.T, db *sql.DB, expectedMethod string) {
+	t.Helper()
+	indexes := []struct {
+		name   string
+		column string
+	}{
+		{name: "idx_block_metadata_object_key_reference", column: "object_key_main"},
+		{name: "idx_block_consolidation_shadow_object_key_reference", column: "consolidated_object_key_main"},
+	}
+	for _, index := range indexes {
+		requireReferenceIndex(t, db, index.name, index.column, expectedMethod)
+	}
+}
+
+func requireReferenceIndex(t *testing.T, db *sql.DB, indexName string, column string, expectedMethod string) {
+	t.Helper()
+	var method, definition string
+	var valid, ready bool
+	err := db.QueryRow(`
+		SELECT access_method.amname, index_state.indisvalid, index_state.indisready,
+			pg_get_indexdef(index_state.indexrelid)
+		FROM pg_index index_state
+		JOIN pg_class index_class ON index_class.oid = index_state.indexrelid
+		JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
+		JOIN pg_am access_method ON access_method.oid = index_class.relam
+		WHERE index_namespace.nspname = current_schema()
+			AND index_class.relname = $1`, indexName).Scan(
+		&method,
+		&valid,
+		&ready,
+		&definition,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expectedMethod, method)
+	require.True(t, valid)
+	require.True(t, ready)
+	if expectedMethod == "hash" {
+		require.Contains(t, definition, "USING hash ("+column+")")
+	}
+}
+
+func requireReferenceIndexPlans(t *testing.T, db *sql.DB) {
+	t.Helper()
+	requireReferenceIndexPlan(t, db, `
+		SELECT COUNT(*)
+		FROM block_metadata
+		WHERE object_key_main = 'consolidated/test.cscb'
+			AND object_key_main <> ''
+			AND NOT (id = ANY(ARRAY[1]::BIGINT[]))`, "idx_block_metadata_object_key_reference")
+	requireReferenceIndexPlan(t, db, `
+		SELECT COUNT(*)
+		FROM block_consolidation_shadow
+		WHERE consolidated_object_key_main = 'consolidated/test.cscb'
+			AND consolidated_object_key_main <> ''
+			AND NOT (block_metadata_id = ANY(ARRAY[1]::BIGINT[]))`, "idx_block_consolidation_shadow_object_key_reference")
+}
+
+func requireReferenceIndexPlan(t *testing.T, db *sql.DB, query string, indexName string) {
+	t.Helper()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.Exec(`SET LOCAL enable_seqscan = off`)
+	require.NoError(t, err)
+
+	rows, err := tx.Query("EXPLAIN (COSTS OFF) " + query)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	require.NoError(t, rows.Err())
+	require.Contains(t, plan.String(), indexName)
+}

--- a/internal/storage/cscbrepair/migration_integration_test.go
+++ b/internal/storage/cscbrepair/migration_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/require"
 
@@ -38,32 +39,120 @@ func TestIntegrationCSCBRepairReferenceIndexMigration(t *testing.T) {
 	goose.SetBaseFS(metapostgres.GetEmbeddedMigrations())
 	require.NoError(goose.SetDialect("postgres"))
 	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+	requireCandidateIndex(t, db)
 	requireReferenceIndexes(t, db, "hash")
-	requireNoTemporaryReferenceIndexes(t, db)
-	requireReferenceIndexPlans(t, db)
+	requireNoTemporaryIndexes(t, db)
+	requireIndexPlans(t, db)
 
 	// Rewind only the index migration and recreate the shape left by the
 	// original B-tree migration. Applying the migration again must replace it,
 	// just as it replaces an invalid concurrent index left by a failed build.
 	require.NoError(goose.DownToContext(ctx, db, "db/migrations", 20260714000001))
 	_, err = db.ExecContext(ctx, `
+		CREATE INDEX idx_block_metadata_cscb_repair_candidate
+		ON block_metadata (tag, height DESC, object_key_main, id)
+		WHERE object_format = 1 AND object_key_main IS NOT NULL AND object_key_main <> '';
+
 		CREATE INDEX idx_block_metadata_object_key_reference
 		ON block_metadata (object_key_main, id)
 		WHERE object_key_main IS NOT NULL AND object_key_main <> '';
 
 		CREATE INDEX idx_block_consolidation_shadow_object_key_reference
 		ON block_consolidation_shadow (consolidated_object_key_main, block_metadata_id)
+		WHERE consolidated_object_key_main IS NOT NULL AND consolidated_object_key_main <> '';
+
+		CREATE INDEX idx_block_metadata_cscb_repair_candidate_new
+		ON block_metadata (tag, height DESC, object_key_main, id)
+		WHERE object_format = 1 AND object_key_main IS NOT NULL AND object_key_main <> '';
+
+		CREATE INDEX idx_block_metadata_object_key_reference_hash_new
+		ON block_metadata USING HASH (object_key_main)
+		WHERE object_key_main IS NOT NULL AND object_key_main <> '';
+
+		CREATE INDEX idx_block_consolidation_shadow_object_key_reference_hash_new
+		ON block_consolidation_shadow USING HASH (consolidated_object_key_main)
 		WHERE consolidated_object_key_main IS NOT NULL AND consolidated_object_key_main <> ''`)
 	require.NoError(err)
-	requireReferenceIndexes(t, db, "btree")
+
+	// Only the isolated local test superuser may emulate catalog state from an
+	// interrupted concurrent build. Migrations still run as the application
+	// owner so this test does not alter normal object ownership or privileges.
+	superuserConfig := *cfg.AWS.Postgres
+	superuserConfig.User = "postgres"
+	superuserConfig.Password = "postgres"
+	catalogDB, err := openRepairDB(ctx, &superuserConfig)
+	require.NoError(err)
+	defer func() { _ = catalogDB.Close() }()
+	_, err = catalogDB.ExecContext(ctx, `
+		UPDATE pg_index
+		SET indisvalid = FALSE, indisready = FALSE
+		WHERE indexrelid IN (
+			'idx_block_metadata_cscb_repair_candidate'::regclass,
+			'idx_block_metadata_object_key_reference'::regclass,
+			'idx_block_consolidation_shadow_object_key_reference'::regclass,
+			'idx_block_metadata_cscb_repair_candidate_new'::regclass,
+			'idx_block_metadata_object_key_reference_hash_new'::regclass,
+			'idx_block_consolidation_shadow_object_key_reference_hash_new'::regclass
+		)`)
+	require.NoError(err)
+	requireInvalidIndexes(t, db, 6)
 
 	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+	requireCandidateIndex(t, db)
 	requireReferenceIndexes(t, db, "hash")
-	requireNoTemporaryReferenceIndexes(t, db)
-	requireReferenceIndexPlans(t, db)
+	requireNoTemporaryIndexes(t, db)
+	requireIndexPlans(t, db)
 }
 
-func requireNoTemporaryReferenceIndexes(t *testing.T, db *sql.DB) {
+func requireCandidateIndex(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var method, definition string
+	var valid, ready bool
+	err := db.QueryRow(`
+		SELECT access_method.amname, index_state.indisvalid, index_state.indisready,
+			pg_get_indexdef(index_state.indexrelid)
+		FROM pg_index index_state
+		JOIN pg_class index_class ON index_class.oid = index_state.indexrelid
+		JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
+		JOIN pg_am access_method ON access_method.oid = index_class.relam
+		WHERE index_namespace.nspname = current_schema()
+			AND index_class.relname = 'idx_block_metadata_cscb_repair_candidate'`).Scan(
+		&method,
+		&valid,
+		&ready,
+		&definition,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "btree", method)
+	require.True(t, valid)
+	require.True(t, ready)
+	require.Contains(t, definition, "(tag, height DESC, object_key_main, id)")
+	require.Contains(t, definition, "object_format = 1")
+}
+
+func requireInvalidIndexes(t *testing.T, db *sql.DB, expected int) {
+	t.Helper()
+	var count int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM pg_index index_state
+		JOIN pg_class index_class ON index_class.oid = index_state.indexrelid
+		JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
+		WHERE index_namespace.nspname = current_schema()
+			AND index_class.relname IN (
+				'idx_block_metadata_cscb_repair_candidate',
+				'idx_block_metadata_object_key_reference',
+				'idx_block_consolidation_shadow_object_key_reference',
+				'idx_block_metadata_cscb_repair_candidate_new',
+				'idx_block_metadata_object_key_reference_hash_new',
+				'idx_block_consolidation_shadow_object_key_reference_hash_new'
+			)
+			AND (NOT index_state.indisvalid OR NOT index_state.indisready)`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, expected, count)
+}
+
+func requireNoTemporaryIndexes(t *testing.T, db *sql.DB) {
 	t.Helper()
 	var count int
 	err := db.QueryRow(`
@@ -72,6 +161,7 @@ func requireNoTemporaryReferenceIndexes(t *testing.T, db *sql.DB) {
 		JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
 		WHERE index_namespace.nspname = current_schema()
 			AND index_class.relname IN (
+				'idx_block_metadata_cscb_repair_candidate_new',
 				'idx_block_metadata_object_key_reference_hash_new',
 				'idx_block_consolidation_shadow_object_key_reference_hash_new'
 			)`).Scan(&count)
@@ -120,23 +210,32 @@ func requireReferenceIndex(t *testing.T, db *sql.DB, indexName string, column st
 	}
 }
 
-func requireReferenceIndexPlans(t *testing.T, db *sql.DB) {
+func requireIndexPlans(t *testing.T, db *sql.DB) {
 	t.Helper()
 	requireReferenceIndexPlan(t, db, `
 		SELECT COUNT(*)
 		FROM block_metadata
-		WHERE object_key_main = 'consolidated/test.cscb'
+		WHERE object_key_main = $1
 			AND object_key_main <> ''
-			AND NOT (id = ANY(ARRAY[1]::BIGINT[]))`, "idx_block_metadata_object_key_reference")
+			AND NOT (id = ANY($2))`, "idx_block_metadata_object_key_reference", "consolidated/test.cscb", pq.Array([]int64{1}))
 	requireReferenceIndexPlan(t, db, `
 		SELECT COUNT(*)
 		FROM block_consolidation_shadow
-		WHERE consolidated_object_key_main = 'consolidated/test.cscb'
+		WHERE consolidated_object_key_main = $1
 			AND consolidated_object_key_main <> ''
-			AND NOT (block_metadata_id = ANY(ARRAY[1]::BIGINT[]))`, "idx_block_consolidation_shadow_object_key_reference")
+			AND NOT (block_metadata_id = ANY($2))`, "idx_block_consolidation_shadow_object_key_reference", "consolidated/test.cscb", pq.Array([]int64{1}))
+	requireReferenceIndexPlan(t, db, `
+		SELECT object_key_main
+		FROM block_metadata
+		WHERE tag = $1
+			AND height >= $2
+			AND height < $3
+			AND object_format = $4
+			AND object_key_main IS NOT NULL
+			AND object_key_main <> ''`, "idx_block_metadata_cscb_repair_candidate", uint32(2), uint64(1000), uint64(2000), 1)
 }
 
-func requireReferenceIndexPlan(t *testing.T, db *sql.DB, query string, indexName string) {
+func requireReferenceIndexPlan(t *testing.T, db *sql.DB, query string, indexName string, args ...any) {
 	t.Helper()
 	tx, err := db.Begin()
 	require.NoError(t, err)
@@ -144,7 +243,7 @@ func requireReferenceIndexPlan(t *testing.T, db *sql.DB, query string, indexName
 	_, err = tx.Exec(`SET LOCAL enable_seqscan = off`)
 	require.NoError(t, err)
 
-	rows, err := tx.Query("EXPLAIN (COSTS OFF) " + query)
+	rows, err := tx.Query("EXPLAIN (COSTS OFF) "+query, args...)
 	require.NoError(t, err)
 	defer rows.Close()
 

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -165,6 +165,8 @@ func findNextCandidateObject(
 		JOIN overlapping_keys candidate ON candidate.object_key_main = bm.object_key_main
 		WHERE bm.tag = $1
 			AND bm.object_format = $4
+			AND bm.object_key_main IS NOT NULL
+			AND bm.object_key_main <> ''
 		GROUP BY bm.object_key_main
 		ORDER BY MAX(bm.height) DESC, bm.object_key_main DESC
 		LIMIT 1`
@@ -1000,6 +1002,7 @@ func loadCandidateByKey(ctx context.Context, q queryer, tag uint32, objectKey st
 		LEFT JOIN block_single_block_retention retirement ON retirement.block_metadata_id = bm.id
 		WHERE bm.tag = $1
 			AND bm.object_key_main = $2
+			AND bm.object_key_main <> ''
 			AND bm.object_format = $3
 		ORDER BY bm.height ASC, bm.id ASC`
 	rows, err := q.QueryContext(ctx, query, tag, objectKey, api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH)
@@ -1534,11 +1537,15 @@ func requireNoUnexpectedOldReferences(ctx context.Context, q queryer, objectKey 
 		SELECT
 			(SELECT COUNT(*)
 			 FROM block_metadata
-			 WHERE object_key_main = $1 AND NOT (id = ANY($2)))
+			 WHERE object_key_main = $1
+				AND object_key_main <> ''
+				AND NOT (id = ANY($2)))
 			+
 			(SELECT COUNT(*)
 			 FROM block_consolidation_shadow
-			 WHERE consolidated_object_key_main = $1 AND NOT (block_metadata_id = ANY($2)))`
+			 WHERE consolidated_object_key_main = $1
+				AND consolidated_object_key_main <> ''
+				AND NOT (block_metadata_id = ANY($2)))`
 	var references uint64
 	if err := q.QueryRowContext(ctx, query, objectKey, pq.Array(ids)).Scan(&references); err != nil {
 		return xerrors.Errorf("failed to count unexpected dirty CSCB references: %w", err)
@@ -1567,11 +1574,15 @@ func requireExactNewReferences(ctx context.Context, q queryer, manifest *Manifes
 		SELECT
 			(SELECT COUNT(*)
 			 FROM block_metadata
-			 WHERE object_key_main = $1 AND NOT (id = ANY($2)))
+			 WHERE object_key_main = $1
+				AND object_key_main <> ''
+				AND NOT (id = ANY($2)))
 			+
 			(SELECT COUNT(*)
 			 FROM block_consolidation_shadow
-			 WHERE consolidated_object_key_main = $1 AND NOT (block_metadata_id = ANY($2)))`
+			 WHERE consolidated_object_key_main = $1
+				AND consolidated_object_key_main <> ''
+				AND NOT (block_metadata_id = ANY($2)))`
 	var references uint64
 	if err := q.QueryRowContext(ctx, query, objectKey, pq.Array(ids)).Scan(&references); err != nil {
 		return xerrors.Errorf("failed to count unexpected rebuilt CSCB references: %w", err)
@@ -1585,9 +1596,13 @@ func requireExactNewReferences(ctx context.Context, q queryer, manifest *Manifes
 func requireNoOldReferences(ctx context.Context, q queryer, objectKey string) error {
 	const query = `
 		SELECT
-			(SELECT COUNT(*) FROM block_metadata WHERE object_key_main = $1)
+			(SELECT COUNT(*)
+			 FROM block_metadata
+			 WHERE object_key_main = $1 AND object_key_main <> '')
 			+
-			(SELECT COUNT(*) FROM block_consolidation_shadow WHERE consolidated_object_key_main = $1)`
+			(SELECT COUNT(*)
+			 FROM block_consolidation_shadow
+			 WHERE consolidated_object_key_main = $1 AND consolidated_object_key_main <> '')`
 	var references uint64
 	if err := q.QueryRowContext(ctx, query, objectKey).Scan(&references); err != nil {
 		return xerrors.Errorf("failed to count old CSCB references: %w", err)

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -636,7 +636,13 @@ func (s *blockStorageTestSuite) TestGetBlockByHashInvalidHeight() {
 func (s *blockStorageTestSuite) TestGetBlockByHashQueryUsesPartialIndex() {
 	require := testutil.Require(s.T())
 
-	rows, err := s.db.QueryContext(context.Background(), "EXPLAIN "+blockMetadataByHashQuery(), tag, s.config.Chain.BlockStartHeight, "0x0")
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	require.NoError(err)
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.ExecContext(context.Background(), "SET LOCAL enable_seqscan = off")
+	require.NoError(err)
+
+	rows, err := tx.QueryContext(context.Background(), "EXPLAIN "+blockMetadataByHashQuery(), tag, s.config.Chain.BlockStartHeight, "0x0")
 	require.NoError(err)
 	defer rows.Close()
 

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
@@ -11,21 +11,30 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_cscb_repair_candidate
 -- the full keys and row IDs consume unnecessary space and the block_metadata
 -- index exceeds Aurora local scratch storage on large chains such as Solana.
 -- Hash indexes preserve the required equality lookups without storing or
--- sorting the full keys. Drop first so retries replace both B-trees created by
--- the original migration and invalid indexes left by failed concurrent builds.
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_object_key_reference
+-- sorting the full keys. Build under a temporary name before replacing the
+-- canonical index, and drop that temporary name first so retries replace an
+-- invalid index left by a failed concurrent build.
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference_hash_new;
+CREATE INDEX CONCURRENTLY idx_block_metadata_object_key_reference_hash_new
     ON block_metadata USING HASH (object_key_main)
     WHERE object_key_main IS NOT NULL
         AND object_key_main <> '';
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
+ALTER INDEX idx_block_metadata_object_key_reference_hash_new
+    RENAME TO idx_block_metadata_object_key_reference;
 
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_object_key_reference
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference_hash_new;
+CREATE INDEX CONCURRENTLY idx_block_consolidation_shadow_object_key_reference_hash_new
     ON block_consolidation_shadow USING HASH (consolidated_object_key_main)
     WHERE consolidated_object_key_main IS NOT NULL
         AND consolidated_object_key_main <> '';
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
+ALTER INDEX idx_block_consolidation_shadow_object_key_reference_hash_new
+    RENAME TO idx_block_consolidation_shadow_object_key_reference;
 
 -- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference_hash_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference_hash_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate;

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
@@ -1,45 +1,28 @@
 -- +goose NO TRANSACTION
 
 -- +goose Up
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate_new;
-CREATE INDEX CONCURRENTLY idx_block_metadata_cscb_repair_candidate_new
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_cscb_repair_candidate
     ON block_metadata (tag, height DESC, object_key_main, id)
     WHERE object_format = 1
         AND object_key_main IS NOT NULL
         AND object_key_main <> '';
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate;
-ALTER INDEX idx_block_metadata_cscb_repair_candidate_new
-    RENAME TO idx_block_metadata_cscb_repair_candidate;
 
 -- CSCB repair only performs exact object-key reference checks. B-trees over
 -- the full keys and row IDs consume unnecessary space and the block_metadata
 -- index exceeds Aurora local scratch storage on large chains such as Solana.
 -- Hash indexes preserve the required equality lookups without storing or
--- sorting the full keys. Build under a temporary name before replacing the
--- canonical index, and drop that temporary name first so retries replace an
--- invalid index left by a failed concurrent build.
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference_hash_new;
-CREATE INDEX CONCURRENTLY idx_block_metadata_object_key_reference_hash_new
+-- sorting the full keys.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_object_key_reference
     ON block_metadata USING HASH (object_key_main)
     WHERE object_key_main IS NOT NULL
         AND object_key_main <> '';
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
-ALTER INDEX idx_block_metadata_object_key_reference_hash_new
-    RENAME TO idx_block_metadata_object_key_reference;
 
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference_hash_new;
-CREATE INDEX CONCURRENTLY idx_block_consolidation_shadow_object_key_reference_hash_new
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_object_key_reference
     ON block_consolidation_shadow USING HASH (consolidated_object_key_main)
     WHERE consolidated_object_key_main IS NOT NULL
         AND consolidated_object_key_main <> '';
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
-ALTER INDEX idx_block_consolidation_shadow_object_key_reference_hash_new
-    RENAME TO idx_block_consolidation_shadow_object_key_reference;
 
 -- +goose Down
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference_hash_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference_hash_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
-DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate;

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
@@ -7,13 +7,21 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_cscb_repair_candidate
         AND object_key_main IS NOT NULL
         AND object_key_main <> '';
 
+-- CSCB repair only performs exact object-key reference checks. B-trees over
+-- the full keys and row IDs consume unnecessary space and the block_metadata
+-- index exceeds Aurora local scratch storage on large chains such as Solana.
+-- Hash indexes preserve the required equality lookups without storing or
+-- sorting the full keys. Drop first so retries replace both B-trees created by
+-- the original migration and invalid indexes left by failed concurrent builds.
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_object_key_reference
-    ON block_metadata (object_key_main, id)
+    ON block_metadata USING HASH (object_key_main)
     WHERE object_key_main IS NOT NULL
         AND object_key_main <> '';
 
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_object_key_reference
-    ON block_consolidation_shadow (consolidated_object_key_main, block_metadata_id)
+    ON block_consolidation_shadow USING HASH (consolidated_object_key_main)
     WHERE consolidated_object_key_main IS NOT NULL
         AND consolidated_object_key_main <> '';
 

--- a/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260714000002_add_cscb_repair_indexes.sql
@@ -1,11 +1,15 @@
 -- +goose NO TRANSACTION
 
 -- +goose Up
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_metadata_cscb_repair_candidate
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate_new;
+CREATE INDEX CONCURRENTLY idx_block_metadata_cscb_repair_candidate_new
     ON block_metadata (tag, height DESC, object_key_main, id)
     WHERE object_format = 1
         AND object_key_main IS NOT NULL
         AND object_key_main <> '';
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate;
+ALTER INDEX idx_block_metadata_cscb_repair_candidate_new
+    RENAME TO idx_block_metadata_cscb_repair_candidate;
 
 -- CSCB repair only performs exact object-key reference checks. B-trees over
 -- the full keys and row IDs consume unnecessary space and the block_metadata
@@ -37,4 +41,5 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_refe
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_object_key_reference;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference_hash_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_object_key_reference;
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate_new;
 DROP INDEX CONCURRENTLY IF EXISTS idx_block_metadata_cscb_repair_candidate;


### PR DESCRIPTION
## Summary

- replace the equality-only CSCB reference B-trees with partial, key-only hash indexes
- make every repair key lookup state the partial-index non-empty predicate explicitly
- keep the migration to direct canonical index creation after an operator-controlled clean down
- add a Docker-backed down/up migration test that verifies both index methods, validity, and query plans

Linear: https://linear.app/cipherowl/issue/INF-1133

## Production sizing evidence

Read-only inspection of Solana production found approximately 432.8M `block_metadata` rows, a 118.9 GB heap, 76.7 GB of existing indexes, and 97-byte average object keys. The failed B-tree build drove Aurora writer `FreeLocalStorage` from 33.3 GB to 172 MB and left an invalid index.

A PostgreSQL 15.15 Docker probe with 1M Solana-shaped rows measured:

| Index | Size | Temp bytes during concurrent build |
|---|---:|---:|
| `(object_key_main, id)` B-tree | 141,959,168 | 124,272,640 |
| `HASH (object_key_main)` | 45,842,432 | 0 |

The Solana-scale projection is approximately 19.8 GB of shared index storage for the hash index versus about 53.8 GB of local temp sorting for the original B-tree.

## Rollout requirement

Production currently has nine databases at `20260714000002` with valid B-trees and Plasma, Solana, and Zcash at `20260714000001` with invalid B-tree remnants.

**Operational precondition:** keep CSCB repair workflows stopped and consolidation disabled for the entire migration. These indexes serve only CSCB repair candidate/reference queries, so the deliberate rebuild interval without canonical repair indexes is acceptable only while those workflows are quiesced. Normal block ingestion does not use these repair indexes.

1. Run Goose down one **only** on databases currently at `20260714000002`.
2. On every database at `20260714000001`, inspect and drop any canonical or temporary repair-index remnants, including invalid indexes left by an interrupted concurrent build.
3. Verify all databases are at `20260714000001` and no repair indexes remain.
4. Apply this updated `20260714000002` to every PostgreSQL chain database.
5. Verify both reference indexes are valid, ready hash indexes and the candidate index remains a valid B-tree.

Do not run Goose down on a database already at `20260714000001`; that would remove the repair manifest migration. If an Up attempt is interrupted while Goose remains at `20260714000001`, clean any invalid repair-index remnants and retry Up directly; do not run another Down.

## Tests

- `go test ./internal/storage/cscbrepair ./internal/storage/metastorage/postgres/... -count=1`
- `make integration TARGET=internal/storage/cscbrepair`
- `make lint`
- PostgreSQL 15.15 Docker sizing probe described above
- clean down/up rehearsal on all 14 affected dev PostgreSQL databases; final state `20260714000002` with candidate B-tree and both reference hash indexes valid/ready/live and query plans verified
