### PR TITLE
perf(INF-1133): parallelize CSCB repair

### DIFF
--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -26,6 +26,7 @@ import (
 	chains3 "github.com/coinbase/chainstorage/internal/s3"
 	"github.com/coinbase/chainstorage/internal/storage/blobstorage"
 	"github.com/coinbase/chainstorage/internal/storage/cscbrepair"
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepairlock"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage"
 	metapostgres "github.com/coinbase/chainstorage/internal/storage/metastorage/postgres"
 	"github.com/coinbase/chainstorage/internal/storage/retirement"
@@ -166,9 +167,15 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 
 	store := retirement.NewS3ObjectStore(rawS3)
 	repository := cscbrepair.NewPostgresRepository(db)
-	candidateKeys, err := repository.ListCandidateObjectKeys(ctx, tag, height, height+1, 10)
+	candidateLockTx, err := db.BeginTx(ctx, nil)
+	require.NoError(err)
+	require.NoError(cscbrepairlock.AcquireTag(ctx, candidateLockTx, tag))
+	listCtx, cancelList := context.WithTimeout(ctx, 2*time.Second)
+	candidateKeys, err := repository.ListCandidateObjectKeys(listCtx, tag, height, height+1, 10)
+	cancelList()
 	require.NoError(err)
 	require.Equal([]string{dirtyKey}, candidateKeys)
+	require.NoError(candidateLockTx.Rollback(), "read-only discovery must not wait for the placement-writer lock")
 	exactCandidate, err := repository.FindCandidateByObjectKey(ctx, tag, dirtyKey)
 	require.NoError(err)
 	require.Equal(dirtyKey, exactCandidate.OldConsolidatedObjectKey)
@@ -389,6 +396,20 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.NoError(err)
 	require.Equal(manifest.ID, retried.ID)
 	require.Equal(cscbrepair.StateCompleted, retried.State)
+	concurrentExecutionKey := repairSHA256(fmt.Sprintf("repair-concurrent-%d", unique))
+	completedByObject, err := repairer.PrepareObject(
+		ctx,
+		concurrentExecutionKey,
+		tag,
+		height,
+		height+1,
+		1,
+		dirtyKey,
+		nil,
+	)
+	require.NoError(err)
+	require.Equal(manifest.ID, completedByObject.ID)
+	require.Equal(cscbrepair.StateCompleted, completedByObject.State)
 
 	// Exercise the real retirement executor after repair completion. The S3
 	// object deletion, shadow cleanup, retirement manifest, and repair audit

--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -165,9 +165,17 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Equal(uint64(1), promotion.Blocks)
 
 	store := retirement.NewS3ObjectStore(rawS3)
-	repairer := cscbrepair.NewRepairer(cscbrepair.NewPostgresRepository(db), store, bucket)
+	repository := cscbrepair.NewPostgresRepository(db)
+	candidateKeys, err := repository.ListCandidateObjectKeys(ctx, tag, height, height+1, 10)
+	require.NoError(err)
+	require.Equal([]string{dirtyKey}, candidateKeys)
+	exactCandidate, err := repository.FindCandidateByObjectKey(ctx, tag, dirtyKey)
+	require.NoError(err)
+	require.Equal(dirtyKey, exactCandidate.OldConsolidatedObjectKey)
+
+	repairer := cscbrepair.NewRepairer(repository, store, bucket)
 	executionKey := repairSHA256(fmt.Sprintf("repair-main-%d", unique))
-	manifest, err := repairer.PrepareNext(ctx, executionKey, tag, height, height+1, 1, nil)
+	manifest, err := repairer.PrepareObject(ctx, executionKey, tag, height, height+1, 1, dirtyKey, nil)
 	require.NoError(err)
 	require.NotNil(manifest)
 	repairID = manifest.ID
@@ -175,6 +183,9 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Equal(dirtyKey, manifest.OldConsolidatedObjectKey)
 	require.Len(manifest.Blocks, 1)
 	require.Len(manifest.Blocks[0].PayloadSHA256, 64)
+	pendingKeys, err := repository.ListCandidateObjectKeys(ctx, tag, height, height+1, 10)
+	require.NoError(err)
+	require.Equal([]string{dirtyKey}, pendingKeys)
 
 	// The trigger must serialize any reference to the pinned key, even when a
 	// writer changes only object_format to a non-CSCB value. This closes the

--- a/internal/storage/cscbrepair/migration_integration_test.go
+++ b/internal/storage/cscbrepair/migration_integration_test.go
@@ -162,6 +162,36 @@ func requireReferenceIndex(t *testing.T, db *sql.DB, indexName string, column st
 
 func requireIndexPlans(t *testing.T, db *sql.DB) {
 	t.Helper()
+	const candidateListQuery = `
+		WITH overlapping_keys AS (
+			SELECT DISTINCT bm.object_key_main
+			FROM block_metadata bm
+			WHERE bm.tag = $1
+				AND bm.height >= $2
+				AND bm.height < $3
+				AND bm.object_format = $4
+				AND bm.object_key_main IS NOT NULL
+				AND bm.object_key_main <> ''
+				AND NOT EXISTS (
+					SELECT 1
+					FROM cscb_repair_manifest repair
+					WHERE repair.tag = bm.tag
+						AND (
+							repair.old_consolidated_object_key_main = bm.object_key_main
+							OR repair.new_consolidated_object_key_main = bm.object_key_main
+						)
+				)
+		)
+		SELECT bm.object_key_main, MIN(bm.height), MAX(bm.height)
+		FROM block_metadata bm
+		JOIN overlapping_keys candidate ON candidate.object_key_main = bm.object_key_main
+		WHERE bm.tag = $1
+			AND bm.object_format = $4
+			AND bm.object_key_main IS NOT NULL
+			AND bm.object_key_main <> ''
+		GROUP BY bm.object_key_main
+		ORDER BY MAX(bm.height) DESC, bm.object_key_main DESC
+		LIMIT $5`
 	const shadowOnlyCandidateQuery = `
 		SELECT shadow.consolidated_object_key_main, MIN(bm.height), MAX(bm.height)
 		FROM block_consolidation_shadow shadow
@@ -212,6 +242,8 @@ func requireIndexPlans(t *testing.T, db *sql.DB) {
 			AND object_format = $4
 			AND object_key_main IS NOT NULL
 			AND object_key_main <> ''`, "idx_block_metadata_cscb_repair_candidate", uint32(2), uint64(1000), uint64(2000), 1)
+	requireReferenceIndexPlan(t, db, candidateListQuery, "idx_block_metadata_cscb_repair_candidate", uint32(2), uint64(1000), uint64(2000), 1, 10)
+	requireReferenceIndexPlan(t, db, candidateListQuery, "idx_block_metadata_object_key_reference", uint32(2), uint64(1000), uint64(2000), 1, 10)
 	requireReferenceIndexPlan(t, db, shadowOnlyCandidateQuery, "idx_block_consolidation_shadow_tag_height", uint32(2), uint64(1000), uint64(2000), 1)
 	requireReferenceIndexPlan(t, db, shadowOnlyCandidateQuery, "block_metadata_pkey", uint32(2), uint64(1000), uint64(2000), 1)
 }

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -101,7 +101,7 @@ func (r *PostgresRepository) FindPending(
 	return manifest, nil
 }
 
-func (r *PostgresRepository) FindPendingByObjectKey(
+func (r *PostgresRepository) FindByObjectKey(
 	ctx context.Context,
 	tag uint32,
 	objectKey string,
@@ -117,14 +117,13 @@ func (r *PostgresRepository) FindPendingByObjectKey(
 			FROM cscb_repair_manifest
 			WHERE tag = $1
 				AND old_consolidated_object_key_main = $2
-				AND state <> $3
 			LIMIT 1`, manifestColumns)
-	manifest, err := scanManifest(r.db.QueryRowContext(ctx, query, tag, objectKey, StateCompleted))
+	manifest, err := scanManifest(r.db.QueryRowContext(ctx, query, tag, objectKey))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
-		return nil, xerrors.Errorf("failed to find pending CSCB repair for object %q: %w", objectKey, err)
+		return nil, xerrors.Errorf("failed to find CSCB repair manifest for object %q: %w", objectKey, err)
 	}
 	if err := loadManifestBlocks(ctx, r.db, manifest); err != nil {
 		return nil, err
@@ -192,17 +191,8 @@ func (r *PostgresRepository) ListCandidateObjectKeys(
 		return nil, xerrors.New("CSCB repair candidate limit must be positive")
 	}
 
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to begin CSCB repair candidate listing: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	if err := lockRepairTag(ctx, tx, tag); err != nil {
-		return nil, err
-	}
-
 	objectKeys := make([]string, 0, limit)
-	pendingRows, err := tx.QueryContext(ctx, `
+	pendingRows, err := r.db.QueryContext(ctx, `
 		SELECT old_consolidated_object_key_main, start_height, end_height
 		FROM cscb_repair_manifest
 		WHERE tag = $1
@@ -242,7 +232,7 @@ func (r *PostgresRepository) ListCandidateObjectKeys(
 
 	remaining := limit - len(objectKeys)
 	if remaining > 0 {
-		activeRows, err := tx.QueryContext(ctx, `
+		activeRows, err := r.db.QueryContext(ctx, `
 			WITH overlapping_keys AS (
 				SELECT DISTINCT bm.object_key_main
 				FROM block_metadata bm
@@ -311,12 +301,9 @@ func (r *PostgresRepository) ListCandidateObjectKeys(
 	}
 
 	if len(objectKeys) == 0 {
-		if err := requireNoShadowOnlyCandidates(ctx, tx, tag, startHeight, endHeight); err != nil {
+		if err := requireNoShadowOnlyCandidates(ctx, r.db, tag, startHeight, endHeight); err != nil {
 			return nil, err
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, xerrors.Errorf("failed to commit CSCB repair candidate listing: %w", err)
 	}
 	return objectKeys, nil
 }

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -101,6 +101,37 @@ func (r *PostgresRepository) FindPending(
 	return manifest, nil
 }
 
+func (r *PostgresRepository) FindPendingByObjectKey(
+	ctx context.Context,
+	tag uint32,
+	objectKey string,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if objectKey == "" {
+		return nil, xerrors.New("CSCB repair object key is required")
+	}
+	query := fmt.Sprintf(`
+			SELECT %s
+			FROM cscb_repair_manifest
+			WHERE tag = $1
+				AND old_consolidated_object_key_main = $2
+				AND state <> $3
+			LIMIT 1`, manifestColumns)
+	manifest, err := scanManifest(r.db.QueryRowContext(ctx, query, tag, objectKey, StateCompleted))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, xerrors.Errorf("failed to find pending CSCB repair for object %q: %w", objectKey, err)
+	}
+	if err := loadManifestBlocks(ctx, r.db, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
 func (r *PostgresRepository) FindNextCandidate(
 	ctx context.Context,
 	tag uint32,
@@ -128,6 +159,166 @@ func (r *PostgresRepository) FindNextCandidate(
 		return nil, err
 	}
 	return manifest, nil
+}
+
+func (r *PostgresRepository) FindCandidateByObjectKey(
+	ctx context.Context,
+	tag uint32,
+	objectKey string,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if objectKey == "" {
+		return nil, xerrors.New("CSCB repair object key is required")
+	}
+	return loadCandidateByKey(ctx, r.db, tag, objectKey)
+}
+
+func (r *PostgresRepository) ListCandidateObjectKeys(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	limit int,
+) ([]string, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if endHeight <= startHeight {
+		return nil, xerrors.New("valid CSCB repair range is required")
+	}
+	if limit <= 0 {
+		return nil, xerrors.New("CSCB repair candidate limit must be positive")
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin CSCB repair candidate listing: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := lockRepairTag(ctx, tx, tag); err != nil {
+		return nil, err
+	}
+
+	objectKeys := make([]string, 0, limit)
+	pendingRows, err := tx.QueryContext(ctx, `
+		SELECT old_consolidated_object_key_main, start_height, end_height
+		FROM cscb_repair_manifest
+		WHERE tag = $1
+			AND state <> $2
+		ORDER BY end_height DESC, old_consolidated_object_key_main DESC
+		LIMIT $3`, tag, StateCompleted, limit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list pending CSCB repair candidates: %w", err)
+	}
+	for pendingRows.Next() {
+		var objectKey string
+		var candidateStart, candidateEnd uint64
+		if err := pendingRows.Scan(&objectKey, &candidateStart, &candidateEnd); err != nil {
+			_ = pendingRows.Close()
+			return nil, xerrors.Errorf("failed to scan pending CSCB repair candidate: %w", err)
+		}
+		if candidateStart < startHeight || candidateEnd > endHeight {
+			_ = pendingRows.Close()
+			return nil, xerrors.Errorf(
+				"pending CSCB repair object %q exceeds approved range: object=[%d, %d) approved=[%d, %d)",
+				objectKey,
+				candidateStart,
+				candidateEnd,
+				startHeight,
+				endHeight,
+			)
+		}
+		objectKeys = append(objectKeys, objectKey)
+	}
+	if err := pendingRows.Err(); err != nil {
+		_ = pendingRows.Close()
+		return nil, xerrors.Errorf("failed to iterate pending CSCB repair candidates: %w", err)
+	}
+	if err := pendingRows.Close(); err != nil {
+		return nil, xerrors.Errorf("failed to close pending CSCB repair candidates: %w", err)
+	}
+
+	remaining := limit - len(objectKeys)
+	if remaining > 0 {
+		activeRows, err := tx.QueryContext(ctx, `
+			WITH overlapping_keys AS (
+				SELECT DISTINCT bm.object_key_main
+				FROM block_metadata bm
+				WHERE bm.tag = $1
+					AND bm.height >= $2
+					AND bm.height < $3
+					AND bm.object_format = $4
+					AND bm.object_key_main IS NOT NULL
+					AND bm.object_key_main <> ''
+					AND NOT EXISTS (
+						SELECT 1
+						FROM cscb_repair_manifest repair
+						WHERE repair.tag = bm.tag
+							AND (
+								repair.old_consolidated_object_key_main = bm.object_key_main
+								OR repair.new_consolidated_object_key_main = bm.object_key_main
+							)
+					)
+			)
+			SELECT bm.object_key_main, MIN(bm.height), MAX(bm.height)
+			FROM block_metadata bm
+			JOIN overlapping_keys candidate ON candidate.object_key_main = bm.object_key_main
+			WHERE bm.tag = $1
+				AND bm.object_format = $4
+				AND bm.object_key_main IS NOT NULL
+				AND bm.object_key_main <> ''
+			GROUP BY bm.object_key_main
+			ORDER BY MAX(bm.height) DESC, bm.object_key_main DESC
+			LIMIT $5`,
+			tag,
+			startHeight,
+			endHeight,
+			api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			remaining,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to list active CSCB repair candidates: %w", err)
+		}
+		for activeRows.Next() {
+			var objectKey string
+			var minHeight, maxHeight uint64
+			if err := activeRows.Scan(&objectKey, &minHeight, &maxHeight); err != nil {
+				_ = activeRows.Close()
+				return nil, xerrors.Errorf("failed to scan active CSCB repair candidate: %w", err)
+			}
+			if minHeight < startHeight || maxHeight >= endHeight {
+				_ = activeRows.Close()
+				return nil, xerrors.Errorf(
+					"CSCB repair object %q crosses approved range: object=[%d, %d] approved=[%d, %d)",
+					objectKey,
+					minHeight,
+					maxHeight,
+					startHeight,
+					endHeight,
+				)
+			}
+			objectKeys = append(objectKeys, objectKey)
+		}
+		if err := activeRows.Err(); err != nil {
+			_ = activeRows.Close()
+			return nil, xerrors.Errorf("failed to iterate active CSCB repair candidates: %w", err)
+		}
+		if err := activeRows.Close(); err != nil {
+			return nil, xerrors.Errorf("failed to close active CSCB repair candidates: %w", err)
+		}
+	}
+
+	if len(objectKeys) == 0 {
+		if err := requireNoShadowOnlyCandidates(ctx, tx, tag, startHeight, endHeight); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit CSCB repair candidate listing: %w", err)
+	}
+	return objectKeys, nil
 }
 
 func findNextCandidateObject(

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -31,6 +31,22 @@ func NewRepairer(repository Repository, store retirement.ObjectStore, bucket str
 	}
 }
 
+func (r *repairerImpl) ListCandidates(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	limit int,
+) ([]string, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, xerrors.New("CSCB repair candidate limit must be positive")
+	}
+	return r.repository.ListCandidateObjectKeys(ctx, tag, startHeight, endHeight, limit)
+}
+
 func (r *repairerImpl) PrepareNext(
 	ctx context.Context,
 	executionKey string,
@@ -38,6 +54,35 @@ func (r *repairerImpl) PrepareNext(
 	startHeight uint64,
 	endHeight uint64,
 	maxBlocks uint64,
+	progress Progress,
+) (*Manifest, error) {
+	return r.prepare(ctx, executionKey, tag, startHeight, endHeight, maxBlocks, "", progress)
+}
+
+func (r *repairerImpl) PrepareObject(
+	ctx context.Context,
+	executionKey string,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	maxBlocks uint64,
+	objectKey string,
+	progress Progress,
+) (*Manifest, error) {
+	if objectKey == "" {
+		return nil, xerrors.New("CSCB repair object key is required")
+	}
+	return r.prepare(ctx, executionKey, tag, startHeight, endHeight, maxBlocks, objectKey, progress)
+}
+
+func (r *repairerImpl) prepare(
+	ctx context.Context,
+	executionKey string,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	maxBlocks uint64,
+	objectKey string,
 	progress Progress,
 ) (*Manifest, error) {
 	if err := r.validate(); err != nil {
@@ -57,12 +102,24 @@ func (r *repairerImpl) PrepareNext(
 		if bound.Tag != tag {
 			return nil, xerrors.Errorf("bound CSCB repair tag changed: expected=%d actual=%d", tag, bound.Tag)
 		}
+		if objectKey != "" && bound.OldConsolidatedObjectKey != objectKey {
+			return nil, xerrors.Errorf(
+				"bound CSCB repair object changed: expected=%q actual=%q",
+				objectKey,
+				bound.OldConsolidatedObjectKey,
+			)
+		}
 		if err := validateApprovedManifest(bound, startHeight, endHeight, maxBlocks); err != nil {
 			return nil, xerrors.Errorf("bound CSCB repair does not fit the approved request: %w", err)
 		}
 		return r.inspectFencedCandidate(ctx, bound, progress)
 	}
-	pending, err := r.repository.FindPending(ctx, tag)
+	var pending *Manifest
+	if objectKey == "" {
+		pending, err = r.repository.FindPending(ctx, tag)
+	} else {
+		pending, err = r.repository.FindPendingByObjectKey(ctx, tag, objectKey)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -76,11 +133,19 @@ func (r *repairerImpl) PrepareNext(
 		}
 		return r.inspectFencedCandidate(ctx, bound, progress)
 	}
-	candidate, err := r.repository.FindNextCandidate(ctx, tag, startHeight, endHeight)
+	var candidate *Manifest
+	if objectKey == "" {
+		candidate, err = r.repository.FindNextCandidate(ctx, tag, startHeight, endHeight)
+	} else {
+		candidate, err = r.repository.FindCandidateByObjectKey(ctx, tag, objectKey)
+	}
 	if err != nil {
 		return nil, err
 	}
 	if candidate == nil {
+		if objectKey != "" {
+			return nil, xerrors.Errorf("CSCB repair candidate is no longer available: object=%q", objectKey)
+		}
 		return r.repository.BindNoCandidateExecution(ctx, executionKey, tag, startHeight, endHeight)
 	}
 	if err := validateCandidate(candidate, startHeight, endHeight, maxBlocks); err != nil {

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -118,7 +118,7 @@ func (r *repairerImpl) prepare(
 	if objectKey == "" {
 		pending, err = r.repository.FindPending(ctx, tag)
 	} else {
-		pending, err = r.repository.FindPendingByObjectKey(ctx, tag, objectKey)
+		pending, err = r.repository.FindByObjectKey(ctx, tag, objectKey)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -125,6 +125,29 @@ func TestPrepareObjectRejectsExecutionBoundToDifferentObject(t *testing.T) {
 	require.ErrorContains(t, err, "bound CSCB repair object changed")
 }
 
+func TestPrepareObjectReturnsCompletedManifestFromConcurrentWorkflow(t *testing.T) {
+	completed := validRepairCandidate()
+	completed.ID = 42
+	completed.State = StateCompleted
+	repository := &completedObjectRepository{manifest: completed}
+	repairer := NewRepairer(repository, &pendingObjectStore{}, "repair-bucket")
+	key := executionKey("completed-object")
+
+	manifest, err := repairer.PrepareObject(
+		context.Background(),
+		key,
+		completed.Tag,
+		completed.StartHeight,
+		completed.EndHeight,
+		1,
+		completed.OldConsolidatedObjectKey,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Same(t, completed, manifest)
+	require.Equal(t, key, repository.executionKey)
+}
+
 func TestListCandidatesDelegatesExactLimit(t *testing.T) {
 	repository := &candidateListRepository{
 		objectKeys: []string{"consolidated/dirty-b.cscb.zstd", "consolidated/dirty-a.cscb.zstd"},
@@ -332,6 +355,28 @@ type candidateListRepository struct {
 	limit      int
 }
 
+type completedObjectRepository struct {
+	Repository
+	manifest     *Manifest
+	executionKey string
+}
+
+func (r *completedObjectRepository) FindByExecutionKey(context.Context, string) (*Manifest, bool, error) {
+	return nil, false, nil
+}
+
+func (r *completedObjectRepository) FindByObjectKey(context.Context, uint32, string) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+func (r *completedObjectRepository) BindExecutionKey(_ context.Context, executionKey string, repairID int64) (*Manifest, error) {
+	if repairID != r.manifest.ID {
+		return nil, errors.New("unexpected repair id")
+	}
+	r.executionKey = executionKey
+	return r.manifest, nil
+}
+
 func (r *candidateListRepository) ListCandidateObjectKeys(_ context.Context, _ uint32, _ uint64, _ uint64, limit int) ([]string, error) {
 	r.limit = limit
 	return r.objectKeys, nil
@@ -379,7 +424,7 @@ func (r *preparationRepository) FindPending(context.Context, uint32) (*Manifest,
 	return nil, nil
 }
 
-func (r *preparationRepository) FindPendingByObjectKey(_ context.Context, _ uint32, objectKey string) (*Manifest, error) {
+func (r *preparationRepository) FindByObjectKey(_ context.Context, _ uint32, objectKey string) (*Manifest, error) {
 	r.requestedObjectKey = objectKey
 	return nil, nil
 }

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -82,6 +82,61 @@ func TestPrepareNextPersistsFenceBeforeS3InspectionAndRetriesSameManifest(t *tes
 	require.Equal(t, 2, store.listCalls)
 }
 
+func TestPrepareObjectSelectsOnlyAssignedObject(t *testing.T) {
+	inspectionErr := errors.New("S3 inspection stopped")
+	candidate := validRepairCandidate()
+	repository := &preparationRepository{candidate: candidate}
+	store := &preparationObjectStore{repository: repository, listErr: inspectionErr}
+	repairer := NewRepairer(repository, store, "repair-bucket")
+
+	_, err := repairer.PrepareObject(
+		context.Background(),
+		executionKey("assigned-object"),
+		candidate.Tag,
+		candidate.StartHeight,
+		candidate.EndHeight,
+		1,
+		candidate.OldConsolidatedObjectKey,
+		nil,
+	)
+	require.ErrorIs(t, err, inspectionErr)
+	require.Equal(t, candidate.OldConsolidatedObjectKey, repository.requestedObjectKey)
+	require.True(t, repository.fenced)
+	require.True(t, repository.bound)
+}
+
+func TestPrepareObjectRejectsExecutionBoundToDifferentObject(t *testing.T) {
+	bound := validRepairCandidate()
+	bound.ID = 41
+	bound.State = StatePrepared
+	repository := &boundRepairRepository{manifest: bound}
+	repairer := NewRepairer(repository, &pendingObjectStore{}, "repair-bucket")
+
+	_, err := repairer.PrepareObject(
+		context.Background(),
+		executionKey("bound-object"),
+		bound.Tag,
+		bound.StartHeight,
+		bound.EndHeight,
+		1,
+		"consolidated/different.cscb.zstd",
+		nil,
+	)
+	require.ErrorContains(t, err, "bound CSCB repair object changed")
+}
+
+func TestListCandidatesDelegatesExactLimit(t *testing.T) {
+	repository := &candidateListRepository{
+		objectKeys: []string{"consolidated/dirty-b.cscb.zstd", "consolidated/dirty-a.cscb.zstd"},
+	}
+	repairer := NewRepairer(repository, &pendingObjectStore{}, "repair-bucket")
+
+	objectKeys, err := repairer.ListCandidates(context.Background(), 2, 1000, 1200, 2)
+	require.NoError(t, err)
+	require.Equal(t, repository.objectKeys, objectKeys)
+	require.Equal(t, 2, repository.limit)
+}
+
 func TestPrepareNextCompletesAlreadyCleanCSCBWithoutRestore(t *testing.T) {
 	candidate := validRepairCandidate()
 	candidate.Blocks[0].Hash = "clean-hash"
@@ -262,6 +317,26 @@ type pendingRepairRepository struct {
 	pending *Manifest
 }
 
+type boundRepairRepository struct {
+	Repository
+	manifest *Manifest
+}
+
+func (r *boundRepairRepository) FindByExecutionKey(context.Context, string) (*Manifest, bool, error) {
+	return r.manifest, true, nil
+}
+
+type candidateListRepository struct {
+	Repository
+	objectKeys []string
+	limit      int
+}
+
+func (r *candidateListRepository) ListCandidateObjectKeys(_ context.Context, _ uint32, _ uint64, _ uint64, limit int) ([]string, error) {
+	r.limit = limit
+	return r.objectKeys, nil
+}
+
 func (r *pendingRepairRepository) FindPending(context.Context, uint32) (*Manifest, error) {
 	return r.pending, nil
 }
@@ -290,6 +365,7 @@ type preparationRepository struct {
 	inspectionRecorded bool
 	alreadyClean       bool
 	fenceCalls         int
+	requestedObjectKey string
 }
 
 func (r *preparationRepository) FindByExecutionKey(_ context.Context, executionKey string) (*Manifest, bool, error) {
@@ -303,8 +379,21 @@ func (r *preparationRepository) FindPending(context.Context, uint32) (*Manifest,
 	return nil, nil
 }
 
+func (r *preparationRepository) FindPendingByObjectKey(_ context.Context, _ uint32, objectKey string) (*Manifest, error) {
+	r.requestedObjectKey = objectKey
+	return nil, nil
+}
+
 func (r *preparationRepository) FindNextCandidate(context.Context, uint32, uint64, uint64) (*Manifest, error) {
 	return r.candidate, nil
+}
+
+func (r *preparationRepository) FindCandidateByObjectKey(_ context.Context, _ uint32, objectKey string) (*Manifest, error) {
+	r.requestedObjectKey = objectKey
+	if r.candidate != nil && r.candidate.OldConsolidatedObjectKey == objectKey {
+		return r.candidate, nil
+	}
+	return nil, nil
 }
 
 func (r *preparationRepository) FenceCandidate(_ context.Context, manifest *Manifest) (*Manifest, error) {

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -70,7 +70,10 @@ type (
 	Repository interface {
 		FindByExecutionKey(ctx context.Context, executionKey string) (*Manifest, bool, error)
 		FindPending(ctx context.Context, tag uint32) (*Manifest, error)
+		FindPendingByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)
 		FindNextCandidate(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
+		FindCandidateByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)
+		ListCandidateObjectKeys(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit int) ([]string, error)
 		FenceCandidate(ctx context.Context, manifest *Manifest) (*Manifest, error)
 		RecordInspection(ctx context.Context, repairID int64, oldObject ObjectVersion, blocks []Block, alreadyClean bool) (*Manifest, error)
 		BindExecutionKey(ctx context.Context, executionKey string, repairID int64) (*Manifest, error)
@@ -83,7 +86,9 @@ type (
 	}
 
 	Repairer interface {
+		ListCandidates(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit int) ([]string, error)
 		PrepareNext(ctx context.Context, executionKey string, tag uint32, startHeight uint64, endHeight uint64, maxBlocks uint64, progress Progress) (*Manifest, error)
+		PrepareObject(ctx context.Context, executionKey string, tag uint32, startHeight uint64, endHeight uint64, maxBlocks uint64, objectKey string, progress Progress) (*Manifest, error)
 		Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
 		Get(ctx context.Context, repairID int64) (*Manifest, error)
 		VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -70,7 +70,7 @@ type (
 	Repository interface {
 		FindByExecutionKey(ctx context.Context, executionKey string) (*Manifest, bool, error)
 		FindPending(ctx context.Context, tag uint32) (*Manifest, error)
-		FindPendingByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)
+		FindByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)
 		FindNextCandidate(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
 		FindCandidateByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)
 		ListCandidateObjectKeys(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit int) ([]string, error)

--- a/internal/workflow/activity/activity.go
+++ b/internal/workflow/activity/activity.go
@@ -34,8 +34,7 @@ const (
 	ActivityBatchConsolidatorLatestBlock = "activity.batch_consolidator.latest_block"
 	ActivityBatchConsolidatorPlan        = "activity.batch_consolidator.plan"
 	ActivityBatchConsolidatorCursor      = "activity.batch_consolidator.cursor"
-
-	loggerMsg = "activity.request"
+	loggerMsg                            = "activity.request"
 
 	resultTypeTag     = "result_type"
 	resultTypeSuccess = "success"
@@ -43,6 +42,8 @@ const (
 
 	reorgDistanceCheckMetric = "reorg_distance_check"
 )
+
+const ActivityBatchConsolidatorRepairCandidates = "activity.batch_consolidator.repair_candidates"
 
 type baseActivity struct {
 	name       string

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -35,6 +35,7 @@ type (
 		latestBlockActivity baseActivity
 		planActivity        baseActivity
 		cursorActivity      baseActivity
+		candidateActivity   baseActivity
 		config              *config.Config
 		metaStorage         metastorage.MetaStorage
 		blobStorage         blobstorage.BlobStorage
@@ -59,6 +60,7 @@ type (
 		EndHeight          uint64 `validate:"gtfield=StartHeight"`
 		MaxBlocks          uint64 `validate:"required"`
 		RepairExecutionKey string
+		RepairObjectKey    string
 	}
 
 	BatchConsolidatorResponse struct {
@@ -118,6 +120,17 @@ type (
 		Tag    uint32
 		Height uint64
 	}
+
+	BatchConsolidatorRepairCandidatesRequest struct {
+		Tag         uint32
+		StartHeight uint64
+		EndHeight   uint64 `validate:"gtfield=StartHeight"`
+		Limit       int    `validate:"required,gt=0,lte=20"`
+	}
+
+	BatchConsolidatorRepairCandidatesResponse struct {
+		ObjectKeys []string
+	}
 )
 
 func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
@@ -127,6 +140,7 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 		latestBlockActivity: newBaseActivity(ActivityBatchConsolidatorLatestBlock, params.Runtime),
 		planActivity:        newBaseActivity(ActivityBatchConsolidatorPlan, params.Runtime),
 		cursorActivity:      newBaseActivity(ActivityBatchConsolidatorCursor, params.Runtime),
+		candidateActivity:   newBaseActivity(ActivityBatchConsolidatorRepairCandidates, params.Runtime),
 		config:              params.Config,
 		metaStorage:         params.MetaStorage,
 		blobStorage:         params.BlobStorage,
@@ -137,6 +151,7 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 	a.latestBlockActivity.register(a.executeLatestBlock)
 	a.planActivity.register(a.executePlan)
 	a.cursorActivity.register(a.executeCursor)
+	a.candidateActivity.register(a.executeRepairCandidates)
 	return a
 }
 
@@ -170,6 +185,12 @@ func (a *BatchConsolidator) GetPromotionPlan(ctx workflow.Context, request *Batc
 func (a *BatchConsolidator) UpdateAutoConsolidateCursor(ctx workflow.Context, request *BatchConsolidatorCursorRequest) (*BatchConsolidatorCursorResponse, error) {
 	var response BatchConsolidatorCursorResponse
 	err := a.cursorActivity.executeActivity(ctx, request, &response)
+	return &response, err
+}
+
+func (a *BatchConsolidator) GetRepairCandidates(ctx workflow.Context, request *BatchConsolidatorRepairCandidatesRequest) (*BatchConsolidatorRepairCandidatesResponse, error) {
+	var response BatchConsolidatorRepairCandidatesResponse
+	err := a.candidateActivity.executeActivity(ctx, request, &response)
 	return &response, err
 }
 
@@ -242,6 +263,33 @@ func (a *BatchConsolidator) executeCursor(ctx context.Context, request *BatchCon
 	}, nil
 }
 
+func (a *BatchConsolidator) executeRepairCandidates(
+	ctx context.Context,
+	request *BatchConsolidatorRepairCandidatesRequest,
+) (*BatchConsolidatorRepairCandidatesResponse, error) {
+	if err := a.candidateActivity.validateRequest(request); err != nil {
+		return nil, err
+	}
+	if err := a.validateConsolidationEnabled(); err != nil {
+		return nil, err
+	}
+	repairer, err := a.getCSCBRepairer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	objectKeys, err := repairer.ListCandidates(
+		ctx,
+		request.Tag,
+		request.StartHeight,
+		request.EndHeight,
+		request.Limit,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list CSCB repair candidates: %w", err)
+	}
+	return &BatchConsolidatorRepairCandidatesResponse{ObjectKeys: objectKeys}, nil
+}
+
 func (a *BatchConsolidator) execute(ctx context.Context, request *BatchConsolidatorRequest) (*BatchConsolidatorResponse, error) {
 	if err := a.validateRequest(request); err != nil {
 		return nil, err
@@ -287,17 +335,31 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 	progress := func(stage string, completed int, total int, height uint64) {
 		sdkactivity.RecordHeartbeat(ctx, "batch_consolidator.repair."+stage, completed, total, height)
 	}
-	manifest, err := repairer.PrepareNext(
-		ctx,
-		request.RepairExecutionKey,
-		request.Tag,
-		request.StartHeight,
-		request.EndHeight,
-		request.MaxBlocks,
-		progress,
-	)
+	var manifest *cscbrepair.Manifest
+	if request.RepairObjectKey == "" {
+		manifest, err = repairer.PrepareNext(
+			ctx,
+			request.RepairExecutionKey,
+			request.Tag,
+			request.StartHeight,
+			request.EndHeight,
+			request.MaxBlocks,
+			progress,
+		)
+	} else {
+		manifest, err = repairer.PrepareObject(
+			ctx,
+			request.RepairExecutionKey,
+			request.Tag,
+			request.StartHeight,
+			request.EndHeight,
+			request.MaxBlocks,
+			request.RepairObjectKey,
+			progress,
+		)
+	}
 	if err != nil {
-		return nil, xerrors.Errorf("failed to prepare next CSCB repair: %w", err)
+		return nil, xerrors.Errorf("failed to prepare CSCB repair: %w", err)
 	}
 	if manifest == nil {
 		return &BatchConsolidatorResponse{

--- a/internal/workflow/activity/batch_consolidator_repair_test.go
+++ b/internal/workflow/activity/batch_consolidator_repair_test.go
@@ -177,6 +177,46 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRecordsAlreadyCleanOb
 	require.Equal([]string{"prepare"}, fake.calls)
 }
 
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBPreparesAssignedObject() {
+	require := testutil.Require(s.T())
+	oldKey := "consolidated/assigned-dirty.cscb.zstd"
+	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, "")
+	completed.Outcome = cscbrepair.OutcomeAlreadyCleanStorageNeutral
+	fake := &repairActivityFake{prepared: completed}
+	s.batchConsolidator.repairer = fake
+
+	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
+		Mode:               config.ConsolidationModeRepairExistingCSCB,
+		Tag:                2,
+		StartHeight:        900,
+		EndHeight:          1200,
+		MaxBlocks:          100,
+		RepairExecutionKey: testRepairExecutionKey,
+		RepairObjectKey:    oldKey,
+	})
+	require.NoError(err)
+	require.Equal(oldKey, response.OldObjectKey)
+	require.Equal([]string{"prepare_object"}, fake.calls)
+	require.Equal(oldKey, fake.objectKey)
+}
+
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBCandidateListing() {
+	require := testutil.Require(s.T())
+	objectKeys := []string{"consolidated/dirty-b.cscb.zstd", "consolidated/dirty-a.cscb.zstd"}
+	fake := &repairActivityFake{candidateObjectKeys: objectKeys}
+	s.batchConsolidator.repairer = fake
+
+	response, err := s.batchConsolidator.executeRepairCandidates(context.Background(), &BatchConsolidatorRepairCandidatesRequest{
+		Tag:         2,
+		StartHeight: 900,
+		EndHeight:   1200,
+		Limit:       2,
+	})
+	require.NoError(err)
+	require.Equal(objectKeys, response.ObjectKeys)
+	require.Equal(2, fake.candidateLimit)
+}
+
 func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string) *cscbrepair.Manifest {
 	return &cscbrepair.Manifest{
 		ID:                       42,
@@ -201,18 +241,33 @@ func repairActivityManifest(state cscbrepair.State, oldKey string, newKey string
 
 type repairActivityFake struct {
 	cscbrepair.Repairer
-	prepared     *cscbrepair.Manifest
-	restored     *cscbrepair.Manifest
-	verified     *cscbrepair.Manifest
-	completed    *cscbrepair.Manifest
-	calls        []string
-	executionKey string
+	prepared            *cscbrepair.Manifest
+	restored            *cscbrepair.Manifest
+	verified            *cscbrepair.Manifest
+	completed           *cscbrepair.Manifest
+	calls               []string
+	executionKey        string
+	objectKey           string
+	candidateObjectKeys []string
+	candidateLimit      int
 }
 
 func (f *repairActivityFake) PrepareNext(_ context.Context, executionKey string, _ uint32, _ uint64, _ uint64, _ uint64, _ cscbrepair.Progress) (*cscbrepair.Manifest, error) {
 	f.calls = append(f.calls, "prepare")
 	f.executionKey = executionKey
 	return f.prepared, nil
+}
+
+func (f *repairActivityFake) PrepareObject(_ context.Context, executionKey string, _ uint32, _ uint64, _ uint64, _ uint64, objectKey string, _ cscbrepair.Progress) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "prepare_object")
+	f.executionKey = executionKey
+	f.objectKey = objectKey
+	return f.prepared, nil
+}
+
+func (f *repairActivityFake) ListCandidates(_ context.Context, _ uint32, _ uint64, _ uint64, limit int) ([]string, error) {
+	f.candidateLimit = limit
+	return f.candidateObjectKeys, nil
 }
 
 func (f *repairActivityFake) Restore(context.Context, int64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -68,6 +68,8 @@ const (
 	batchConsolidatorAutoCursorVersion             = 1
 	batchConsolidatorAutoParallelismChangeID       = "batch-consolidator-auto-parallelism"
 	batchConsolidatorAutoParallelismVersion        = 1
+	batchConsolidatorRepairParallelismChangeID     = "batch-consolidator-repair-parallelism"
+	batchConsolidatorRepairParallelismVersion      = 1
 	batchConsolidatorPreviousMaxParallelism        = 10
 	batchConsolidatorMaxParallelism                = 20
 	maxUint64                                      = ^uint64(0)
@@ -167,13 +169,32 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 		statsCtx := w.withShadowStatsActivityOptions(ctx, cfg)
 		cursorCtx := w.withCursorActivityOptions(ctx, cfg)
 		if mode.IsRepairExistingCSCB() {
-			if parallelism != 1 {
-				return xerrors.Errorf("repair_existing_cscb requires parallelism=1, got %d", parallelism)
+			repairParallelismVersion := workflow.GetVersion(
+				ctx,
+				batchConsolidatorRepairParallelismChangeID,
+				workflow.DefaultVersion,
+				batchConsolidatorRepairParallelismVersion,
+			)
+			if repairParallelismVersion == workflow.DefaultVersion {
+				if parallelism != 1 {
+					return xerrors.Errorf("legacy repair_existing_cscb execution requires parallelism=1, got %d", parallelism)
+				}
 			}
 			if err := w.validateHistoricalBackfillRange(ctx, logger, tag, request.StartHeight, request.EndHeight, cfg.IrreversibleDistance); err != nil {
 				return err
 			}
-			return w.executeRepairExistingCSCB(
+			if repairParallelismVersion == workflow.DefaultVersion {
+				return w.executeRepairExistingCSCB(
+					ctx,
+					logger,
+					metrics,
+					request,
+					tag,
+					checkpointSize,
+					maxBlocks,
+				)
+			}
+			return w.executeRepairExistingCSCBParallel(
 				ctx,
 				logger,
 				metrics,
@@ -181,6 +202,7 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 				tag,
 				checkpointSize,
 				maxBlocks,
+				parallelism,
 			)
 		}
 		usePersistedShadowStats := workflow.GetVersion(
@@ -539,6 +561,145 @@ func (w *BatchConsolidator) executeRepairExistingCSCB(
 			zap.Bool("rebuilt_cscb", response.ObjectKey != "" && response.ObjectKey != response.OldObjectKey),
 		)
 		repairIteration++
+		if processedBlocks >= checkpointSize {
+			newRequest := *request
+			logger.Info(
+				"CSCB repair checkpoint reached",
+				zap.Uint64("processed_blocks", processedBlocks),
+				zap.Reflect("new_request", newRequest),
+			)
+			return w.continueAsNew(ctx, &newRequest)
+		}
+	}
+}
+
+func (w *BatchConsolidator) executeRepairExistingCSCBParallel(
+	ctx workflow.Context,
+	logger *zap.Logger,
+	metrics client.MetricsHandler,
+	request *BatchConsolidatorRequest,
+	tag uint32,
+	checkpointSize uint64,
+	maxBlocks uint64,
+	parallelism int,
+) error {
+	processedBlocks := uint64(0)
+	repairIteration := uint64(0)
+	for {
+		candidates, err := w.batchConsolidator.GetRepairCandidates(ctx, &activity.BatchConsolidatorRepairCandidatesRequest{
+			Tag:         tag,
+			StartHeight: request.StartHeight,
+			EndHeight:   request.EndHeight,
+			Limit:       parallelism,
+		})
+		if err != nil {
+			return xerrors.Errorf(
+				"failed to list existing CSCB repair candidates in range [%d, %d): %w",
+				request.StartHeight,
+				request.EndHeight,
+				err,
+			)
+		}
+		if len(candidates.ObjectKeys) == 0 {
+			metrics.Counter(batchConsolidatorEmptyBatchCounter).Inc(1)
+			logger.Info("CSCB repair range is complete")
+			return nil
+		}
+		if len(candidates.ObjectKeys) > parallelism {
+			return xerrors.Errorf(
+				"CSCB repair candidate list exceeds parallelism: candidates=%d parallelism=%d",
+				len(candidates.ObjectKeys),
+				parallelism,
+			)
+		}
+
+		pending := make([]batchConsolidatorPendingActivity, 0, len(candidates.ObjectKeys))
+		seen := make(map[string]struct{}, len(candidates.ObjectKeys))
+		for _, objectKey := range candidates.ObjectKeys {
+			if objectKey == "" {
+				return xerrors.New("CSCB repair candidate list contains an empty object key")
+			}
+			if _, ok := seen[objectKey]; ok {
+				return xerrors.Errorf("CSCB repair candidate list contains duplicate object key %q", objectKey)
+			}
+			seen[objectKey] = struct{}{}
+			activityRequest := &activity.BatchConsolidatorRequest{
+				Mode:               config.ConsolidationModeRepairExistingCSCB,
+				Tag:                tag,
+				StartHeight:        request.StartHeight,
+				EndHeight:          request.EndHeight,
+				MaxBlocks:          maxBlocks,
+				RepairExecutionKey: makeRepairExecutionKey(ctx, repairIteration),
+				RepairObjectKey:    objectKey,
+			}
+			pending = append(pending, batchConsolidatorPendingActivity{
+				request: activityRequest,
+				future:  workflow.ExecuteActivity(ctx, activity.ActivityBatchConsolidator, activityRequest),
+			})
+			repairIteration++
+		}
+
+		var firstErr error
+		for _, pendingActivity := range pending {
+			var response activity.BatchConsolidatorResponse
+			if err := pendingActivity.future.Get(ctx, &response); err != nil {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf(
+						"failed to repair existing CSCB object %q: %w",
+						pendingActivity.request.RepairObjectKey,
+						err,
+					)
+				}
+				continue
+			}
+			if response.RepairedObjects != 1 {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf(
+						"repair_existing_cscb returned repaired_objects=%d for object %q",
+						response.RepairedObjects,
+						pendingActivity.request.RepairObjectKey,
+					)
+				}
+				continue
+			}
+			if response.OldObjectKey != pendingActivity.request.RepairObjectKey {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf(
+						"repair_existing_cscb returned unexpected old object: expected=%q actual=%q",
+						pendingActivity.request.RepairObjectKey,
+						response.OldObjectKey,
+					)
+				}
+				continue
+			}
+			if response.ScannedBlocks == 0 {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf(
+						"repair_existing_cscb made no block progress for old object %q",
+						response.OldObjectKey,
+					)
+				}
+				continue
+			}
+
+			processedBlocks += response.ScannedBlocks
+			metrics.Counter(batchConsolidatorObjectCounter).Inc(int64(response.RepairedObjects))
+			metrics.Counter(batchConsolidatorConsolidatedBlockCounter).Inc(int64(response.ConsolidatedBlocks))
+			metrics.Gauge(batchConsolidatorHeightGauge).Update(float64(response.EndHeight - 1))
+			logger.Info(
+				"repaired existing CSCB object",
+				zap.String("old_object_key", response.OldObjectKey),
+				zap.String("new_object_key", response.ObjectKey),
+				zap.Uint64("start_height", response.StartHeight),
+				zap.Uint64("end_height", response.EndHeight),
+				zap.Uint64("blocks", response.ScannedBlocks),
+				zap.Uint64("canonical_blocks", response.ConsolidatedBlocks),
+				zap.Bool("rebuilt_cscb", response.ObjectKey != "" && response.ObjectKey != response.OldObjectKey),
+			)
+		}
+		if firstErr != nil {
+			return firstErr
+		}
 		if processedBlocks >= checkpointSize {
 			newRequest := *request
 			logger.Info(

--- a/internal/workflow/batch_consolidator_repair_test.go
+++ b/internal/workflow/batch_consolidator_repair_test.go
@@ -3,8 +3,12 @@ package workflow
 import (
 	"context"
 	"encoding/hex"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/stretchr/testify/mock"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
@@ -13,6 +17,11 @@ import (
 
 func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBCompletesThenChecksForNextObject() {
 	require := testutil.Require(s.T())
+	s.env.OnGetVersion(
+		batchConsolidatorRepairParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorRepairParallelismVersion,
+	).Return(temporalworkflow.DefaultVersion)
 	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
 	s.mockAutoConsolidateLatestHeight(2000)
 	var requests []*activity.BatchConsolidatorRequest
@@ -63,6 +72,11 @@ func isRepairExecutionKey(value string) bool {
 
 func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBRequiresSerialExecution() {
 	require := testutil.Require(s.T())
+	s.env.OnGetVersion(
+		batchConsolidatorRepairParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorRepairParallelismVersion,
+	).Return(temporalworkflow.DefaultVersion)
 
 	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
 		Mode:        config.ConsolidationModeRepairExistingCSCB,
@@ -73,5 +87,78 @@ func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBRequiresSerialExecuti
 		Parallelism: 2,
 	})
 	require.Error(err)
-	require.Contains(err.Error(), "repair_existing_cscb requires parallelism=1")
+	require.Contains(err.Error(), "legacy repair_existing_cscb execution requires parallelism=1")
+}
+
+func (s *batchConsolidatorTestSuite) TestRepairExistingCSCBProcessesDistinctObjectsInParallel() {
+	require := testutil.Require(s.T())
+	s.env.OnGetVersion(
+		batchConsolidatorRepairParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		batchConsolidatorRepairParallelismVersion,
+	).Return(temporalworkflow.Version(batchConsolidatorRepairParallelismVersion))
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+	s.mockAutoConsolidateLatestHeight(2000)
+
+	objectKeys := []string{
+		"consolidated/dirty-1100-1200.cscb.zstd",
+		"consolidated/dirty-1000-1100.cscb.zstd",
+	}
+	var candidateCalls atomic.Int32
+	s.env.OnActivity(activity.ActivityBatchConsolidatorRepairCandidates, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.BatchConsolidatorRepairCandidatesRequest) (*activity.BatchConsolidatorRepairCandidatesResponse, error) {
+			require.Equal(uint32(2), request.Tag)
+			require.Equal(uint64(1000), request.StartHeight)
+			require.Equal(uint64(1200), request.EndHeight)
+			require.Equal(2, request.Limit)
+			if candidateCalls.Add(1) == 1 {
+				return &activity.BatchConsolidatorRepairCandidatesResponse{ObjectKeys: objectKeys}, nil
+			}
+			return &activity.BatchConsolidatorRepairCandidatesResponse{}, nil
+		}).Twice()
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	var requestsMu sync.Mutex
+	requests := make([]*activity.BatchConsolidatorRequest, 0, len(objectKeys))
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			requestsMu.Lock()
+			requests = append(requests, request)
+			requestsMu.Unlock()
+			current := inFlight.Add(1)
+			for {
+				previous := maxInFlight.Load()
+				if current <= previous || maxInFlight.CompareAndSwap(previous, current) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			inFlight.Add(-1)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight:        1000,
+				EndHeight:          1100,
+				ScannedBlocks:      100,
+				ConsolidatedBlocks: 100,
+				ObjectKey:          request.RepairObjectKey + ".clean",
+				OldObjectKey:       request.RepairObjectKey,
+				RepairedObjects:    1,
+			}, nil
+		}).Twice()
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeRepairExistingCSCB,
+		Tag:         2,
+		StartHeight: 1000,
+		EndHeight:   1200,
+		MaxBlocks:   100,
+		Parallelism: 2,
+	})
+	require.NoError(err)
+	require.Equal(int32(2), maxInFlight.Load())
+	require.Len(requests, 2)
+	require.ElementsMatch(objectKeys, []string{requests[0].RepairObjectKey, requests[1].RepairObjectKey})
+	require.True(isRepairExecutionKey(requests[0].RepairExecutionKey))
+	require.True(isRepairExecutionKey(requests[1].RepairExecutionKey))
+	require.NotEqual(requests[0].RepairExecutionKey, requests[1].RepairExecutionKey)
 }


### PR DESCRIPTION
## Summary
- list distinct preexisting CSCB repair candidates, resuming pending manifests first
- assign one exact CSCB object key to each repair activity and run up to `Parallelism` activities concurrently
- preserve replay compatibility for existing serial repair workflows with a Temporal version marker

Auto-consolidation remains stopped; this only drains the fixed backlog of previously created dirty CSCBs. Each object still uses the existing durable fence, restore, rebuild, verify, promote, and completion state machine.

## Safety
- candidate discovery is read-only and does not acquire the tag-wide placement-writer lock
- exact-key preparation rejects workflow/activity key drift and reuses manifests in any state, including work completed by another execution
- range and `MaxBlocks` validation remains fail-closed per object
- duplicate or empty candidate keys fail the workflow before dispatch
- all scheduled activities are awaited before an error or checkpoint is returned

## Verification
- `TEST_TYPE=unit go test ./internal/storage/cscbrepair ./internal/workflow/activity ./internal/workflow -count=1`
- `TEST_TYPE=unit go test -race ./internal/workflow -run TestBatchConsolidatorWorkflowTestSuite/TestRepairExistingCSCBProcessesDistinctObjectsInParallel -count=1`
- PostgreSQL 13 + versioned LocalStack S3: `TestIntegrationCSCBRepairFullLifecycle`, including discovery while the tag writer lock is held and completed-manifest reuse
- PostgreSQL 13: `TestIntegrationCSCBRepairReferenceIndexMigration`, including the full candidate-list plan
- focused `go vet`

Linear: https://linear.app/cipherowl/issue/INF-1133