### PR TITLE
fix(INF-1133): restore runtime database migrations

### DIFF
--- a/internal/storage/metastorage/postgres/block_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/block_storage_integration_test.go
@@ -45,20 +45,6 @@ type blockStorageTestSuite struct {
 	db       *sql.DB
 }
 
-func (s *blockStorageTestSuite) SetupSuite() {
-	require := testutil.Require(s.T())
-	cfg, err := config.New()
-	require.NoError(err)
-	if !cfg.IsIntegrationTest() || cfg.AWS.Postgres == nil {
-		return
-	}
-
-	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
-	require.NoError(err)
-	defer db.Close()
-	require.NoError(runMigrations(context.Background(), db))
-}
-
 func (s *blockStorageTestSuite) SetupTest() {
 	require := testutil.Require(s.T())
 

--- a/internal/storage/metastorage/postgres/connection.go
+++ b/internal/storage/metastorage/postgres/connection.go
@@ -7,6 +7,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"go.uber.org/zap"
+	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -54,8 +55,13 @@ func newDBConnection(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, 
 	db.SetConnMaxLifetime(cfg.MaxLifetime)
 	db.SetConnMaxIdleTime(cfg.MaxIdleTime)
 
-	// Do not run schema migrations from runtime service connections.
-	// Server pods may connect through read replicas, and worker users may not own
-	// existing tables. Run migrations explicitly through admin db-init/db-migrate.
+	// Always run migrations - goose will check which migrations have been applied
+	// and only run new ones. This ensures incremental migrations work properly.
+	logger.Debug("Running database migrations")
+	if err := runMigrations(ctx, db); err != nil {
+		return nil, xerrors.Errorf("failed to run migrations: %w", err)
+	}
+	logger.Debug("Migrations completed successfully")
+
 	return db, nil
 }

--- a/internal/storage/metastorage/postgres/event_storage_integration_test.go
+++ b/internal/storage/metastorage/postgres/event_storage_integration_test.go
@@ -28,20 +28,6 @@ type eventStorageTestSuite struct {
 	db       *sql.DB
 }
 
-func (s *eventStorageTestSuite) SetupSuite() {
-	require := testutil.Require(s.T())
-	cfg, err := config.New()
-	require.NoError(err)
-	if !cfg.IsIntegrationTest() || cfg.AWS.Postgres == nil {
-		return
-	}
-
-	db, err := newDBConnection(context.Background(), cfg.AWS.Postgres)
-	require.NoError(err)
-	defer db.Close()
-	require.NoError(runMigrations(context.Background(), db))
-}
-
 func (s *eventStorageTestSuite) SetupTest() {
 	require := testutil.Require(s.T())
 	var accessor internal.MetaStorage


### PR DESCRIPTION
## Summary

- restore embedded Goose migrations during PostgreSQL service connection bootstrap
- fail startup when schema migration fails
- remove the suite-level migration hooks that only compensated for disabled runtime migrations

## Why

Runtime migrations were temporarily disabled while the CSCB repair index migration was being fixed. The migration is now safe on current `master`, so service bootstrap should again apply pending schema changes before returning a PostgreSQL connection.

## Impact

Chainstorage server and worker startup will apply pending PostgreSQL migrations idempotently. Existing databases at the latest Goose version remain unchanged.

## Validation

- `PATH=/tmp/chainstorage-pr-tools:$PATH make test TARGET=internal/storage/metastorage/postgres`
- `TEST_TYPE=unit go test ./...`
- fresh local PostgreSQL integration suite; migrations applied through `20260714000002`
- targeted fresh-database connection integration test
- `git diff --check`

Linear: [INF-1133](https://linear.app/cipherowl/issue/INF-1133)
