### PR TITLE
fix(INF-1133): compare semantic single-block versions

### DIFF
--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -123,23 +123,28 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	}
 	singleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
 	require.NoError(err)
-	duplicateSingleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
+	semanticDuplicate := proto.Clone(block).(*api.Block)
+	semanticDuplicate.GetSolana().Header = []byte("{\n  \"transactions\": [\"repair\"],\n  \"slot\": 9500000000\n}")
+	require.JSONEq(string(block.GetSolana().Header), string(semanticDuplicate.GetSolana().Header))
+	duplicateSingleBlockKey, err := singleBlockUploader.Upload(ctx, semanticDuplicate, api.Compression_GZIP)
 	require.NoError(err)
 	require.Equal(singleBlockKey, duplicateSingleBlockKey)
 	singleBlockTopology, err := store.ListObjectVersions(ctx, bucket, singleBlockKey)
 	require.NoError(err)
 	require.Len(singleBlockTopology.Versions, 2)
 	require.Empty(singleBlockTopology.DeleteMarkers)
-	var currentSingleBlockVersionID, historicalSingleBlockVersionID string
+	var currentSingleBlockVersion, historicalSingleBlockVersion retirement.ObjectVersion
 	for _, version := range singleBlockTopology.Versions {
 		if version.IsLatest {
-			currentSingleBlockVersionID = version.VersionID
+			currentSingleBlockVersion = version
 		} else {
-			historicalSingleBlockVersionID = version.VersionID
+			historicalSingleBlockVersion = version
 		}
 	}
-	require.NotEmpty(currentSingleBlockVersionID)
-	require.NotEmpty(historicalSingleBlockVersionID)
+	require.NotEmpty(currentSingleBlockVersion.VersionID)
+	require.NotEmpty(historicalSingleBlockVersion.VersionID)
+	require.NotEqual(currentSingleBlockVersion.ETag, historicalSingleBlockVersion.ETag)
+	require.NotEqual(currentSingleBlockVersion.Bytes, historicalSingleBlockVersion.Bytes)
 	block.Metadata.ObjectKeyMain = singleBlockKey
 	require.NoError(meta.PersistBlockMetas(ctx, true, []*api.BlockMetadata{block.Metadata}, nil))
 
@@ -206,7 +211,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Equal(cscbrepair.StatePrepared, manifest.State)
 	require.Equal(dirtyKey, manifest.OldConsolidatedObjectKey)
 	require.Len(manifest.Blocks, 1)
-	require.Equal(currentSingleBlockVersionID, manifest.Blocks[0].SingleBlockObjectVersion.VersionID)
+	require.Equal(currentSingleBlockVersion.VersionID, manifest.Blocks[0].SingleBlockObjectVersion.VersionID)
 	require.Len(manifest.Blocks[0].PayloadSHA256, 64)
 	pendingKeys, err := repository.ListCandidateObjectKeys(ctx, tag, height, height+1, 10)
 	require.NoError(err)
@@ -294,7 +299,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.Zero(activeSingleBlock.ByteLength)
 	restoredBlock, err := blob.Download(ctx, activeSingleBlock)
 	require.NoError(err)
