### PR TITLE
fix(INF-1133): tolerate identical single-block versions

### DIFF
--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -104,6 +104,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	})
 	require.NoError(err)
 	defer cleanupRepairBucket(t, rawS3, bucket)
+	store := retirement.NewS3ObjectStore(rawS3)
 
 	block := &api.Block{
 		Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
@@ -122,6 +123,23 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	}
 	singleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
 	require.NoError(err)
+	duplicateSingleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
+	require.NoError(err)
+	require.Equal(singleBlockKey, duplicateSingleBlockKey)
+	singleBlockTopology, err := store.ListObjectVersions(ctx, bucket, singleBlockKey)
+	require.NoError(err)
+	require.Len(singleBlockTopology.Versions, 2)
+	require.Empty(singleBlockTopology.DeleteMarkers)
+	var currentSingleBlockVersionID, historicalSingleBlockVersionID string
+	for _, version := range singleBlockTopology.Versions {
+		if version.IsLatest {
+			currentSingleBlockVersionID = version.VersionID
+		} else {
+			historicalSingleBlockVersionID = version.VersionID
+		}
+	}
+	require.NotEmpty(currentSingleBlockVersionID)
+	require.NotEmpty(historicalSingleBlockVersionID)
 	block.Metadata.ObjectKeyMain = singleBlockKey
 	require.NoError(meta.PersistBlockMetas(ctx, true, []*api.BlockMetadata{block.Metadata}, nil))
 
@@ -165,7 +183,6 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.NoError(err)
 	require.Equal(uint64(1), promotion.Blocks)
 
-	store := retirement.NewS3ObjectStore(rawS3)
 	repository := cscbrepair.NewPostgresRepository(db)
 	candidateLockTx, err := db.BeginTx(ctx, nil)
 	require.NoError(err)
@@ -189,6 +206,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Equal(cscbrepair.StatePrepared, manifest.State)
 	require.Equal(dirtyKey, manifest.OldConsolidatedObjectKey)
 	require.Len(manifest.Blocks, 1)
+	require.Equal(currentSingleBlockVersionID, manifest.Blocks[0].SingleBlockObjectVersion.VersionID)
 	require.Len(manifest.Blocks[0].PayloadSHA256, 64)
 	pendingKeys, err := repository.ListCandidateObjectKeys(ctx, tag, height, height+1, 10)
 	require.NoError(err)
@@ -372,9 +390,19 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	})
 	require.NoError(err)
 	require.False(rawClean.HasStoragePlacement)
-	singleBlockTopology, err := store.ListObjectVersions(ctx, bucket, singleBlockKey)
+	singleBlockTopology, err = store.ListObjectVersions(ctx, bucket, singleBlockKey)
+	require.NoError(err)
+	require.Len(singleBlockTopology.Versions, 2)
+	_, err = rawS3.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket:    aws.String(bucket),
+		Key:       aws.String(singleBlockKey),
+		VersionId: aws.String(historicalSingleBlockVersionID),
+	})
+	require.NoError(err)
+	singleBlockTopology, err = store.ListObjectVersions(ctx, bucket, singleBlockKey)
 	require.NoError(err)
 	require.Len(singleBlockTopology.Versions, 1)
+	require.Equal(currentSingleBlockVersionID, singleBlockTopology.Versions[0].VersionID)
 
 	activeClean, err := meta.GetBlockByHeight(ctx, tag, height)
 	require.NoError(err)

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -188,7 +188,7 @@ func (r *repairerImpl) inspectFencedCandidate(
 		if objectKeySHA256(block.SingleBlockObjectKey) != block.SingleBlockObjectKeySHA256 {
 			return nil, xerrors.Errorf("single-block object key audit digest changed at height %d", block.Height)
 		}
-		singleVersion, err := r.inspectExactObjectVersion(ctx, block.SingleBlockObjectKey)
+		singleVersion, err := r.inspectSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to pin single-block object at height %d: %w", block.Height, err)
 		}
@@ -237,7 +237,7 @@ func (r *repairerImpl) Restore(ctx context.Context, repairID int64, progress Pro
 	}
 	for i := range manifest.Blocks {
 		block := &manifest.Blocks[i]
-		if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+		if err := r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
 			return nil, xerrors.Errorf("single-block object changed before restore at height %d: %w", block.Height, err)
 		}
 		reportProgress(progress, "restore_object_revalidated", i+1, len(manifest.Blocks), block.Height)
