### PR TITLE
fix(INF-1133): make upload guard queries indexable

### DIFF
--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -64,6 +64,50 @@ func blockMetadataByHashQuery() string {
 				LIMIT 1`, blockMetadataColumns)
 }
 
+func singleBlockUploadGuardByHashQuery() string {
+	return `
+		SELECT
+			bm.single_block_retention_fenced_at IS NOT NULL
+			OR EXISTS (
+				SELECT 1
+				FROM cscb_repair_block repair_block
+				JOIN cscb_repair_manifest repair ON repair.id = repair_block.repair_id
+				WHERE repair_block.block_metadata_id = bm.id
+					AND repair.state <> 'completed'
+			)
+		FROM block_metadata bm
+		WHERE bm.tag = $1
+			AND bm.height = $2
+			AND bm.hash = $3
+			AND bm.skipped = FALSE
+		FOR UPDATE`
+}
+
+// A block without a hash can only be identified by its canonical tag and height.
+// Resolve that row through canonical_blocks so the lookup remains indexed.
+func singleBlockUploadGuardWithoutHashQuery() string {
+	return `
+		SELECT
+			bm.single_block_retention_fenced_at IS NOT NULL
+			OR EXISTS (
+				SELECT 1
+				FROM cscb_repair_block repair_block
+				JOIN cscb_repair_manifest repair ON repair.id = repair_block.repair_id
+				WHERE repair_block.block_metadata_id = bm.id
+					AND repair.state <> 'completed'
+			)
+		FROM canonical_blocks cb
+		JOIN block_metadata bm
+			ON bm.id = cb.block_metadata_id
+			AND bm.tag = cb.tag
+			AND bm.height = cb.height
+		WHERE cb.tag = $1
+			AND cb.height = $2
+			AND bm.hash IS NULL
+			AND bm.skipped = FALSE
+		FOR UPDATE OF bm`
+}
+
 func newBlockStorage(db *sql.DB, params Params) (internal.BlockStorage, error) {
 	metrics := params.Metrics.SubScope("block_storage").Tagged(map[string]string{
 		"storage_type": "postgres",
@@ -103,22 +147,11 @@ func (b *blockStorageImpl) AcquireSingleBlockUploadGuard(
 		return nil, err
 	}
 	var singleBlockWriteFenced bool
-	err = tx.QueryRowContext(ctx, `
-		SELECT
-			bm.single_block_retention_fenced_at IS NOT NULL
-			OR EXISTS (
-				SELECT 1
-				FROM cscb_repair_block repair_block
-				JOIN cscb_repair_manifest repair ON repair.id = repair_block.repair_id
-				WHERE repair_block.block_metadata_id = bm.id
-					AND repair.state <> 'completed'
-			)
-		FROM block_metadata bm
-		WHERE bm.tag = $1
-			AND bm.height = $2
-			AND bm.hash IS NOT DISTINCT FROM NULLIF($3, '')
-			AND bm.skipped = FALSE
-		FOR UPDATE`, tag, height, hash).Scan(&singleBlockWriteFenced)
+	if hash == "" {
+		err = tx.QueryRowContext(ctx, singleBlockUploadGuardWithoutHashQuery(), tag, height).Scan(&singleBlockWriteFenced)
+	} else {
+		err = tx.QueryRowContext(ctx, singleBlockUploadGuardByHashQuery(), tag, height, hash).Scan(&singleBlockWriteFenced)
+	}
 	if err != nil && err != sql.ErrNoRows {
 		_ = tx.Rollback()
 		_ = conn.Close()

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -105,7 +105,7 @@ func singleBlockUploadGuardWithoutHashQuery() string {
 			AND cb.height = $2
 			AND bm.hash IS NULL
 			AND bm.skipped = FALSE
-		FOR UPDATE OF bm`
+		FOR UPDATE OF cb, bm`
 }
 
 func newBlockStorage(db *sql.DB, params Params) (internal.BlockStorage, error) {

--- a/internal/storage/metastorage/postgres/block_storage.go
+++ b/internal/storage/metastorage/postgres/block_storage.go
@@ -96,16 +96,19 @@ func singleBlockUploadGuardWithoutHashQuery() string {
 				WHERE repair_block.block_metadata_id = bm.id
 					AND repair.state <> 'completed'
 			)
-		FROM canonical_blocks cb
-		JOIN block_metadata bm
-			ON bm.id = cb.block_metadata_id
-			AND bm.tag = cb.tag
-			AND bm.height = cb.height
-		WHERE cb.tag = $1
-			AND cb.height = $2
+		FROM block_metadata bm
+		WHERE bm.id = (
+			SELECT cb.block_metadata_id
+			FROM canonical_blocks cb
+			WHERE cb.tag = $1
+				AND cb.height = $2
+			FOR UPDATE
+		)
+			AND bm.tag = $1
+			AND bm.height = $2
 			AND bm.hash IS NULL
 			AND bm.skipped = FALSE
-		FOR UPDATE OF cb, bm`
+		FOR UPDATE OF bm`
 }
 
 func newBlockStorage(db *sql.DB, params Params) (internal.BlockStorage, error) {

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -819,8 +819,8 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardWithoutHashQueryUsesCa
 	plan := strings.Join(lines, "\n")
 	assert.Contains(s.T(), plan, "Index Scan using canonical_blocks_")
 	assert.Contains(s.T(), plan, "Index Cond: ((height = '10'::bigint) AND (tag = 1))")
-	// PostgreSQL may surface the primary-key equality as a join filter when the tables are nearly empty.
 	assert.Contains(s.T(), plan, "block_metadata_pkey")
+	assert.Regexp(s.T(), `Index Cond: \(id = \$[0-9]+\)`, plan)
 	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -363,21 +363,24 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardMatchesNullableHash() 
 	require.NoError(err)
 	require.NotNil(guard)
 	require.False(guard.RetirementFenced())
-	canonicalUpdateDone := make(chan error, 1)
-	go func() {
-		_, updateErr := s.db.ExecContext(ctx, `
-			UPDATE canonical_blocks
-			SET block_metadata_id = $1
-			WHERE tag = $2 AND height = $3`, nonCanonicalBlockMetadataID, tag, height)
-		canonicalUpdateDone <- updateErr
-	}()
-	select {
-	case updateErr := <-canonicalUpdateDone:
-		require.Failf("canonical update bypassed upload guard", "unexpected result: %v", updateErr)
-	case <-time.After(100 * time.Millisecond):
-	}
+	canonicalUpdateConn, err := s.db.Conn(ctx)
+	require.NoError(err)
+	defer canonicalUpdateConn.Close()
+	_, err = canonicalUpdateConn.ExecContext(ctx, "SET lock_timeout = '100ms'")
+	require.NoError(err)
+	_, err = canonicalUpdateConn.ExecContext(ctx, `
+		UPDATE canonical_blocks
+		SET block_metadata_id = $1
+		WHERE tag = $2 AND height = $3`, nonCanonicalBlockMetadataID, tag, height)
+	require.ErrorContains(err, "canceling statement due to lock timeout")
 	require.NoError(guard.Release())
-	require.NoError(<-canonicalUpdateDone)
+	_, err = canonicalUpdateConn.ExecContext(ctx, "SET lock_timeout = 0")
+	require.NoError(err)
+	_, err = canonicalUpdateConn.ExecContext(ctx, `
+		UPDATE canonical_blocks
+		SET block_metadata_id = $1
+		WHERE tag = $2 AND height = $3`, nonCanonicalBlockMetadataID, tag, height)
+	require.NoError(err)
 	fencedGuard, err := guardStorage.AcquireSingleBlockUploadGuard(ctx, tag, height, "")
 	require.NoError(err)
 	require.NotNil(fencedGuard)
@@ -783,6 +786,7 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardByHashQueryUsesPartial
 
 	plan := strings.Join(lines, "\n")
 	assert.Contains(s.T(), plan, "unique_tag_hash_regular")
+	assert.Contains(s.T(), plan, "Index Cond: ((tag = 1) AND ((hash)::text = '0x0'::text))")
 	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -819,8 +819,8 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardWithoutHashQueryUsesCa
 	plan := strings.Join(lines, "\n")
 	assert.Contains(s.T(), plan, "Index Scan using canonical_blocks_")
 	assert.Contains(s.T(), plan, "Index Cond: ((height = '10'::bigint) AND (tag = 1))")
+	// PostgreSQL may surface the primary-key equality as a join filter when the tables are nearly empty.
 	assert.Contains(s.T(), plan, "block_metadata_pkey")
-	assert.Contains(s.T(), plan, "Index Cond: (id = cb.block_metadata_id)")
 	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -332,6 +332,30 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardMatchesNullableHash() 
 		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
 	).Scan(&blockMetadataID)
 	require.NoError(err)
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO canonical_blocks (height, block_metadata_id, tag)
+		VALUES ($1, $2, $3)`, height, blockMetadataID, tag)
+	require.NoError(err)
+	var nonCanonicalBlockMetadataID int64
+	err = s.db.QueryRowContext(ctx, `
+		INSERT INTO block_metadata (
+			height, tag, hash, parent_height, object_key_main, timestamp, skipped,
+			object_format, byte_offset, byte_length, uncompressed_length
+		) VALUES ($1, $2, NULL, $3, $4, $5, FALSE, $6, 0, 128, 128)
+		RETURNING id`,
+		height,
+		tag,
+		height-1,
+		"consolidated/non-canonical-null-hash.cscb.gzip",
+		time.Now().UTC().Unix(),
+		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+	).Scan(&nonCanonicalBlockMetadataID)
+	require.NoError(err)
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE block_metadata
+		SET single_block_retention_fenced_at = CURRENT_TIMESTAMP
+		WHERE id = $1`, nonCanonicalBlockMetadataID)
+	require.NoError(err)
 
 	guardStorage, ok := s.accessor.(internal.SingleBlockUploadGuardStorage)
 	require.True(ok)
@@ -351,6 +375,68 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardMatchesNullableHash() 
 	require.NotNil(fencedGuard)
 	require.True(fencedGuard.RetirementFenced())
 	require.NoError(fencedGuard.Release())
+}
+
+func (s *blockStorageTestSuite) TestSingleBlockUploadGuardMatchesExactHash() {
+	require := testutil.Require(s.T())
+	ctx := context.Background()
+	height := s.config.Chain.BlockStartHeight + 3
+
+	var fencedBlockMetadataID int64
+	for _, blockHash := range []string{"unfenced-hash", "fenced-hash"} {
+		var blockMetadataID int64
+		err := s.db.QueryRowContext(ctx, `
+			INSERT INTO block_metadata (
+				height, tag, hash, parent_height, object_key_main, timestamp, skipped,
+				object_format, byte_offset, byte_length, uncompressed_length
+			) VALUES ($1, $2, $3, $4, $5, $6, FALSE, $7, 0, 128, 128)
+			RETURNING id`,
+			height,
+			tag,
+			blockHash,
+			height-1,
+			"consolidated/"+blockHash+".cscb.gzip",
+			time.Now().UTC().Unix(),
+			api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+		).Scan(&blockMetadataID)
+		require.NoError(err)
+		if blockHash == "fenced-hash" {
+			fencedBlockMetadataID = blockMetadataID
+		}
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE block_metadata
+		SET single_block_retention_fenced_at = CURRENT_TIMESTAMP
+		WHERE id = $1`, fencedBlockMetadataID)
+	require.NoError(err)
+
+	guardStorage, ok := s.accessor.(internal.SingleBlockUploadGuardStorage)
+	require.True(ok)
+	unfencedGuard, err := guardStorage.AcquireSingleBlockUploadGuard(ctx, tag, height, "unfenced-hash")
+	require.NoError(err)
+	require.False(unfencedGuard.RetirementFenced())
+	require.NoError(unfencedGuard.Release())
+	fencedGuard, err := guardStorage.AcquireSingleBlockUploadGuard(ctx, tag, height, "fenced-hash")
+	require.NoError(err)
+	require.True(fencedGuard.RetirementFenced())
+	require.NoError(fencedGuard.Release())
+}
+
+func (s *blockStorageTestSuite) TestSingleBlockUploadGuardWithoutHashAllowsMissingCanonicalMetadata() {
+	require := testutil.Require(s.T())
+	guardStorage, ok := s.accessor.(internal.SingleBlockUploadGuardStorage)
+	require.True(ok)
+
+	guard, err := guardStorage.AcquireSingleBlockUploadGuard(
+		context.Background(),
+		tag,
+		s.config.Chain.BlockStartHeight+4,
+		"",
+	)
+	require.NoError(err)
+	require.NotNil(guard)
+	require.False(guard.RetirementFenced())
+	require.NoError(guard.Release())
 }
 
 func (s *blockStorageTestSuite) TestSingleBlockShadowCompatibilityColumnsStaySynchronized() {
@@ -656,6 +742,70 @@ func (s *blockStorageTestSuite) TestGetBlockByHashQueryUsesPartialIndex() {
 
 	plan := strings.Join(lines, "\n")
 	assert.Contains(s.T(), plan, "unique_tag_hash_regular")
+	assert.NotContains(s.T(), plan, "Seq Scan")
+}
+
+func (s *blockStorageTestSuite) TestSingleBlockUploadGuardByHashQueryUsesPartialIndex() {
+	require := testutil.Require(s.T())
+
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	require.NoError(err)
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.ExecContext(context.Background(), "SET LOCAL enable_seqscan = off")
+	require.NoError(err)
+
+	rows, err := tx.QueryContext(
+		context.Background(),
+		"EXPLAIN "+singleBlockUploadGuardByHashQuery(),
+		tag,
+		s.config.Chain.BlockStartHeight,
+		"0x0",
+	)
+	require.NoError(err)
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(rows.Err())
+
+	plan := strings.Join(lines, "\n")
+	assert.Contains(s.T(), plan, "unique_tag_hash_regular")
+	assert.NotContains(s.T(), plan, "Seq Scan")
+}
+
+func (s *blockStorageTestSuite) TestSingleBlockUploadGuardWithoutHashQueryUsesCanonicalIndexes() {
+	require := testutil.Require(s.T())
+
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	require.NoError(err)
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.ExecContext(context.Background(), "SET LOCAL enable_seqscan = off")
+	require.NoError(err)
+
+	rows, err := tx.QueryContext(
+		context.Background(),
+		"EXPLAIN "+singleBlockUploadGuardWithoutHashQuery(),
+		tag,
+		s.config.Chain.BlockStartHeight,
+	)
+	require.NoError(err)
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(rows.Err())
+
+	plan := strings.Join(lines, "\n")
+	assert.Contains(s.T(), plan, "Index Scan using canonical_blocks_")
+	assert.Contains(s.T(), plan, "block_metadata_pkey")
 	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 

--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -363,13 +363,21 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardMatchesNullableHash() 
 	require.NoError(err)
 	require.NotNil(guard)
 	require.False(guard.RetirementFenced())
+	canonicalUpdateDone := make(chan error, 1)
+	go func() {
+		_, updateErr := s.db.ExecContext(ctx, `
+			UPDATE canonical_blocks
+			SET block_metadata_id = $1
+			WHERE tag = $2 AND height = $3`, nonCanonicalBlockMetadataID, tag, height)
+		canonicalUpdateDone <- updateErr
+	}()
+	select {
+	case updateErr := <-canonicalUpdateDone:
+		require.Failf("canonical update bypassed upload guard", "unexpected result: %v", updateErr)
+	case <-time.After(100 * time.Millisecond):
+	}
 	require.NoError(guard.Release())
-
-	_, err = s.db.ExecContext(ctx, `
-		UPDATE block_metadata
-		SET single_block_retention_fenced_at = CURRENT_TIMESTAMP
-		WHERE id = $1`, blockMetadataID)
-	require.NoError(err)
+	require.NoError(<-canonicalUpdateDone)
 	fencedGuard, err := guardStorage.AcquireSingleBlockUploadGuard(ctx, tag, height, "")
 	require.NoError(err)
 	require.NotNil(fencedGuard)
@@ -742,6 +750,7 @@ func (s *blockStorageTestSuite) TestGetBlockByHashQueryUsesPartialIndex() {
 
 	plan := strings.Join(lines, "\n")
 	assert.Contains(s.T(), plan, "unique_tag_hash_regular")
+	assert.Contains(s.T(), plan, "Index Cond: ((tag = 1) AND ((hash)::text = '0x0'::text))")
 	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 
@@ -805,7 +814,9 @@ func (s *blockStorageTestSuite) TestSingleBlockUploadGuardWithoutHashQueryUsesCa
 
 	plan := strings.Join(lines, "\n")
 	assert.Contains(s.T(), plan, "Index Scan using canonical_blocks_")
+	assert.Contains(s.T(), plan, "Index Cond: ((height = '10'::bigint) AND (tag = 1))")
 	assert.Contains(s.T(), plan, "block_metadata_pkey")
+	assert.Contains(s.T(), plan, "Index Cond: (id = cb.block_metadata_id)")
 	assert.NotContains(s.T(), plan, "Seq Scan")
 }
 

--- a/internal/storage/metastorage/postgres/connection.go
+++ b/internal/storage/metastorage/postgres/connection.go
@@ -7,7 +7,6 @@ import (
 
 	_ "github.com/lib/pq"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -23,6 +22,9 @@ func newDBConnection(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, 
 	// Add connect_timeout if specified
 	if cfg.ConnectTimeout > 0 {
 		dsn += fmt.Sprintf(" connect_timeout=%d", int(cfg.ConnectTimeout.Seconds()))
+	}
+	if cfg.StatementTimeout > 0 {
+		dsn += fmt.Sprintf(" statement_timeout=%d", cfg.StatementTimeout.Milliseconds())
 	}
 
 	// Debug output for CI troubleshooting
@@ -51,14 +53,6 @@ func newDBConnection(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, 
 	db.SetMaxIdleConns(cfg.MinConnections)
 	db.SetConnMaxLifetime(cfg.MaxLifetime)
 	db.SetConnMaxIdleTime(cfg.MaxIdleTime)
-
-	// Set statement timeout if specified
-	if cfg.StatementTimeout > 0 {
-		_, err := db.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = '%dms'", cfg.StatementTimeout.Milliseconds()))
-		if err != nil {
-			return nil, xerrors.Errorf("failed to set statement timeout: %w", err)
-		}
-	}
 
 	// Do not run schema migrations from runtime service connections.
 	// Server pods may connect through read replicas, and worker users may not own

--- a/internal/storage/metastorage/postgres/connection_integration_test.go
+++ b/internal/storage/metastorage/postgres/connection_integration_test.go
@@ -1,0 +1,42 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coinbase/chainstorage/internal/config"
+)
+
+func TestIntegrationNewDBConnectionAppliesStatementTimeoutToEveryConnection(t *testing.T) {
+	cfg, err := config.New()
+	require.NoError(t, err)
+	if !cfg.IsIntegrationTest() || cfg.AWS.Postgres == nil {
+		t.Skip("Postgres is not configured for integration tests")
+	}
+
+	postgresCfg := *cfg.AWS.Postgres
+	postgresCfg.MaxConnections = 2
+	postgresCfg.MinConnections = 0
+	postgresCfg.StatementTimeout = 1234 * time.Millisecond
+
+	db, err := newDBConnection(context.Background(), &postgresCfg)
+	require.NoError(t, err)
+	defer db.Close()
+
+	first, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer first.Close()
+	second, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer second.Close()
+
+	for _, conn := range []*sql.Conn{first, second} {
+		var timeout string
+		require.NoError(t, conn.QueryRowContext(context.Background(), "SHOW statement_timeout").Scan(&timeout))
+		require.Equal(t, "1234ms", timeout)
+	}
+}


### PR DESCRIPTION
## Summary

- split the shared PostgreSQL single-block upload guard into indexed hashed and hashless queries
- use `unique_tag_hash_regular` for non-empty hashes and canonical height/tag plus metadata primary keys for empty hashes
- apply `statement_timeout` as a PostgreSQL startup parameter so every physical pooled connection receives it
- add query-plan, exact-row selection, nullable-hash, missing-row, and multi-connection timeout regressions

No schema migration or chain-specific configuration is required.

## Validation

- `TEST_TYPE=unit go test ./internal/storage/metastorage/... ./internal/storage/blobstorage/...`
- `go vet ./internal/storage/metastorage/postgres`
- full Docker/PostgreSQL integration suite for `internal/storage/metastorage/postgres`
- Docker/PostgreSQL/LocalStack `TestIntegrationCSCBRepairFullLifecycle`

The repository-wide unit run reached an unrelated BSC linker step and stopped because the local disk reported `no space left on device`; all affected suites above passed.

Linear: https://linear.app/cipherowl/issue/INF-1133