-	require.True(proto.Equal(storageutils.CloneBlockWithoutStoragePlacement(block), storageutils.CloneBlockWithoutStoragePlacement(restoredBlock)))
+	require.True(proto.Equal(storageutils.CloneBlockWithoutStoragePlacement(semanticDuplicate), storageutils.CloneBlockWithoutStoragePlacement(restoredBlock)))
 	_, err = db.ExecContext(ctx, `UPDATE block_metadata SET object_key_main = $2 WHERE id = $1`, blockMetadataID, dirtyKey)
 	require.ErrorContains(err, "cannot reference a pinned old CSCB object")
 	_, err = db.ExecContext(ctx, `
@@ -396,13 +401,13 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	_, err = rawS3.DeleteObject(ctx, &awss3.DeleteObjectInput{
 		Bucket:    aws.String(bucket),
 		Key:       aws.String(singleBlockKey),
-		VersionId: aws.String(historicalSingleBlockVersionID),
+		VersionId: aws.String(historicalSingleBlockVersion.VersionID),
 	})
 	require.NoError(err)
 	singleBlockTopology, err = store.ListObjectVersions(ctx, bucket, singleBlockKey)
 	require.NoError(err)
 	require.Len(singleBlockTopology.Versions, 1)
-	require.Equal(currentSingleBlockVersionID, singleBlockTopology.Versions[0].VersionID)
+	require.Equal(currentSingleBlockVersion.VersionID, singleBlockTopology.Versions[0].VersionID)
 
 	activeClean, err := meta.GetBlockByHeight(ctx, tag, height)
 	require.NoError(err)
@@ -413,7 +418,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	// CSCB neutrality is asserted independently above.
 	require.True(storageutils.HasBlockStoragePlacement(readClean))
 	require.True(proto.Equal(
-		storageutils.CloneBlockWithoutStoragePlacement(block),
+		storageutils.CloneBlockWithoutStoragePlacement(semanticDuplicate),
 		storageutils.CloneBlockWithoutStoragePlacement(readClean),
 	))
 
@@ -512,7 +517,7 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	readAfterRetirement, err := blob.Download(ctx, activeAfterRetirement)
 	require.NoError(err)
 	require.True(proto.Equal(
-		storageutils.CloneBlockWithoutStoragePlacement(block),
+		storageutils.CloneBlockWithoutStoragePlacement(semanticDuplicate),
 		storageutils.CloneBlockWithoutStoragePlacement(readAfterRetirement),
 	))
 

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -210,7 +210,7 @@ func (r *repairerImpl) inspectFencedCandidate(
 			return nil, xerrors.Errorf("failed to verify source CSCB payload at height %d: %w", block.Height, err)
 		}
 		hasStoragePlacement = hasStoragePlacement || oldInspection.HasStoragePlacement
-		if singleInspection.CanonicalSHA256 != oldInspection.CanonicalSHA256 {
+		if singleInspection.SemanticSHA256 != oldInspection.SemanticSHA256 {
 			return nil, xerrors.Errorf("single-block and CSCB payloads differ at height %d", block.Height)
 		}
 		block.PayloadSHA256 = singleInspection.CanonicalSHA256
@@ -503,7 +503,7 @@ func (r *repairerImpl) inspectSingleBlockObjectVersion(
 
 	// Retries historically created redundant single-block versions whose raw
 	// Solana JSON serialization can differ while representing the same block.
-	// Verify every immutable version through the canonical block digest before
+	// Verify every immutable version through the semantic block digest before
 	// pinning the current one.
 	verifier := retirement.NewPinnedPayloadVerifier(r.store)
 	currentCandidate := candidate
@@ -522,9 +522,9 @@ func (r *repairerImpl) inspectSingleBlockObjectVersion(
 		if err != nil {
 			return ObjectVersion{}, xerrors.Errorf("failed to read historical single-block object version %q: %w", version.VersionID, err)
 		}
-		if historicalInspection.CanonicalSHA256 != currentInspection.CanonicalSHA256 {
+		if historicalInspection.SemanticSHA256 != currentInspection.SemanticSHA256 {
 			return ObjectVersion{}, xerrors.Errorf(
-				"single-block object versions contain different canonical block payloads: current=%q historical=%q",
+				"single-block object versions contain different semantic block payloads: current=%q historical=%q",
 				current.VersionID,
 				version.VersionID,
 			)

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -189,7 +189,13 @@ func (r *repairerImpl) inspectFencedCandidate(
 		if objectKeySHA256(block.SingleBlockObjectKey) != block.SingleBlockObjectKeySHA256 {
 			return nil, xerrors.Errorf("single-block object key audit digest changed at height %d", block.Height)
 		}
-		singleVersion, err := r.inspectSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey)
+		singleVersion, err := r.inspectSingleBlockObjectVersion(ctx, retirement.Candidate{
+			Bucket: manifest.Bucket,
+			Key:    block.SingleBlockObjectKey,
+			Height: block.Height,
+			Hash:   block.Hash,
+			Tag:    block.Tag,
+		})
 		if err != nil {
 			return nil, xerrors.Errorf("failed to pin single-block object at height %d: %w", block.Height, err)
 		}
@@ -471,14 +477,17 @@ func (r *repairerImpl) inspectExactObjectVersion(ctx context.Context, key string
 	return result, nil
 }
 
-func (r *repairerImpl) inspectSingleBlockObjectVersion(ctx context.Context, key string) (ObjectVersion, error) {
-	topology, err := r.store.ListObjectVersions(ctx, r.bucket, key)
+func (r *repairerImpl) inspectSingleBlockObjectVersion(
+	ctx context.Context,
+	candidate retirement.Candidate,
+) (ObjectVersion, error) {
+	topology, err := r.store.ListObjectVersions(ctx, r.bucket, candidate.Key)
 	if err != nil {
 		return ObjectVersion{}, err
 	}
 	current, err := currentSingleBlockObjectVersion(topology)
 	if err != nil {
-		return ObjectVersion{}, xerrors.Errorf("unsafe single-block object topology: key=%q: %w", key, err)
+		return ObjectVersion{}, xerrors.Errorf("unsafe single-block object topology: key=%q: %w", candidate.Key, err)
 	}
 	if len(topology.Versions) == 1 {
 		return current, nil
@@ -486,46 +495,36 @@ func (r *repairerImpl) inspectSingleBlockObjectVersion(ctx context.Context, key 
 	if len(topology.Versions) > maxSingleBlockVersionsToInspect {
 		return ObjectVersion{}, xerrors.Errorf(
 			"too many single-block object versions to safely inspect: key=%q count=%d max=%d",
-			key,
+			candidate.Key,
 			len(topology.Versions),
 			maxSingleBlockVersionsToInspect,
 		)
 	}
 
-	// Retries historically created redundant single-block versions. Verify every
-	// immutable version byte-for-byte before pinning the current one.
-	currentPayload, err := r.store.ReadObjectVersion(ctx, r.bucket, key, current.VersionID)
+	// Retries historically created redundant single-block versions whose raw
+	// Solana JSON serialization can differ while representing the same block.
+	// Verify every immutable version through the canonical block digest before
+	// pinning the current one.
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	currentCandidate := candidate
+	currentCandidate.VersionID = current.VersionID
+	currentInspection, err := verifier.InspectSingleBlock(ctx, currentCandidate)
 	if err != nil {
 		return ObjectVersion{}, xerrors.Errorf("failed to read current single-block object version %q: %w", current.VersionID, err)
 	}
-	if uint64(len(currentPayload)) != current.Bytes {
-		return ObjectVersion{}, xerrors.Errorf(
-			"current single-block object version size changed: version=%q expected=%d actual=%d",
-			current.VersionID,
-			current.Bytes,
-			len(currentPayload),
-		)
-	}
-	currentDigest := sha256.Sum256(currentPayload)
 	for _, version := range topology.Versions {
 		if version.VersionID == current.VersionID {
 			continue
 		}
-		payload, err := r.store.ReadObjectVersion(ctx, r.bucket, key, version.VersionID)
+		historicalCandidate := candidate
+		historicalCandidate.VersionID = version.VersionID
+		historicalInspection, err := verifier.InspectSingleBlock(ctx, historicalCandidate)
 		if err != nil {
 			return ObjectVersion{}, xerrors.Errorf("failed to read historical single-block object version %q: %w", version.VersionID, err)
 		}
-		if uint64(len(payload)) != current.Bytes {
+		if historicalInspection.CanonicalSHA256 != currentInspection.CanonicalSHA256 {
 			return ObjectVersion{}, xerrors.Errorf(
-				"historical single-block object version size changed: version=%q expected=%d actual=%d",
-				version.VersionID,
-				current.Bytes,
-				len(payload),
-			)
-		}
-		if sha256.Sum256(payload) != currentDigest {
-			return ObjectVersion{}, xerrors.Errorf(
-				"single-block object versions contain different payloads: current=%q historical=%q",
+				"single-block object versions contain different canonical block payloads: current=%q historical=%q",
 				current.VersionID,
 				version.VersionID,
 			)
@@ -588,15 +587,6 @@ func currentSingleBlockObjectVersion(topology retirement.ObjectVersionTopology) 
 	}
 	if !currentFound {
 		return ObjectVersion{}, xerrors.New("single-block object has no latest data version")
-	}
-	for _, version := range topology.Versions {
-		if version.ETag != current.ETag || version.Bytes != current.Bytes {
-			return ObjectVersion{}, xerrors.Errorf(
-				"single-block object versions have different metadata: current=%q version=%q",
-				current.VersionID,
-				version.VersionID,
-			)
-		}
 	}
 	return current, nil
 }

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -227,31 +227,35 @@ func TestPrepareNextCompletesAlreadyCleanCSCBWithoutRestore(t *testing.T) {
 	require.True(t, repository.alreadyClean)
 }
 
-func TestInspectSingleBlockObjectVersionAllowsIdenticalDuplicateVersions(t *testing.T) {
-	payload := []byte("identical single-block payload")
+func TestInspectSingleBlockObjectVersionAllowsSemanticallyIdenticalDuplicateVersions(t *testing.T) {
+	candidate := singleBlockVersionCandidate()
+	currentPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","transactions":[]}`)
+	historicalPayload := singleBlockVersionPayload(t, candidate, "{\n  \"transactions\": [],\n  \"blockhash\": \"block-hash\"\n}")
+	require.NotEqual(t, currentPayload, historicalPayload)
 	store := &versionedObjectStore{
 		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
-			{VersionID: "current-version", ETag: "same-etag", Bytes: uint64(len(payload)), IsLatest: true},
-			{VersionID: "historical-version", ETag: "same-etag", Bytes: uint64(len(payload))},
+			{VersionID: "current-version", ETag: "current-etag", Bytes: uint64(len(currentPayload)), IsLatest: true},
+			{VersionID: "historical-version", ETag: "historical-etag", Bytes: uint64(len(historicalPayload))},
 		}},
 		objects: map[string][]byte{
-			"current-version":    payload,
-			"historical-version": append([]byte(nil), payload...),
+			"current-version":    currentPayload,
+			"historical-version": historicalPayload,
 		},
 	}
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
-	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
 	require.NoError(t, err)
 	require.Equal(t, ObjectVersion{
 		VersionID: "current-version",
-		ETag:      "same-etag",
-		Bytes:     uint64(len(payload)),
+		ETag:      "current-etag",
+		Bytes:     uint64(len(currentPayload)),
 	}, version)
 	require.Equal(t, []string{"current-version", "historical-version"}, store.readVersionIDs)
 }
 
 func TestInspectSingleBlockObjectVersionDoesNotReadSingleVersionTwice(t *testing.T) {
+	candidate := singleBlockVersionCandidate()
 	store := &versionedObjectStore{
 		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
 			{VersionID: "current-version", ETag: "current-etag", Bytes: 4, IsLatest: true},
@@ -259,13 +263,14 @@ func TestInspectSingleBlockObjectVersionDoesNotReadSingleVersionTwice(t *testing
 	}
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
-	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
 	require.NoError(t, err)
 	require.Equal(t, "current-version", version.VersionID)
 	require.Empty(t, store.readVersionIDs)
 }
 
 func TestInspectSingleBlockObjectVersionRejectsTooManyVersionsBeforeReading(t *testing.T) {
+	candidate := singleBlockVersionCandidate()
 	versions := make([]retirement.ObjectVersion, maxSingleBlockVersionsToInspect+1)
 	for i := range versions {
 		versions[i] = retirement.ObjectVersion{
@@ -280,43 +285,33 @@ func TestInspectSingleBlockObjectVersionRejectsTooManyVersionsBeforeReading(t *t
 	}
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
-	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
 	require.ErrorContains(t, err, "too many single-block object versions to safely inspect")
 	require.Empty(t, store.readVersionIDs)
 }
 
 func TestInspectSingleBlockObjectVersionRejectsDifferentDuplicatePayloads(t *testing.T) {
+	candidate := singleBlockVersionCandidate()
+	currentPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","value":1}`)
+	historicalPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","value":2}`)
 	store := &versionedObjectStore{
 		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
-			{VersionID: "current-version", ETag: "same-etag", Bytes: 4, IsLatest: true},
-			{VersionID: "historical-version", ETag: "same-etag", Bytes: 4},
+			{VersionID: "current-version", ETag: "current-etag", Bytes: uint64(len(currentPayload)), IsLatest: true},
+			{VersionID: "historical-version", ETag: "historical-etag", Bytes: uint64(len(historicalPayload))},
 		}},
 		objects: map[string][]byte{
-			"current-version":    []byte("same"),
-			"historical-version": []byte("diff"),
+			"current-version":    currentPayload,
+			"historical-version": historicalPayload,
 		},
 	}
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
-	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
-	require.ErrorContains(t, err, "versions contain different payloads")
-}
-
-func TestInspectSingleBlockObjectVersionRejectsDifferentDuplicateMetadata(t *testing.T) {
-	store := &versionedObjectStore{
-		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
-			{VersionID: "current-version", ETag: "current-etag", Bytes: 4, IsLatest: true},
-			{VersionID: "historical-version", ETag: "historical-etag", Bytes: 4},
-		}},
-	}
-	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
-
-	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
-	require.ErrorContains(t, err, "versions have different metadata")
-	require.Empty(t, store.readVersionIDs)
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
+	require.ErrorContains(t, err, "versions contain different canonical block payloads")
 }
 
 func TestInspectSingleBlockObjectVersionRejectsDeleteMarker(t *testing.T) {
+	candidate := singleBlockVersionCandidate()
 	store := &versionedObjectStore{
 		topology: retirement.ObjectVersionTopology{
 			Versions: []retirement.ObjectVersion{
@@ -327,7 +322,7 @@ func TestInspectSingleBlockObjectVersionRejectsDeleteMarker(t *testing.T) {
 	}
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
-	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), "single/1000.zstd")
+	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
 	require.ErrorContains(t, err, "zero delete markers")
 }
 
@@ -544,6 +539,34 @@ func validRepairCandidate() *Manifest {
 			OldUncompressedLength:    200,
 		}},
 	}