@@ -283,7 +283,7 @@ func (r *repairerImpl) VerifyRebuilt(ctx context.Context, repairID int64, progre
 	verifiedCanonical := 0
 	for i := range manifest.Blocks {
 		block := &manifest.Blocks[i]
-		if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+		if err := r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
 			return nil, xerrors.Errorf("single-block object changed during repair at height %d: %w", block.Height, err)
 		}
 		payload := makePayloadCandidate(manifest, block, newObjectKey, newVersion)
@@ -358,7 +358,7 @@ func (r *repairerImpl) Complete(ctx context.Context, repairID int64, progress Pr
 	verifier := retirement.NewPinnedPayloadVerifier(r.store)
 	for i := range manifest.Blocks {
 		block := &manifest.Blocks[i]
-		if err := r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+		if err := r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
 			return nil, xerrors.Errorf("single-block object changed before completion at height %d: %w", block.Height, err)
 		}
 		payload := makePayloadCandidate(manifest, block, manifest.NewConsolidatedObjectKey, manifest.NewConsolidatedObjectVersion)
@@ -470,12 +470,126 @@ func (r *repairerImpl) inspectExactObjectVersion(ctx context.Context, key string
 	return result, nil
 }
 
+func (r *repairerImpl) inspectSingleBlockObjectVersion(ctx context.Context, key string) (ObjectVersion, error) {
+	topology, err := r.store.ListObjectVersions(ctx, r.bucket, key)
+	if err != nil {
+		return ObjectVersion{}, err
+	}
+	current, err := currentSingleBlockObjectVersion(topology)
+	if err != nil {
+		return ObjectVersion{}, xerrors.Errorf("unsafe single-block object topology: key=%q: %w", key, err)
+	}
+	if len(topology.Versions) == 1 {
+		return current, nil
+	}
+
+	// Retries historically created redundant single-block versions. Verify every
+	// immutable version byte-for-byte before pinning the current one.
+	currentPayload, err := r.store.ReadObjectVersion(ctx, r.bucket, key, current.VersionID)
+	if err != nil {
+		return ObjectVersion{}, xerrors.Errorf("failed to read current single-block object version %q: %w", current.VersionID, err)
+	}
+	if uint64(len(currentPayload)) != current.Bytes {
+		return ObjectVersion{}, xerrors.Errorf(
+			"current single-block object version size changed: version=%q expected=%d actual=%d",
+			current.VersionID,
+			current.Bytes,
+			len(currentPayload),
+		)
+	}
+	currentDigest := sha256.Sum256(currentPayload)
+	for _, version := range topology.Versions {
+		if version.VersionID == current.VersionID {
+			continue
+		}
+		payload, err := r.store.ReadObjectVersion(ctx, r.bucket, key, version.VersionID)
+		if err != nil {
+			return ObjectVersion{}, xerrors.Errorf("failed to read historical single-block object version %q: %w", version.VersionID, err)
+		}
+		if uint64(len(payload)) != current.Bytes {
+			return ObjectVersion{}, xerrors.Errorf(
+				"historical single-block object version size changed: version=%q expected=%d actual=%d",
+				version.VersionID,
+				current.Bytes,
+				len(payload),
+			)
+		}
+		if sha256.Sum256(payload) != currentDigest {
+			return ObjectVersion{}, xerrors.Errorf(
+				"single-block object versions contain different payloads: current=%q historical=%q",
+				current.VersionID,
+				version.VersionID,
+			)
+		}
+	}
+	return current, nil
+}
+
 func (r *repairerImpl) requirePinnedObjectVersion(ctx context.Context, key string, expected ObjectVersion) error {
 	topology, err := r.store.ListObjectVersions(ctx, r.bucket, key)
 	if err != nil {
 		return err
 	}
 	return requireExactTopology(topology, expected)
+}
+
+func (r *repairerImpl) requirePinnedSingleBlockObjectVersion(ctx context.Context, key string, expected ObjectVersion) error {
+	topology, err := r.store.ListObjectVersions(ctx, r.bucket, key)
+	if err != nil {
+		return err
+	}
+	current, err := currentSingleBlockObjectVersion(topology)
+	if err != nil {
+		return err
+	}
+	if current != expected {
+		return xerrors.Errorf(
+			"pinned single-block object current version changed: version=%q etag=%q bytes=%d",
+			current.VersionID,
+			current.ETag,
+			current.Bytes,
+		)
+	}
+	return nil
+}
+
+func currentSingleBlockObjectVersion(topology retirement.ObjectVersionTopology) (ObjectVersion, error) {
+	if len(topology.Versions) == 0 || len(topology.DeleteMarkers) != 0 {
+		return ObjectVersion{}, xerrors.Errorf(
+			"expected at least one data version and zero delete markers, got versions=%d delete_markers=%d",
+			len(topology.Versions),
+			len(topology.DeleteMarkers),
+		)
+	}
+
+	var current ObjectVersion
+	currentFound := false
+	for _, version := range topology.Versions {
+		candidate := ObjectVersion{VersionID: version.VersionID, ETag: version.ETag, Bytes: version.Bytes}
+		if !immutableVersionID(candidate.VersionID) || candidate.ETag == "" || candidate.Bytes == 0 {
+			return ObjectVersion{}, xerrors.Errorf("single-block object version is not immutable and complete: version=%q", candidate.VersionID)
+		}
+		if version.IsLatest {
+			if currentFound {
+				return ObjectVersion{}, xerrors.New("single-block object has multiple latest data versions")
+			}
+			current = candidate
+			currentFound = true
+		}
+	}
+	if !currentFound {
+		return ObjectVersion{}, xerrors.New("single-block object has no latest data version")
+	}
+	for _, version := range topology.Versions {
+		if version.ETag != current.ETag || version.Bytes != current.Bytes {
+			return ObjectVersion{}, xerrors.Errorf(
+				"single-block object versions have different metadata: current=%q version=%q",
+				current.VersionID,
+				version.VersionID,
+			)
+		}
+	}
+	return current, nil
 }
 
 func requireExactTopology(topology retirement.ObjectVersionTopology, expected ObjectVersion) error {

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	completedOutcome    = "old_consolidated_object_retained_unreferenced"
-	alreadyCleanOutcome = OutcomeAlreadyCleanStorageNeutral
+	completedOutcome                = "old_consolidated_object_retained_unreferenced"
+	alreadyCleanOutcome             = OutcomeAlreadyCleanStorageNeutral
+	maxSingleBlockVersionsToInspect = 10
 )
 
 type repairerImpl struct {
@@ -481,6 +482,14 @@ func (r *repairerImpl) inspectSingleBlockObjectVersion(ctx context.Context, key 
 	}
 	if len(topology.Versions) == 1 {
 		return current, nil
+	}
+	if len(topology.Versions) > maxSingleBlockVersionsToInspect {
+		return ObjectVersion{}, xerrors.Errorf(
+			"too many single-block object versions to safely inspect: key=%q count=%d max=%d",
+			key,
+			len(topology.Versions),
+			maxSingleBlockVersionsToInspect,
+		)
 	}
 
 	// Retries historically created redundant single-block versions. Verify every

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -336,6 +336,83 @@ func TestRequirePinnedSingleBlockObjectVersionAllowsHistoricalDuplicateRemoval(t
 	require.NoError(t, repairer.requirePinnedSingleBlockObjectVersion(context.Background(), "single/1000.zstd", pinned))
 }
 
+func TestRepairPhasesRejectSingleBlockTopologyDriftBeforeMutation(t *testing.T) {
+	phases := []struct {
+		name   string
+		state  State
+		invoke func(Repairer, int64) (*Manifest, error)
+	}{
+		{
+			name:  "restore",
+			state: StatePrepared,
+			invoke: func(repairer Repairer, repairID int64) (*Manifest, error) {
+				return repairer.Restore(context.Background(), repairID, nil)
+			},
+		},
+		{
+			name:  "verify rebuilt",
+			state: StateRestored,
+			invoke: func(repairer Repairer, repairID int64) (*Manifest, error) {
+				return repairer.VerifyRebuilt(context.Background(), repairID, nil)
+			},
+		},
+		{
+			name:  "complete",
+			state: StateVerified,
+			invoke: func(repairer Repairer, repairID int64) (*Manifest, error) {
+				return repairer.Complete(context.Background(), repairID, nil)
+			},
+		},
+	}
+	drifts := []struct {
+		name     string
+		topology func(ObjectVersion) retirement.ObjectVersionTopology
+	}{
+		{
+			name: "new latest version",
+			topology: func(pinned ObjectVersion) retirement.ObjectVersionTopology {
+				return retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+					{VersionID: "new-version", ETag: pinned.ETag, Bytes: pinned.Bytes, IsLatest: true},
+					objectTopologyVersion(pinned),
+				}}
+			},
+		},
+		{
+			name: "delete marker",
+			topology: func(pinned ObjectVersion) retirement.ObjectVersionTopology {
+				return retirement.ObjectVersionTopology{
+					Versions:      []retirement.ObjectVersion{objectTopologyVersion(pinned)},
+					DeleteMarkers: []retirement.ObjectDeleteMarker{{VersionID: "delete-marker", IsLatest: true}},
+				}
+			},
+		},
+	}
+
+	for _, phase := range phases {
+		for _, drift := range drifts {
+			t.Run(phase.name+"/"+drift.name, func(t *testing.T) {
+				manifest := phaseBoundaryManifest(t, phase.state)
+				repository := &phaseBoundaryRepository{manifest: manifest}
+				store := &completionObjectStore{topologies: map[string]retirement.ObjectVersionTopology{
+					manifest.OldConsolidatedObjectKey: {
+						Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.OldConsolidatedObjectVersion)},
+					},
+					manifest.NewConsolidatedObjectKey: {
+						Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.NewConsolidatedObjectVersion)},
+					},
+					manifest.Blocks[0].SingleBlockObjectKey: drift.topology(manifest.Blocks[0].SingleBlockObjectVersion),
+				}}
+
+				_, err := phase.invoke(NewRepairer(repository, store, "repair-bucket"), manifest.ID)
+				require.ErrorContains(t, err, "single-block object changed")
+				require.False(t, repository.restoreCalled)
+				require.False(t, repository.recordVerifiedCalled)
+				require.False(t, repository.completeCalled)
+			})
+		}
+	}
+}
+
 func TestCompleteRejectsRetainedObjectTopologyDrift(t *testing.T) {
 	manifest := completionManifest(t)
 	repository := &completionRepository{manifest: manifest}
@@ -699,6 +776,37 @@ type completionRepository struct {
 	committed      bool
 }
 
+type phaseBoundaryRepository struct {
+	Repository
+	manifest             *Manifest
+	restoreCalled        bool
+	recordVerifiedCalled bool
+	completeCalled       bool
+}
+
+func (r *phaseBoundaryRepository) Get(context.Context, int64) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+func (r *phaseBoundaryRepository) GetRebuilt(context.Context, int64) (*Manifest, error) {
+	return r.manifest, nil
+}
+
+func (r *phaseBoundaryRepository) RestoreToSingleBlock(context.Context, int64) (*Manifest, error) {
+	r.restoreCalled = true
+	return r.manifest, nil
+}
+
+func (r *phaseBoundaryRepository) RecordVerified(context.Context, int64, string, ObjectVersion) (*Manifest, error) {
+	r.recordVerifiedCalled = true
+	return r.manifest, nil
+}
+
+func (r *phaseBoundaryRepository) CompleteRetainingOldObject(context.Context, int64, string) (*Manifest, error) {
+	r.completeCalled = true
+	return r.manifest, nil
+}
+
 func (r *completionRepository) Get(context.Context, int64) (*Manifest, error) {
 	return r.manifest, nil
 }
@@ -769,6 +877,19 @@ func completionManifest(t *testing.T) *Manifest {
 		TotalBlockCount:              1,
 		Blocks:                       []Block{block},
 	}
+}
+
+func phaseBoundaryManifest(t *testing.T, state State) *Manifest {
+	t.Helper()
+	manifest := completionManifest(t)
+	manifest.State = state
+	manifest.CanonicalBlockCount = 1
+	manifest.NewConsolidatedObjectKey = "consolidated/clean.cscb.zstd"
+	manifest.NewConsolidatedObjectVersion = ObjectVersion{VersionID: "new-version", ETag: "new-etag", Bytes: 300}
+	manifest.Blocks[0].Canonical = true
+	manifest.Blocks[0].ActiveObjectKey = manifest.NewConsolidatedObjectKey
+	manifest.Blocks[0].NewConsolidatedObjectKey = manifest.NewConsolidatedObjectKey
+	return manifest
 }
 
 func completionSingleBlockPayload(t *testing.T, block Block) []byte {

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"hash/crc32"
 	"testing"
 	"time"
@@ -261,6 +262,26 @@ func TestInspectSingleBlockObjectVersionDoesNotReadSingleVersionTwice(t *testing
 	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
 	require.NoError(t, err)
 	require.Equal(t, "current-version", version.VersionID)
+	require.Empty(t, store.readVersionIDs)
+}
+
+func TestInspectSingleBlockObjectVersionRejectsTooManyVersionsBeforeReading(t *testing.T) {
+	versions := make([]retirement.ObjectVersion, maxSingleBlockVersionsToInspect+1)
+	for i := range versions {
+		versions[i] = retirement.ObjectVersion{
+			VersionID: fmt.Sprintf("version-%d", i),
+			ETag:      "same-etag",
+			Bytes:     4,
+			IsLatest:  i == 0,
+		}
+	}
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: versions},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	require.ErrorContains(t, err, "too many single-block object versions to safely inspect")
 	require.Empty(t, store.readVersionIDs)
 }
 

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -195,7 +195,10 @@ func TestPrepareNextCompletesAlreadyCleanCSCBWithoutRestore(t *testing.T) {
 				Versions: []retirement.ObjectVersion{{VersionID: "clean-cscb-version", ETag: "clean-cscb-etag", Bytes: uint64(len(cscbObject)), IsLatest: true}},
 			},
 			candidate.Blocks[0].SingleBlockObjectKey: {
-				Versions: []retirement.ObjectVersion{{VersionID: "single-version", ETag: "single-etag", Bytes: uint64(len(singleObject)), IsLatest: true}},
+				Versions: []retirement.ObjectVersion{
+					{VersionID: "single-current-version", ETag: "single-etag", Bytes: uint64(len(singleObject)), IsLatest: true},
+					{VersionID: "single-historical-version", ETag: "single-etag", Bytes: uint64(len(singleObject))},
+				},
 			},
 		},
 		objects: map[string][]byte{
@@ -221,6 +224,116 @@ func TestPrepareNextCompletesAlreadyCleanCSCBWithoutRestore(t *testing.T) {
 	require.Nil(t, manifest.RestoredAt)
 	require.True(t, repository.inspectionRecorded)
 	require.True(t, repository.alreadyClean)
+}
+
+func TestInspectSingleBlockObjectVersionAllowsIdenticalDuplicateVersions(t *testing.T) {
+	payload := []byte("identical single-block payload")
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+			{VersionID: "current-version", ETag: "same-etag", Bytes: uint64(len(payload)), IsLatest: true},
+			{VersionID: "historical-version", ETag: "same-etag", Bytes: uint64(len(payload))},
+		}},
+		objects: map[string][]byte{
+			"current-version":    payload,
+			"historical-version": append([]byte(nil), payload...),
+		},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	require.NoError(t, err)
+	require.Equal(t, ObjectVersion{
+		VersionID: "current-version",
+		ETag:      "same-etag",
+		Bytes:     uint64(len(payload)),
+	}, version)
+	require.Equal(t, []string{"current-version", "historical-version"}, store.readVersionIDs)
+}
+
+func TestInspectSingleBlockObjectVersionDoesNotReadSingleVersionTwice(t *testing.T) {
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+			{VersionID: "current-version", ETag: "current-etag", Bytes: 4, IsLatest: true},
+		}},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	require.NoError(t, err)
+	require.Equal(t, "current-version", version.VersionID)
+	require.Empty(t, store.readVersionIDs)
+}
+
+func TestInspectSingleBlockObjectVersionRejectsDifferentDuplicatePayloads(t *testing.T) {
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+			{VersionID: "current-version", ETag: "same-etag", Bytes: 4, IsLatest: true},
+			{VersionID: "historical-version", ETag: "same-etag", Bytes: 4},
+		}},
+		objects: map[string][]byte{
+			"current-version":    []byte("same"),
+			"historical-version": []byte("diff"),
+		},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	require.ErrorContains(t, err, "versions contain different payloads")
+}
+
+func TestInspectSingleBlockObjectVersionRejectsDifferentDuplicateMetadata(t *testing.T) {
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+			{VersionID: "current-version", ETag: "current-etag", Bytes: 4, IsLatest: true},
+			{VersionID: "historical-version", ETag: "historical-etag", Bytes: 4},
+		}},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	require.ErrorContains(t, err, "versions have different metadata")
+	require.Empty(t, store.readVersionIDs)
+}
+
+func TestInspectSingleBlockObjectVersionRejectsDeleteMarker(t *testing.T) {
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{
+			Versions: []retirement.ObjectVersion{
+				{VersionID: "current-version", ETag: "same-etag", Bytes: 4, IsLatest: true},
+			},
+			DeleteMarkers: []retirement.ObjectDeleteMarker{{VersionID: "delete-marker"}},
+		},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	require.ErrorContains(t, err, "zero delete markers")
+}
+
+func TestRequirePinnedSingleBlockObjectVersionRejectsNewLatestVersion(t *testing.T) {
+	pinned := ObjectVersion{VersionID: "pinned-version", ETag: "same-etag", Bytes: 4}
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+			{VersionID: "new-version", ETag: "same-etag", Bytes: 4, IsLatest: true},
+			{VersionID: pinned.VersionID, ETag: pinned.ETag, Bytes: pinned.Bytes},
+		}},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	err := repairer.requirePinnedSingleBlockObjectVersion(context.Background(), "single/1000.zstd", pinned)
+	require.ErrorContains(t, err, "current version changed")
+}
+
+func TestRequirePinnedSingleBlockObjectVersionAllowsHistoricalDuplicateRemoval(t *testing.T) {
+	pinned := ObjectVersion{VersionID: "pinned-version", ETag: "same-etag", Bytes: 4}
+	store := &versionedObjectStore{
+		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
+			{VersionID: pinned.VersionID, ETag: pinned.ETag, Bytes: pinned.Bytes, IsLatest: true},
+		}},
+	}
+	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
+
+	require.NoError(t, repairer.requirePinnedSingleBlockObjectVersion(context.Background(), "single/1000.zstd", pinned))
 }
 
 func TestCompleteRejectsRetainedObjectTopologyDrift(t *testing.T) {
@@ -399,6 +512,35 @@ func executionKey(seed string) string {
 }
 
 type pendingObjectStore struct{ retirement.ObjectStore }
+
+type versionedObjectStore struct {
+	retirement.ObjectStore
+	topology       retirement.ObjectVersionTopology
+	objects        map[string][]byte
+	readVersionIDs []string
+}
+
+func (s *versionedObjectStore) ListObjectVersions(
+	context.Context,
+	string,
+	string,
+) (retirement.ObjectVersionTopology, error) {
+	return s.topology, nil
+}
+
+func (s *versionedObjectStore) ReadObjectVersion(
+	_ context.Context,
+	_ string,
+	_ string,
+	versionID string,
+) ([]byte, error) {
+	s.readVersionIDs = append(s.readVersionIDs, versionID)
+	payload, ok := s.objects[versionID]
+	if !ok {
+		return nil, errors.New("object version not found")
+	}
+	return append([]byte(nil), payload...), nil
+}
 
 type preparationRepository struct {
 	Repository


### PR DESCRIPTION
## Summary

- allow CSCB repair to accept redundant single-block S3 versions only when every immutable version is byte-identical and topology is otherwise safe
- pin the current/latest version and revalidate it through restore, verify, and completion
- keep old/new CSCB topology strict and leave single-block retirement semantics unchanged

## Production evidence

The Solana repair workflow for `[432672000,432772000)` completed 79/80 objects and failed on height `432697689`. Its single-block key has two versions with identical ETag, size, checksum, parsed identity, and compressed SHA-256. A bounded audit found 92 such keys at consecutive heights `432697689..432697780`, consistent with one retried upload.

This change does not delete redundant versions. Retirement continues to fail closed when more than one version remains.

## Verification

- `go test ./internal/storage/cscbrepair ./internal/storage/retirement`
- `make test`
- Docker-backed `TestIntegrationCSCBRepairFullLifecycle` with two identical S3 versions
- `git diff --check`

Linear: https://linear.app/cipherowl/issue/INF-1133