+}
+
+func singleBlockVersionCandidate() retirement.Candidate {
+	return retirement.Candidate{
+		Bucket: "repair-bucket",
+		Key:    "single/1000.gzip",
+		Tag:    2,
+		Height: 1000,
+		Hash:   "block-hash",
+	}
+}
+
+func singleBlockVersionPayload(t *testing.T, candidate retirement.Candidate, header string) []byte {
+	t.Helper()
+	payload, err := proto.Marshal(&api.Block{
+		Metadata: &api.BlockMetadata{
+			Tag:    candidate.Tag,
+			Height: candidate.Height,
+			Hash:   candidate.Hash,
+		},
+		Blobdata: &api.Block_Solana{
+			Solana: &api.SolanaBlobdata{Header: []byte(header)},
+		},
+	})
+	require.NoError(t, err)
+	compressed, err := storageutils.Compress(payload, api.Compression_GZIP)
+	require.NoError(t, err)
+	return compressed
 }
 
 type pendingRepairRepository struct {

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coinbase/chainstorage/internal/storage/blobstorage/cscb"
 	"github.com/coinbase/chainstorage/internal/storage/retirement"
 	storageutils "github.com/coinbase/chainstorage/internal/storage/utils"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
@@ -307,7 +308,7 @@ func TestInspectSingleBlockObjectVersionRejectsDifferentDuplicatePayloads(t *tes
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
 	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
-	require.ErrorContains(t, err, "versions contain different canonical block payloads")
+	require.ErrorContains(t, err, "versions contain different semantic block payloads")
 }
 
 func TestInspectSingleBlockObjectVersionRejectsDeleteMarker(t *testing.T) {
@@ -427,6 +428,63 @@ func TestRepairPhasesRejectSingleBlockTopologyDriftBeforeMutation(t *testing.T) 
 			})
 		}
 	}
+}
+
+func TestVerifyRebuiltResumesManifestWithPreSemanticSolanaDigest(t *testing.T) {
+	manifest := phaseBoundaryManifest(t, StateRestored)
+	block := &manifest.Blocks[0]
+	rawBlock := &api.Block{
+		Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+		Network:    common.Network_NETWORK_SOLANA_MAINNET,
+		Metadata: &api.BlockMetadata{
+			Tag:    block.Tag,
+			Height: block.Height,
+			Hash:   block.Hash,
+		},
+		Blobdata: &api.Block_Solana{Solana: &api.SolanaBlobdata{
+			Header: []byte("{\n  \"transactions\": [],\n  \"blockhash\": \"block-hash\"\n}"),
+		}},
+	}
+	payload, err := (proto.MarshalOptions{Deterministic: true}).Marshal(rawBlock)
+	require.NoError(t, err)
+	preSemanticDigest := sha256.Sum256(payload)
+	block.PayloadSHA256 = hex.EncodeToString(preSemanticDigest[:])
+	block.NewByteOffset = 0
+	block.NewByteLength = uint64(len(payload))
+	block.NewUncompressedLength = uint64(len(payload))
+
+	singleObject, err := storageutils.Compress(payload, api.Compression_GZIP)
+	require.NoError(t, err)
+	block.SingleBlockObjectVersion.Bytes = uint64(len(singleObject))
+	newCSCB := buildRepairSingleBlockCSCB(t, retirement.Candidate{
+		BlockMetadataID: block.BlockMetadataID,
+		Tag:             block.Tag,
+		Height:          block.Height,
+		Hash:            block.Hash,
+		ByteOffset:      block.NewByteOffset,
+	}, payload)
+	manifest.NewConsolidatedObjectVersion.Bytes = uint64(len(newCSCB))
+
+	repository := &phaseBoundaryRepository{manifest: manifest}
+	store := &completionObjectStore{
+		topologies: map[string]retirement.ObjectVersionTopology{
+			manifest.NewConsolidatedObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.NewConsolidatedObjectVersion)},
+			},
+			block.SingleBlockObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(block.SingleBlockObjectVersion)},
+			},
+		},
+		objects: map[string][]byte{
+			manifest.NewConsolidatedObjectKey: newCSCB,
+			block.SingleBlockObjectKey:        singleObject,
+		},
+	}
+
+	_, err = NewRepairer(repository, store, manifest.Bucket).VerifyRebuilt(context.Background(), manifest.ID, nil)
+	require.NoError(t, err)
+	require.True(t, repository.recordVerifiedCalled)
+	require.Equal(t, hex.EncodeToString(preSemanticDigest[:]), block.PayloadSHA256)
 }
 
 func TestCompleteRejectsRetainedObjectTopologyDrift(t *testing.T) {
@@ -893,6 +951,28 @@ func (s *completionObjectStore) ReadObjectVersion(
 	_ string,
 ) ([]byte, error) {
 	return s.objects[key], nil
+}
+
+func (s *completionObjectStore) ReadObjectVersionRange(
+	_ context.Context,
+	_ string,
+	key string,
+	_ string,
+	offset uint64,
+	length uint64,
+) ([]byte, error) {
+	object, ok := s.objects[key]
+	if !ok {
+		return nil, errors.New("object not found")
+	}
+	end := offset + length
+	if end < offset || offset > uint64(len(object)) {
+		return nil, errors.New("object range out of bounds")
+	}
+	if end > uint64(len(object)) {
+		end = uint64(len(object))
+	}
+	return append([]byte(nil), object[offset:end]...), nil
 }
 
 func completionManifest(t *testing.T) *Manifest {

--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"io"
 	"strconv"
 
 	"golang.org/x/xerrors"
@@ -127,12 +129,44 @@ func (v *payloadVerifier) VerifyConsolidated(ctx context.Context, candidate Cand
 }
 
 func canonicalBlockDigest(block *api.Block) (string, error) {
-	payload, err := (proto.MarshalOptions{Deterministic: true}).Marshal(block)
+	canonical, err := canonicalizeEmbeddedBlockPayload(block)
+	if err != nil {
+		return "", err
+	}
+	payload, err := (proto.MarshalOptions{Deterministic: true}).Marshal(canonical)
 	if err != nil {
 		return "", xerrors.Errorf("failed to marshal canonical block payload: %w", err)
 	}
 	digest := sha256.Sum256(payload)
 	return hex.EncodeToString(digest[:]), nil
+}
+
+func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
+	canonical := proto.Clone(block).(*api.Block)
+	solana := canonical.GetSolana()
+	if solana == nil || len(solana.Header) == 0 {
+		return canonical, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(solana.Header))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, xerrors.Errorf("failed to parse embedded Solana block JSON: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, xerrors.New("embedded Solana block JSON contains multiple values")
+		}
+		return nil, xerrors.Errorf("failed to finish parsing embedded Solana block JSON: %w", err)
+	}
+	canonicalHeader, err := json.Marshal(value)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to canonicalize embedded Solana block JSON: %w", err)
+	}
+	solana.Header = canonicalHeader
+	return canonical, nil
 }
 
 func validatePayloadIdentity(block *api.Block, candidate Candidate) error {

--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -27,6 +27,7 @@ type blockPayloadVerifier interface {
 type (
 	PinnedPayloadInspection struct {
 		CanonicalSHA256     string
+		SemanticSHA256      string
 		HasStoragePlacement bool
 	}
 
@@ -89,12 +90,18 @@ func (v *payloadVerifier) InspectSingleBlock(ctx context.Context, candidate Cand
 	if err := validatePayloadIdentity(&singleBlockBlock, candidate); err != nil {
 		return PinnedPayloadInspection{}, xerrors.Errorf("pinned single-block block identity mismatch: %w", err)
 	}
-	digest, err := canonicalBlockDigest(storageutils.CloneBlockWithoutStoragePlacement(&singleBlockBlock))
+	normalized := storageutils.CloneBlockWithoutStoragePlacement(&singleBlockBlock)
+	digest, err := canonicalBlockDigest(normalized)
+	if err != nil {
+		return PinnedPayloadInspection{}, err
+	}
+	semanticDigest, err := semanticBlockDigest(normalized)
 	if err != nil {
 		return PinnedPayloadInspection{}, err
 	}
 	return PinnedPayloadInspection{
 		CanonicalSHA256:     digest,
+		SemanticSHA256:      semanticDigest,
 		HasStoragePlacement: storageutils.HasBlockStoragePlacement(&singleBlockBlock),
 	}, nil
 }
@@ -107,12 +114,18 @@ func (v *payloadVerifier) InspectConsolidated(ctx context.Context, candidate Can
 	if err := validatePayloadIdentity(cscbBlock, candidate); err != nil {
 		return PinnedPayloadInspection{}, xerrors.Errorf("pinned CSCB block identity mismatch: %w", err)
 	}
-	digest, err := canonicalBlockDigest(storageutils.CloneBlockWithoutStoragePlacement(cscbBlock))
+	normalized := storageutils.CloneBlockWithoutStoragePlacement(cscbBlock)
+	digest, err := canonicalBlockDigest(normalized)
+	if err != nil {
+		return PinnedPayloadInspection{}, err
+	}
+	semanticDigest, err := semanticBlockDigest(normalized)
 	if err != nil {
 		return PinnedPayloadInspection{}, err
 	}
 	return PinnedPayloadInspection{
 		CanonicalSHA256:     digest,
+		SemanticSHA256:      semanticDigest,
 		HasStoragePlacement: storageutils.HasBlockStoragePlacement(cscbBlock),
 	}, nil
 }
@@ -129,6 +142,17 @@ func (v *payloadVerifier) VerifyConsolidated(ctx context.Context, candidate Cand
 }
 
 func canonicalBlockDigest(block *api.Block) (string, error) {
+	// This digest is persisted in retirement and repair manifests. Keep its
+	// deterministic-protobuf algorithm stable across upgrades and rollbacks.
+	payload, err := (proto.MarshalOptions{Deterministic: true}).Marshal(block)
+	if err != nil {
+		return "", xerrors.Errorf("failed to marshal canonical block payload: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func semanticBlockDigest(block *api.Block) (string, error) {
 	canonical, err := canonicalizeEmbeddedBlockPayload(block)
 	if err != nil {
 		return "", err

--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -142,10 +142,9 @@ func canonicalBlockDigest(block *api.Block) (string, error) {
 }
 
 func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
-	canonical := proto.Clone(block).(*api.Block)
-	solana := canonical.GetSolana()
+	solana := block.GetSolana()
 	if solana == nil || len(solana.Header) == 0 {
-		return canonical, nil
+		return block, nil
 	}
 
 	decoder := json.NewDecoder(bytes.NewReader(solana.Header))
@@ -165,7 +164,8 @@ func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("failed to canonicalize embedded Solana block JSON: %w", err)
 	}
-	solana.Header = canonicalHeader
+	canonical := proto.Clone(block).(*api.Block)
+	canonical.GetSolana().Header = canonicalHeader
 	return canonical, nil
 }
 

--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -173,14 +173,13 @@ func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
 
 	decoder := json.NewDecoder(bytes.NewReader(solana.Header))
 	decoder.UseNumber()
-	var value any
-	if err := decoder.Decode(&value); err != nil {
+	value, err := decodeUniqueJSONValue(decoder)
+	if err != nil {
 		return nil, xerrors.Errorf("failed to parse embedded Solana block JSON: %w", err)
 	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
+	if token, err := decoder.Token(); err != io.EOF {
 		if err == nil {
-			return nil, xerrors.New("embedded Solana block JSON contains multiple values")
+			return nil, xerrors.Errorf("embedded Solana block JSON contains multiple values: trailing=%v", token)
 		}
 		return nil, xerrors.Errorf("failed to finish parsing embedded Solana block JSON: %w", err)
 	}
@@ -191,6 +190,70 @@ func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
 	canonical := proto.Clone(block).(*api.Block)
 	canonical.GetSolana().Header = canonicalHeader
 	return canonical, nil
+}
+
+func decodeUniqueJSONValue(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+
+	switch delim {
+	case '{':
+		object := make(map[string]any)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, xerrors.Errorf("JSON object key is not a string: %v", keyToken)
+			}
+			if _, exists := object[key]; exists {
+				return nil, xerrors.Errorf("duplicate JSON object key %q", key)
+			}
+			value, err := decodeUniqueJSONValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = value
+		}
+		if err := requireJSONClosingDelimiter(decoder, '}'); err != nil {
+			return nil, err
+		}
+		return object, nil
+	case '[':
+		array := make([]any, 0)
+		for decoder.More() {
+			value, err := decodeUniqueJSONValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, value)
+		}
+		if err := requireJSONClosingDelimiter(decoder, ']'); err != nil {
+			return nil, err
+		}
+		return array, nil
+	default:
+		return nil, xerrors.Errorf("unexpected JSON delimiter %q", delim)
+	}
+}
+
+func requireJSONClosingDelimiter(decoder *json.Decoder, expected json.Delim) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if token != expected {
+		return xerrors.Errorf("unexpected JSON closing delimiter %v; expected %q", token, expected)
+	}
+	return nil
 }
 
 func validatePayloadIdentity(block *api.Block, candidate Candidate) error {

--- a/internal/storage/retirement/payload_verifier_test.go
+++ b/internal/storage/retirement/payload_verifier_test.go
@@ -104,6 +104,40 @@ func TestPayloadVerifier_ParsesSupportedSingleBlockCompression(t *testing.T) {
 	}
 }
 
+func TestCanonicalBlockDigestCanonicalizesSolanaJSON(t *testing.T) {
+	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
+	first := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","transactions":[],"slot":429600000}`)
+	second := solanaPayloadBlock(candidate, "{\n  \"slot\": 429600000,\n  \"transactions\": [],\n  \"blockhash\": \"block-hash\"\n}")
+	require.NotEqual(t, first.GetSolana().GetHeader(), second.GetSolana().GetHeader())
+
+	firstDigest, err := canonicalBlockDigest(first)
+	require.NoError(t, err)
+	secondDigest, err := canonicalBlockDigest(second)
+	require.NoError(t, err)
+	require.Equal(t, firstDigest, secondDigest)
+}
+
+func TestCanonicalBlockDigestRejectsDifferentSolanaJSON(t *testing.T) {
+	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
+	first := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","slot":429600000}`)
+	second := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","slot":429600001}`)
+
+	firstDigest, err := canonicalBlockDigest(first)
+	require.NoError(t, err)
+	secondDigest, err := canonicalBlockDigest(second)
+	require.NoError(t, err)
+	require.NotEqual(t, firstDigest, secondDigest)
+}
+
+func TestCanonicalBlockDigestRejectsMalformedSolanaJSON(t *testing.T) {
+	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
+	_, err := canonicalBlockDigest(solanaPayloadBlock(candidate, `{"blockhash":`))
+	require.ErrorContains(t, err, "failed to parse embedded Solana block JSON")
+
+	_, err = canonicalBlockDigest(solanaPayloadBlock(candidate, `{"blockhash":"block-hash"} {}`))
+	require.ErrorContains(t, err, "contains multiple values")
+}
+
 func TestPayloadVerifier_RejectsSemanticAndSerializedMismatch(t *testing.T) {
 	require := require.New(t)
 	candidate, store, _ := retirementPayloadFixture(t)
@@ -201,6 +235,21 @@ func retirementPayloadFixture(t *testing.T) (Candidate, *fakeStore, []byte) {
 	store.objects[versionObjectKey(candidate.Key, candidate.VersionID)] = gzipPayload(t, payload)
 	store.objects[versionObjectKey(candidate.ConsolidatedKey, candidate.CSCBVersionID)] = buildSingleBlockCSCB(t, candidate, payload)
 	return candidate, store, payload
+}
+
+func solanaPayloadBlock(candidate Candidate, header string) *api.Block {
+	return &api.Block{
+		Blockchain: common.Blockchain_BLOCKCHAIN_SOLANA,
+		Network:    common.Network_NETWORK_SOLANA_MAINNET,
+		Metadata: &api.BlockMetadata{
+			Tag:    candidate.Tag,
+			Height: candidate.Height,
+			Hash:   candidate.Hash,
+		},
+		Blobdata: &api.Block_Solana{
+			Solana: &api.SolanaBlobdata{Header: []byte(header)},
+		},
+	}
 }
 
 func buildSingleBlockCSCB(t *testing.T, candidate Candidate, payload []byte) []byte {

--- a/internal/storage/retirement/payload_verifier_test.go
+++ b/internal/storage/retirement/payload_verifier_test.go
@@ -144,6 +144,20 @@ func TestSemanticBlockDigestRejectsMalformedSolanaJSON(t *testing.T) {
 	require.ErrorContains(t, err, "contains multiple values")
 }
 
+func TestSemanticBlockDigestRejectsDuplicateSolanaJSONKeys(t *testing.T) {
+	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
+	tests := map[string]string{
+		"top level": `{"slot":429600000,"slot":429600001}`,
+		"nested":    `{"meta":{"slot":429600000,"slot":429600001}}`,
+	}
+	for name, header := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := semanticBlockDigest(solanaPayloadBlock(candidate, header))
+			require.ErrorContains(t, err, `duplicate JSON object key "slot"`)
+		})
+	}
+}
+
 func TestPayloadVerifier_RejectsSemanticAndSerializedMismatch(t *testing.T) {
 	require := require.New(t)
 	candidate, store, _ := retirementPayloadFixture(t)

--- a/internal/storage/retirement/payload_verifier_test.go
+++ b/internal/storage/retirement/payload_verifier_test.go
@@ -104,37 +104,43 @@ func TestPayloadVerifier_ParsesSupportedSingleBlockCompression(t *testing.T) {
 	}
 }
 
-func TestCanonicalBlockDigestCanonicalizesSolanaJSON(t *testing.T) {
+func TestPayloadDigestsPreservePersistedFormatAndCanonicalizeSemanticComparison(t *testing.T) {
 	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
 	first := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","transactions":[],"slot":429600000}`)
 	second := solanaPayloadBlock(candidate, "{\n  \"slot\": 429600000,\n  \"transactions\": [],\n  \"blockhash\": \"block-hash\"\n}")
 	require.NotEqual(t, first.GetSolana().GetHeader(), second.GetSolana().GetHeader())
 
-	firstDigest, err := canonicalBlockDigest(first)
+	firstPersistedDigest, err := canonicalBlockDigest(first)
 	require.NoError(t, err)
-	secondDigest, err := canonicalBlockDigest(second)
+	secondPersistedDigest, err := canonicalBlockDigest(second)
 	require.NoError(t, err)
-	require.Equal(t, firstDigest, secondDigest)
+	require.NotEqual(t, firstPersistedDigest, secondPersistedDigest)
+
+	firstSemanticDigest, err := semanticBlockDigest(first)
+	require.NoError(t, err)
+	secondSemanticDigest, err := semanticBlockDigest(second)
+	require.NoError(t, err)
+	require.Equal(t, firstSemanticDigest, secondSemanticDigest)
 }
 
-func TestCanonicalBlockDigestRejectsDifferentSolanaJSON(t *testing.T) {
+func TestSemanticBlockDigestRejectsDifferentSolanaJSON(t *testing.T) {
 	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
 	first := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","slot":429600000}`)
 	second := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","slot":429600001}`)
 
-	firstDigest, err := canonicalBlockDigest(first)
+	firstDigest, err := semanticBlockDigest(first)
 	require.NoError(t, err)
-	secondDigest, err := canonicalBlockDigest(second)
+	secondDigest, err := semanticBlockDigest(second)
 	require.NoError(t, err)
 	require.NotEqual(t, firstDigest, secondDigest)
 }
 
-func TestCanonicalBlockDigestRejectsMalformedSolanaJSON(t *testing.T) {
+func TestSemanticBlockDigestRejectsMalformedSolanaJSON(t *testing.T) {
 	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
-	_, err := canonicalBlockDigest(solanaPayloadBlock(candidate, `{"blockhash":`))
+	_, err := semanticBlockDigest(solanaPayloadBlock(candidate, `{"blockhash":`))
 	require.ErrorContains(t, err, "failed to parse embedded Solana block JSON")
 
-	_, err = canonicalBlockDigest(solanaPayloadBlock(candidate, `{"blockhash":"block-hash"} {}`))
+	_, err = semanticBlockDigest(solanaPayloadBlock(candidate, `{"blockhash":"block-hash"} {}`))
 	require.ErrorContains(t, err, "contains multiple values")
 }
 


### PR DESCRIPTION
## Summary

- canonicalize embedded Solana JSON before computing the repair/retirement block digest, so field order and insignificant whitespace do not create false mismatches
- inspect and identity-check every immutable single-block version before pinning the current version; true payload differences, malformed JSON, delete markers, mutable/incomplete versions, and excessive version counts still fail closed
- extend the Docker lifecycle test to reproduce two semantically identical versions with different ETags, compressed sizes, and raw serialization

## Production evidence

`workflow.batch_consolidator/repair_existing_cscb_431572000_431872000_p20_r1_20260718T2330Z` failed after 225/300 CSCBs because 15 single-block keys in `[431632000,431647000)` each had two versions with different ETags and compressed sizes. Read-only inspection of all 30 immutable versions showed identical block identity, Chainstorage metadata, transaction metadata, and parsed Solana JSON for every pair; only JSON serialization differed.

No S3 or production database mutation is performed by this change. Existing pending repair manifests remain fenced for a deployment-time retry.

## Verification

- `env TEST_TYPE=unit go test ./...`
- `go test -race ./internal/storage/retirement ./internal/storage/cscbrepair`
- `go vet ./internal/storage/retirement ./internal/storage/cscbrepair`
- Docker-backed `TestIntegrationCSCBRepairFullLifecycle` with different-ETag/different-size semantic duplicate versions
- `git diff --check`

Linear: https://linear.app/cipherowl/issue/INF-1133