### PR TITLE
fix(INF-1133): atomically rebuild CSCBs from pinned blocks

### DIFF
--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -121,11 +121,14 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 			Solana: &api.SolanaBlobdata{Header: []byte(`{"slot":9500000000,"transactions":["repair"]}`)},
 		},
 	}
-	singleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
+	historicalBlock := proto.Clone(block).(*api.Block)
+	historicalBlock.GetSolana().Header = []byte(`{"slot":9500000000,"transactions":["stale"]}`)
+	singleBlockKey, err := singleBlockUploader.Upload(ctx, historicalBlock, api.Compression_GZIP)
 	require.NoError(err)
 	semanticDuplicate := proto.Clone(block).(*api.Block)
 	semanticDuplicate.GetSolana().Header = []byte("{\n  \"transactions\": [\"repair\"],\n  \"slot\": 9500000000\n}")
 	require.JSONEq(string(block.GetSolana().Header), string(semanticDuplicate.GetSolana().Header))
+	require.NotEqual(string(historicalBlock.GetSolana().Header), string(semanticDuplicate.GetSolana().Header))
 	duplicateSingleBlockKey, err := singleBlockUploader.Upload(ctx, semanticDuplicate, api.Compression_GZIP)
 	require.NoError(err)
 	require.Equal(singleBlockKey, duplicateSingleBlockKey)

--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -291,48 +291,27 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	})
 	require.ErrorContains(err, "failed to lock canonical retirement metadata")
 
-	manifest, err = repairer.Restore(ctx, manifest.ID, nil)
+	activeBeforeRebuild, err := meta.GetBlockByHeight(ctx, tag, height)
 	require.NoError(err)
-	require.Equal(cscbrepair.StateRestored, manifest.State)
-	require.NotNil(manifest.RestoredAt)
-	activeSingleBlock, err := meta.GetBlockByHeight(ctx, tag, height)
-	require.NoError(err)
-	require.Equal(singleBlockKey, activeSingleBlock.ObjectKeyMain)
-	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK, activeSingleBlock.ObjectFormat)
-	require.Zero(activeSingleBlock.ByteLength)
-	restoredBlock, err := blob.Download(ctx, activeSingleBlock)
-	require.NoError(err)
-	require.True(proto.Equal(storageutils.CloneBlockWithoutStoragePlacement(semanticDuplicate), storageutils.CloneBlockWithoutStoragePlacement(restoredBlock)))
-	_, err = db.ExecContext(ctx, `UPDATE block_metadata SET object_key_main = $2 WHERE id = $1`, blockMetadataID, dirtyKey)
-	require.ErrorContains(err, "cannot reference a pinned old CSCB object")
-	_, err = db.ExecContext(ctx, `
-		INSERT INTO block_consolidation_shadow (
-			block_metadata_id, tag, height, hash, single_block_object_key_main,
-			consolidated_object_key_main, object_format, byte_offset, byte_length,
-			uncompressed_length, validated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, clock_timestamp())`,
-		blockMetadataID,
-		tag,
-		height,
-		block.Metadata.Hash,
-		singleBlockKey,
-		dirtyKey,
-		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
-		manifest.Blocks[0].OldByteOffset,
-		manifest.Blocks[0].OldByteLength,
-		manifest.Blocks[0].OldUncompressedLength,
-	)
-	require.ErrorContains(err, "cannot reference a pinned old CSCB object")
+	require.Equal(dirtyKey, activeBeforeRebuild.ObjectKeyMain)
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, activeBeforeRebuild.ObjectFormat)
 
-	records, err = meta.GetBlocksMissingConsolidationShadow(ctx, tag, height, height+1, 1)
-	require.NoError(err)
-	require.Len(records, 1)
-	cleanBlock, err := blob.Download(ctx, records[0].Metadata)
-	require.NoError(err)
-	cleanPayload, err := proto.Marshal(storageutils.CloneBlockWithoutStoragePlacement(cleanBlock))
-	require.NoError(err)
+	var pinnedPayloads []cscbrepair.PinnedPayload
+	require.NoError(repairer.VisitPinnedPayloads(ctx, manifest.ID, nil, func(payload cscbrepair.PinnedPayload) error {
+		pinnedPayloads = append(pinnedPayloads, payload)
+		return nil
+	}))
+	require.Len(pinnedPayloads, 1)
+	var pinnedBlock api.Block
+	require.NoError(proto.Unmarshal(pinnedPayloads[0].RawBlockPayload, &pinnedBlock))
+	require.False(storageutils.HasBlockStoragePlacement(&pinnedBlock))
+	require.True(proto.Equal(
+		storageutils.CloneBlockWithoutStoragePlacement(semanticDuplicate),
+		storageutils.CloneBlockWithoutStoragePlacement(&pinnedBlock),
+	))
+	cleanPayload := pinnedPayloads[0].RawBlockPayload
 	cleanKey, cleanPlacements, err := blob.UploadConsolidated(ctx, []blobstorage.ConsolidatedBlockPayload{{
-		Metadata:           records[0].Metadata,
+		Metadata:           pinnedPayloads[0].Metadata,
 		MetadataID:         blockMetadataID,
 		RawBlockPayload:    blobstorage.BytesPayloadSource(cleanPayload),
 		UncompressedLength: uint64(len(cleanPayload)),
@@ -341,21 +320,25 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.NotEqual(dirtyKey, cleanKey)
 	require.Len(cleanPlacements, 1)
 	cleanPlacement := cleanPlacements[0]
-	require.NoError(meta.PersistBlockConsolidationShadows(ctx, []*metastorage.ConsolidationShadowPlacement{{
-		BlockMetadataID:           blockMetadataID,
-		Tag:                       tag,
-		Height:                    height,
-		Hash:                      block.Metadata.Hash,
-		SingleBlockObjectKeyMain:  singleBlockKey,
-		ConsolidatedObjectKeyMain: cleanKey,
-		ObjectFormat:              cleanPlacement.ObjectFormat,
-		ByteOffset:                cleanPlacement.ByteOffset,
-		ByteLength:                cleanPlacement.ByteLength,
-		UncompressedLength:        cleanPlacement.UncompressedLength,
-	}}))
-	promotion, err = meta.PromoteBlockConsolidationShadows(ctx, tag, height, height+1, 1, 72*time.Hour)
+	activeBeforePromotion, err := meta.GetBlockByHeight(ctx, tag, height)
 	require.NoError(err)
-	require.Equal(uint64(1), promotion.Blocks)
+	require.Equal(dirtyKey, activeBeforePromotion.ObjectKeyMain, "source CSCB must remain active until atomic promotion")
+
+	manifest, err = repairer.VerifyAndPromote(ctx, manifest.ID, cleanKey, []cscbrepair.RebuiltPlacement{{
+		BlockMetadataID:    cleanPlacement.MetadataID,
+		Height:             cleanPlacement.Height,
+		Hash:               cleanPlacement.Hash,
+		ObjectFormat:       cleanPlacement.ObjectFormat,
+		ByteOffset:         cleanPlacement.ByteOffset,
+		ByteLength:         cleanPlacement.ByteLength,
+		UncompressedLength: cleanPlacement.UncompressedLength,
+	}}, 72*time.Hour, nil)
+	require.NoError(err)
+	require.Equal(cscbrepair.StateVerified, manifest.State)
+	require.Equal(cleanKey, manifest.NewConsolidatedObjectKey)
+	require.NotZero(manifest.NewConsolidatedObjectVersion.Bytes)
+	require.NotNil(manifest.RestoredAt)
+	require.NotNil(manifest.VerifiedAt)
 	var retentionStartedAt, singleBlockDeleteAfter time.Time
 	require.NoError(db.QueryRowContext(ctx, `
 		SELECT single_block_retention_started_at, single_block_delete_after
@@ -363,13 +346,10 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 		WHERE block_metadata_id = $1`, blockMetadataID).Scan(&retentionStartedAt, &singleBlockDeleteAfter))
 	require.False(retentionStartedAt.Before(*manifest.RestoredAt))
 	require.WithinDuration(retentionStartedAt.Add(72*time.Hour), singleBlockDeleteAfter, time.Microsecond)
-
-	manifest, err = repairer.VerifyRebuilt(ctx, manifest.ID, nil)
+	activeAfterPromotion, err := meta.GetBlockByHeight(ctx, tag, height)
 	require.NoError(err)
-	require.Equal(cscbrepair.StateVerified, manifest.State)
-	require.Equal(cleanKey, manifest.NewConsolidatedObjectKey)
-	require.NotZero(manifest.NewConsolidatedObjectVersion.Bytes)
-	require.NotNil(manifest.VerifiedAt)
+	require.Equal(cleanKey, activeAfterPromotion.ObjectKeyMain)
+	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, activeAfterPromotion.ObjectFormat)
 
 	manifest, err = repairer.Complete(ctx, manifest.ID, nil)
 	require.NoError(err)

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -1067,6 +1067,223 @@ func (r *PostgresRepository) RecordVerified(
 	return verified, nil
 }
 
+func (r *PostgresRepository) PromoteVerified(
+	ctx context.Context,
+	repairID int64,
+	objectKey string,
+	object ObjectVersion,
+	placements []RebuiltPlacement,
+	singleBlockObjectRetention time.Duration,
+) (*Manifest, error) {
+	if err := r.validateDB(); err != nil {
+		return nil, err
+	}
+	if objectKey == "" || object.VersionID == "" || object.ETag == "" || object.Bytes == 0 {
+		return nil, xerrors.New("verified CSCB object identity is required")
+	}
+	if singleBlockObjectRetention <= 0 {
+		return nil, xerrors.New("positive single-block object retention is required")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin atomic CSCB repair promotion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	manifest, err := lockManifestForRepair(ctx, tx, repairID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State == StateVerified || manifest.State == StateCompleted {
+		if manifest.NewConsolidatedObjectKey != objectKey ||
+			manifest.NewConsolidatedObjectVersion != object {
+			return nil, xerrors.Errorf("verified CSCB repair identity changed for repair id %d", manifest.ID)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to commit idempotent atomic CSCB repair promotion: %w", err)
+		}
+		return manifest, nil
+	}
+	if manifest.State != StatePrepared && manifest.State != StateRestored {
+		return nil, xerrors.Errorf(
+			"CSCB repair must be prepared or restored before atomic promotion: id=%d state=%s",
+			manifest.ID,
+			manifest.State,
+		)
+	}
+	placementsByID, err := validateRebuiltPlacements(manifest, objectKey, placements)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockRepairRows(ctx, tx, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	if err := lockConsolidatedObjectKeys(ctx, tx, manifest.OldConsolidatedObjectKey, objectKey); err != nil {
+		return nil, err
+	}
+	if err := requireNoUnexpectedOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey, manifest.Blocks); err != nil {
+		return nil, err
+	}
+	var promotionTime time.Time
+	if err := tx.QueryRowContext(ctx, `SELECT clock_timestamp()`).Scan(&promotionTime); err != nil {
+		return nil, xerrors.Errorf("failed to capture CSCB repair promotion time: %w", err)
+	}
+	if manifest.State == StatePrepared {
+		const markRestored = `
+			UPDATE cscb_repair_manifest
+			SET state = $2,
+				restored_at = $3,
+				updated_at = $3
+			WHERE id = $1 AND state = $4`
+		result, err := tx.ExecContext(ctx, markRestored, manifest.ID, StateRestored, promotionTime, StatePrepared)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to mark CSCB repair restored during atomic promotion: %w", err)
+		}
+		if err := requireRowsAffected(result, 1, "mark CSCB repair restored during atomic promotion"); err != nil {
+			return nil, err
+		}
+		manifest.State = StateRestored
+		manifest.RestoredAt = &promotionTime
+	}
+	deleteAfter := promotionTime.Add(singleBlockObjectRetention)
+
+	for _, block := range manifest.Blocks {
+		placement := placementsByID[block.BlockMetadataID]
+		if err := validateRepairPromotionRow(ctx, tx, manifest, block, objectKey, placement); err != nil {
+			return nil, err
+		}
+
+		const upsertShadow = `
+			INSERT INTO block_consolidation_shadow (
+				block_metadata_id, tag, height, hash, single_block_object_key_main,
+				consolidated_object_key_main, object_format, byte_offset, byte_length,
+				uncompressed_length, validated_at, single_block_retention_started_at,
+				single_block_delete_after
+			) VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, $9, $10, $11, $11, $12)
+			ON CONFLICT (block_metadata_id) DO UPDATE SET
+				tag = EXCLUDED.tag,
+				height = EXCLUDED.height,
+				hash = EXCLUDED.hash,
+				single_block_object_key_main = EXCLUDED.single_block_object_key_main,
+				consolidated_object_key_main = EXCLUDED.consolidated_object_key_main,
+				object_format = EXCLUDED.object_format,
+				byte_offset = EXCLUDED.byte_offset,
+				byte_length = EXCLUDED.byte_length,
+				uncompressed_length = EXCLUDED.uncompressed_length,
+				validated_at = EXCLUDED.validated_at,
+				single_block_retention_started_at = EXCLUDED.single_block_retention_started_at,
+				single_block_delete_after = EXCLUDED.single_block_delete_after
+			WHERE block_consolidation_shadow.tag = EXCLUDED.tag
+				AND block_consolidation_shadow.height = EXCLUDED.height
+				AND block_consolidation_shadow.hash IS NOT DISTINCT FROM EXCLUDED.hash
+				AND block_consolidation_shadow.single_block_object_key_main = EXCLUDED.single_block_object_key_main
+				AND block_consolidation_shadow.single_block_object_deleted_at IS NULL
+			RETURNING block_metadata_id`
+		var shadowID int64
+		if err := tx.QueryRowContext(
+			ctx,
+			upsertShadow,
+			block.BlockMetadataID,
+			block.Tag,
+			block.Height,
+			block.Hash,
+			block.SingleBlockObjectKey,
+			objectKey,
+			int32(placement.ObjectFormat),
+			placement.ByteOffset,
+			placement.ByteLength,
+			placement.UncompressedLength,
+			promotionTime,
+			deleteAfter,
+		).Scan(&shadowID); err != nil {
+			return nil, xerrors.Errorf("failed to upsert repaired CSCB shadow for metadata_id=%d: %w", block.BlockMetadataID, err)
+		}
+
+		const promoteMetadata = `
+			UPDATE block_metadata
+			SET object_key_main = $5,
+				object_format = $6,
+				byte_offset = $7,
+				byte_length = $8,
+				uncompressed_length = $9
+			WHERE id = $1
+				AND tag = $2
+				AND height = $3
+				AND hash IS NOT DISTINCT FROM NULLIF($4, '')
+				AND skipped = FALSE
+				AND single_block_retention_fenced_at IS NULL`
+		result, err := tx.ExecContext(
+			ctx,
+			promoteMetadata,
+			block.BlockMetadataID,
+			block.Tag,
+			block.Height,
+			block.Hash,
+			objectKey,
+			int32(placement.ObjectFormat),
+			placement.ByteOffset,
+			placement.ByteLength,
+			placement.UncompressedLength,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to promote repaired CSCB metadata_id=%d: %w", block.BlockMetadataID, err)
+		}
+		if err := requireRowsAffected(result, 1, "promote repaired CSCB metadata"); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := requireNoOldReferences(ctx, tx, manifest.OldConsolidatedObjectKey); err != nil {
+		return nil, err
+	}
+	if err := requireExactRepairedReferences(ctx, tx, manifest, objectKey); err != nil {
+		return nil, err
+	}
+	const markVerified = `
+		UPDATE cscb_repair_manifest
+		SET state = $2,
+			new_consolidated_object_key_main = $3,
+			new_consolidated_object_version_id = $4,
+			new_consolidated_object_etag = $5,
+			new_consolidated_object_bytes = $6,
+			restored_at = COALESCE(restored_at, $7),
+			verified_at = $7,
+			updated_at = $7
+		WHERE id = $1 AND state = $8`
+	result, err := tx.ExecContext(
+		ctx,
+		markVerified,
+		manifest.ID,
+		StateVerified,
+		objectKey,
+		object.VersionID,
+		object.ETag,
+		object.Bytes,
+		promotionTime,
+		StateRestored,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to mark atomically promoted CSCB repair verified: %w", err)
+	}
+	if err := requireRowsAffected(result, 1, "mark atomically promoted CSCB repair verified"); err != nil {
+		return nil, err
+	}
+	verified, err := loadManifest(ctx, tx, manifest.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := loadRebuiltBlocks(ctx, tx, verified); err != nil {
+		return nil, err
+	}
+	if err := validateRebuiltMetadata(verified, objectKey); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to commit atomic CSCB repair promotion: %w", err)
+	}
+	return verified, nil
+}
+
 func (r *PostgresRepository) CompleteRetainingOldObject(
 	ctx context.Context,
 	repairID int64,
@@ -1118,7 +1335,13 @@ func (r *PostgresRepository) CompleteRetainingOldObject(
 		return nil, err
 	}
 	if manifest.CanonicalBlockCount > 0 {
-		if err := requireExactNewReferences(ctx, tx, manifest, manifest.NewConsolidatedObjectKey); err != nil {
+		var err error
+		if allRepairRowsOnObject(manifest, manifest.NewConsolidatedObjectKey) {
+			err = requireExactRepairedReferences(ctx, tx, manifest, manifest.NewConsolidatedObjectKey)
+		} else {
+			err = requireExactNewReferences(ctx, tx, manifest, manifest.NewConsolidatedObjectKey)
+		}
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -1613,6 +1836,124 @@ func lockRepairRows(ctx context.Context, tx *sql.Tx, blocks []Block) error {
 	return shadowRows.Err()
 }
 
+func validateRepairPromotionRow(
+	ctx context.Context,
+	tx *sql.Tx,
+	manifest *Manifest,
+	block Block,
+	newObjectKey string,
+	placement RebuiltPlacement,
+) error {
+	const query = `
+		SELECT
+			EXISTS (
+				SELECT 1 FROM canonical_blocks cb
+				WHERE cb.block_metadata_id = bm.id AND cb.tag = bm.tag AND cb.height = bm.height
+			),
+			COALESCE(bm.object_key_main, ''),
+			bm.object_format,
+			bm.byte_offset,
+			bm.byte_length,
+			bm.uncompressed_length,
+			bm.skipped,
+			(bm.single_block_retention_fenced_at IS NOT NULL),
+			EXISTS (
+				SELECT 1 FROM block_single_block_retention retirement
+				WHERE retirement.block_metadata_id = bm.id
+			),
+			(shadow.block_metadata_id IS NOT NULL),
+			COALESCE(shadow.single_block_object_key_main, ''),
+			COALESCE(shadow.consolidated_object_key_main, ''),
+			shadow.object_format,
+			shadow.byte_offset,
+			shadow.byte_length,
+			shadow.uncompressed_length,
+			(shadow.single_block_object_deleted_at IS NOT NULL)
+		FROM block_metadata bm
+		LEFT JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+		WHERE bm.id = $1
+			AND bm.tag = $2
+			AND bm.height = $3
+			AND bm.hash IS NOT DISTINCT FROM NULLIF($4, '')`
+	var canonical, skipped, fenced, retirementManifest, shadowExists, singleBlockDeleted bool
+	var activeKey, shadowSingleKey, shadowConsolidatedKey string
+	var activeFormat int32
+	var activeOffset, activeLength, activeUncompressed sql.NullInt64
+	var shadowFormat, shadowOffset, shadowLength, shadowUncompressed sql.NullInt64
+	if err := tx.QueryRowContext(
+		ctx,
+		query,
+		block.BlockMetadataID,
+		block.Tag,
+		block.Height,
+		block.Hash,
+	).Scan(
+		&canonical,
+		&activeKey,
+		&activeFormat,
+		&activeOffset,
+		&activeLength,
+		&activeUncompressed,
+		&skipped,
+		&fenced,
+		&retirementManifest,
+		&shadowExists,
+		&shadowSingleKey,
+		&shadowConsolidatedKey,
+		&shadowFormat,
+		&shadowOffset,
+		&shadowLength,
+		&shadowUncompressed,
+		&singleBlockDeleted,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return xerrors.Errorf("CSCB repair metadata identity changed for metadata_id=%d", block.BlockMetadataID)
+		}
+		return xerrors.Errorf("failed to validate CSCB repair promotion row metadata_id=%d: %w", block.BlockMetadataID, err)
+	}
+	if canonical != block.Canonical || skipped || fenced || retirementManifest || singleBlockDeleted {
+		return xerrors.Errorf("CSCB repair promotion row is blocked or changed for metadata_id=%d", block.BlockMetadataID)
+	}
+	oldLayout := activeKey == manifest.OldConsolidatedObjectKey &&
+		activeFormat == int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH) &&
+		nullableUint64(activeOffset) == block.OldByteOffset &&
+		nullableUint64(activeLength) == block.OldByteLength &&
+		nullableUint64(activeUncompressed) == block.OldUncompressedLength
+	singleLayout := activeKey == block.SingleBlockObjectKey &&
+		activeFormat == int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK) &&
+		!activeOffset.Valid && !activeLength.Valid && !activeUncompressed.Valid
+	newLayout := activeKey == newObjectKey &&
+		activeFormat == int32(placement.ObjectFormat) &&
+		nullableUint64(activeOffset) == placement.ByteOffset &&
+		nullableUint64(activeLength) == placement.ByteLength &&
+		nullableUint64(activeUncompressed) == placement.UncompressedLength
+	if !oldLayout && !singleLayout && !newLayout {
+		return xerrors.Errorf("CSCB repair active placement changed for metadata_id=%d", block.BlockMetadataID)
+	}
+	if !shadowExists {
+		if !singleLayout {
+			return xerrors.Errorf("CSCB repair shadow is missing for metadata_id=%d", block.BlockMetadataID)
+		}
+		return nil
+	}
+	if shadowSingleKey != block.SingleBlockObjectKey || !shadowFormat.Valid ||
+		shadowFormat.Int64 != int64(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH) {
+		return xerrors.Errorf("CSCB repair shadow identity changed for metadata_id=%d", block.BlockMetadataID)
+	}
+	oldShadow := shadowConsolidatedKey == manifest.OldConsolidatedObjectKey &&
+		nullableUint64(shadowOffset) == block.OldByteOffset &&
+		nullableUint64(shadowLength) == block.OldByteLength &&
+		nullableUint64(shadowUncompressed) == block.OldUncompressedLength
+	newShadow := shadowConsolidatedKey == newObjectKey &&
+		nullableUint64(shadowOffset) == placement.ByteOffset &&
+		nullableUint64(shadowLength) == placement.ByteLength &&
+		nullableUint64(shadowUncompressed) == placement.UncompressedLength
+	if !oldShadow && !newShadow {
+		return xerrors.Errorf("CSCB repair shadow placement changed for metadata_id=%d", block.BlockMetadataID)
+	}
+	return nil
+}
+
 func compareCandidateRows(current *Manifest, pinned *Manifest) error {
 	if current == nil || pinned == nil {
 		return xerrors.New("CSCB repair candidate is required")
@@ -1655,7 +1996,13 @@ func validateRebuiltMetadata(manifest *Manifest, objectKey string) error {
 	}
 	canonicalCount := uint64(0)
 	for _, block := range manifest.Blocks {
-		if !block.Canonical {
+		if block.Canonical {
+			canonicalCount++
+		}
+		if block.ActiveObjectKey != objectKey {
+			if block.Canonical {
+				return xerrors.Errorf("canonical row is not on the rebuilt CSCB: metadata_id=%d", block.BlockMetadataID)
+			}
 			if block.ActiveObjectKey != block.SingleBlockObjectKey ||
 				block.ActiveObjectFormat != int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK) ||
 				block.NewConsolidatedObjectKey != "" ||
@@ -1669,9 +2016,7 @@ func validateRebuiltMetadata(manifest *Manifest, objectKey string) error {
 			}
 			continue
 		}
-		canonicalCount++
-		if block.ActiveObjectKey != objectKey ||
-			block.NewConsolidatedObjectKey != objectKey ||
+		if block.NewConsolidatedObjectKey != objectKey ||
 			block.ActiveObjectFormat != int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH) ||
 			block.NewByteLength == 0 ||
 			block.NewUncompressedLength == 0 ||
@@ -1770,6 +2115,71 @@ func requireExactNewReferences(ctx context.Context, q queryer, manifest *Manifes
 		return xerrors.Errorf("rebuilt CSCB %q has %d references outside the pinned canonical row set", objectKey, references)
 	}
 	return nil
+}
+
+func requireExactRepairedReferences(ctx context.Context, q queryer, manifest *Manifest, objectKey string) error {
+	ids := make([]int64, 0, len(manifest.Blocks))
+	for _, block := range manifest.Blocks {
+		ids = append(ids, block.BlockMetadataID)
+	}
+	if len(ids) == 0 || len(ids) != len(manifest.Blocks) {
+		return xerrors.Errorf(
+			"rebuilt CSCB expected reference count mismatch: expected=%d actual=%d",
+			len(manifest.Blocks),
+			len(ids),
+		)
+	}
+	const query = `
+		SELECT
+			(SELECT COUNT(*)
+			 FROM block_metadata
+			 WHERE object_key_main = $1
+				AND object_key_main <> ''
+				AND id = ANY($2))
+			+
+			(SELECT COUNT(*)
+			 FROM block_consolidation_shadow
+			 WHERE consolidated_object_key_main = $1
+				AND consolidated_object_key_main <> ''
+				AND block_metadata_id = ANY($2)),
+			(SELECT COUNT(*)
+			 FROM block_metadata
+			 WHERE object_key_main = $1
+				AND object_key_main <> ''
+				AND NOT (id = ANY($2)))
+			+
+			(SELECT COUNT(*)
+			 FROM block_consolidation_shadow
+			 WHERE consolidated_object_key_main = $1
+				AND consolidated_object_key_main <> ''
+				AND NOT (block_metadata_id = ANY($2)))`
+	var expectedReferences, unexpectedReferences uint64
+	if err := q.QueryRowContext(ctx, query, objectKey, pq.Array(ids)).Scan(&expectedReferences, &unexpectedReferences); err != nil {
+		return xerrors.Errorf("failed to count rebuilt CSCB references: %w", err)
+	}
+	want := uint64(len(ids) * 2)
+	if expectedReferences != want || unexpectedReferences != 0 {
+		return xerrors.Errorf(
+			"rebuilt CSCB %q reference mismatch: expected=%d actual=%d unexpected=%d",
+			objectKey,
+			want,
+			expectedReferences,
+			unexpectedReferences,
+		)
+	}
+	return nil
+}
+
+func allRepairRowsOnObject(manifest *Manifest, objectKey string) bool {
+	if manifest == nil || objectKey == "" || len(manifest.Blocks) == 0 {
+		return false
+	}
+	for _, block := range manifest.Blocks {
+		if block.ActiveObjectKey != objectKey || block.NewConsolidatedObjectKey != objectKey {
+			return false
+		}
+	}
+	return true
 }
 
 func requireNoOldReferences(ctx context.Context, q queryer, objectKey string) error {

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -6,10 +6,14 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/storage/retirement"
+	storageutils "github.com/coinbase/chainstorage/internal/storage/utils"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
 const (
@@ -188,13 +192,22 @@ func (r *repairerImpl) inspectFencedCandidate(
 		if objectKeySHA256(block.SingleBlockObjectKey) != block.SingleBlockObjectKeySHA256 {
 			return nil, xerrors.Errorf("single-block object key audit digest changed at height %d", block.Height)
 		}
-		singleVersion, err := r.inspectSingleBlockObjectVersion(ctx, retirement.Candidate{
+		singleBlockCandidate := retirement.Candidate{
 			Bucket: manifest.Bucket,
 			Key:    block.SingleBlockObjectKey,
 			Height: block.Height,
 			Hash:   block.Hash,
 			Tag:    block.Tag,
-		})
+		}
+		var singleVersion ObjectVersion
+		if manifest.CanonicalBlockCount == 0 {
+			// A zero-canonical repair leaves active metadata on an unversioned
+			// single-block key. It is only safe when no historical version can
+			// become current later.
+			singleVersion, err = r.inspectExactObjectVersion(ctx, block.SingleBlockObjectKey)
+		} else {
+			singleVersion, err = r.inspectSingleBlockObjectVersion(ctx, singleBlockCandidate)
+		}
 		if err != nil {
 			return nil, xerrors.Errorf("failed to pin single-block object at height %d: %w", block.Height, err)
 		}
@@ -243,7 +256,7 @@ func (r *repairerImpl) Restore(ctx context.Context, repairID int64, progress Pro
 	}
 	for i := range manifest.Blocks {
 		block := &manifest.Blocks[i]
-		if err := r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+		if err := r.requirePinnedSingleBlockObjectVersionForManifest(ctx, manifest, block); err != nil {
 			return nil, xerrors.Errorf("single-block object changed before restore at height %d: %w", block.Height, err)
 		}
 		reportProgress(progress, "restore_object_revalidated", i+1, len(manifest.Blocks), block.Height)
@@ -261,6 +274,192 @@ func (r *repairerImpl) Get(ctx context.Context, repairID int64) (*Manifest, erro
 		return nil, err
 	}
 	return r.repository.Get(ctx, repairID)
+}
+
+func (r *repairerImpl) VisitPinnedPayloads(
+	ctx context.Context,
+	repairID int64,
+	progress Progress,
+	visit func(PinnedPayload) error,
+) error {
+	if err := r.validate(); err != nil {
+		return err
+	}
+	if visit == nil {
+		return xerrors.New("pinned payload visitor is required")
+	}
+	manifest, err := r.repository.Get(ctx, repairID)
+	if err != nil {
+		return err
+	}
+	if manifest.State != StatePrepared && manifest.State != StateRestored {
+		return xerrors.Errorf(
+			"CSCB repair must be prepared or restored before loading pinned payloads: id=%d state=%s",
+			manifest.ID,
+			manifest.State,
+		)
+	}
+	if manifest.CanonicalBlockCount == 0 {
+		return xerrors.Errorf("zero-canonical CSCB repair does not produce a rebuilt object: id=%d", manifest.ID)
+	}
+	if err := r.requirePinnedObjectVersion(
+		ctx,
+		manifest.OldConsolidatedObjectKey,
+		manifest.OldConsolidatedObjectVersion,
+	); err != nil {
+		return xerrors.Errorf("CSCB repair source changed before rebuild: %w", err)
+	}
+
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	for i := range manifest.Blocks {
+		block := &manifest.Blocks[i]
+		if err := r.requirePinnedSingleBlockObjectVersion(
+			ctx,
+			block.SingleBlockObjectKey,
+			block.SingleBlockObjectVersion,
+		); err != nil {
+			return xerrors.Errorf("single-block object changed before rebuild at height %d: %w", block.Height, err)
+		}
+		candidate := makePayloadCandidate(
+			manifest,
+			block,
+			manifest.OldConsolidatedObjectKey,
+			manifest.OldConsolidatedObjectVersion,
+		)
+		pinnedBlock, inspection, err := verifier.ReadSingleBlock(ctx, candidate)
+		if err != nil {
+			return xerrors.Errorf("failed to read pinned single-block payload at height %d: %w", block.Height, err)
+		}
+		if inspection.CanonicalSHA256 != block.PayloadSHA256 {
+			return xerrors.Errorf("single-block payload digest changed before rebuild at height %d", block.Height)
+		}
+		normalized := storageutils.CloneBlockWithoutStoragePlacement(pinnedBlock)
+		raw, err := (proto.MarshalOptions{Deterministic: true}).Marshal(normalized)
+		if err != nil {
+			return xerrors.Errorf("failed to marshal pinned block at height %d: %w", block.Height, err)
+		}
+		metadata, ok := proto.Clone(normalized.GetMetadata()).(*api.BlockMetadata)
+		if !ok || metadata == nil {
+			return xerrors.Errorf("pinned block metadata is missing at height %d", block.Height)
+		}
+		if err := visit(PinnedPayload{
+			BlockMetadataID: block.BlockMetadataID,
+			Metadata:        metadata,
+			RawBlockPayload: raw,
+		}); err != nil {
+			return xerrors.Errorf("failed to stage pinned payload at height %d: %w", block.Height, err)
+		}
+		reportProgress(progress, "pinned_payload_loaded", i+1, len(manifest.Blocks), block.Height)
+	}
+	return nil
+}
+
+func (r *repairerImpl) VerifyAndPromote(
+	ctx context.Context,
+	repairID int64,
+	objectKey string,
+	placements []RebuiltPlacement,
+	singleBlockObjectRetention time.Duration,
+	progress Progress,
+) (*Manifest, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	if singleBlockObjectRetention <= 0 {
+		return nil, xerrors.New("positive single-block object retention is required")
+	}
+	manifest, err := r.repository.Get(ctx, repairID)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.State == StateVerified || manifest.State == StateCompleted {
+		return manifest, nil
+	}
+	if manifest.State != StatePrepared && manifest.State != StateRestored {
+		return nil, xerrors.Errorf(
+			"CSCB repair must be prepared or restored before promotion: id=%d state=%s",
+			manifest.ID,
+			manifest.State,
+		)
+	}
+	if manifest.CanonicalBlockCount == 0 {
+		return nil, xerrors.Errorf("zero-canonical CSCB repair cannot promote a rebuilt object: id=%d", manifest.ID)
+	}
+	if objectKey == "" || objectKey == manifest.OldConsolidatedObjectKey {
+		return nil, xerrors.Errorf("rebuilt CSCB object key is invalid: %q", objectKey)
+	}
+	newVersion, err := r.inspectExactObjectVersion(ctx, objectKey)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to pin rebuilt CSCB object: %w", err)
+	}
+	placementsByID, err := validateRebuiltPlacements(manifest, objectKey, placements)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier := retirement.NewPinnedPayloadVerifier(r.store)
+	for i := range manifest.Blocks {
+		block := &manifest.Blocks[i]
+		if err := r.requirePinnedSingleBlockObjectVersion(
+			ctx,
+			block.SingleBlockObjectKey,
+			block.SingleBlockObjectVersion,
+		); err != nil {
+			return nil, xerrors.Errorf("single-block object changed during rebuild at height %d: %w", block.Height, err)
+		}
+		placement := placementsByID[block.BlockMetadataID]
+		candidate := retirement.Candidate{
+			Bucket:             manifest.Bucket,
+			Key:                block.SingleBlockObjectKey,
+			VersionID:          block.SingleBlockObjectVersion.VersionID,
+			Height:             block.Height,
+			Hash:               block.Hash,
+			ConsolidatedKey:    objectKey,
+			Tag:                block.Tag,
+			CSCBVersionID:      newVersion.VersionID,
+			ByteOffset:         placement.ByteOffset,
+			ByteLength:         placement.ByteLength,
+			UncompressedLength: placement.UncompressedLength,
+		}
+		singleInspection, err := verifier.InspectSingleBlock(ctx, candidate)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to re-read pinned single-block payload at height %d: %w", block.Height, err)
+		}
+		if singleInspection.CanonicalSHA256 != block.PayloadSHA256 {
+			return nil, xerrors.Errorf("single-block payload digest changed during rebuild at height %d", block.Height)
+		}
+		cleanInspection, err := verifier.InspectConsolidated(ctx, candidate)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to verify rebuilt CSCB payload at height %d: %w", block.Height, err)
+		}
+		if cleanInspection.HasStoragePlacement || cleanInspection.CanonicalSHA256 != block.PayloadSHA256 {
+			return nil, xerrors.Errorf("rebuilt CSCB payload is not storage-neutral and identical at height %d", block.Height)
+		}
+		reportProgress(progress, "rebuilt_payload_verified", i+1, len(manifest.Blocks), block.Height)
+	}
+	if err := r.requirePinnedObjectVersion(
+		ctx,
+		manifest.OldConsolidatedObjectKey,
+		manifest.OldConsolidatedObjectVersion,
+	); err != nil {
+		return nil, xerrors.Errorf("CSCB repair source changed before atomic promotion: %w", err)
+	}
+	if err := r.requirePinnedObjectVersion(ctx, objectKey, newVersion); err != nil {
+		return nil, xerrors.Errorf("rebuilt CSCB changed before atomic promotion: %w", err)
+	}
+	verified, err := r.repository.PromoteVerified(
+		ctx,
+		manifest.ID,
+		objectKey,
+		newVersion,
+		placements,
+		singleBlockObjectRetention,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to atomically promote verified CSCB repair: %w", err)
+	}
+	reportProgress(progress, "promoted_verified", len(verified.Blocks), len(verified.Blocks), verified.EndHeight-1)
+	return verified, nil
 }
 
 func (r *repairerImpl) VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error) {
@@ -289,7 +488,7 @@ func (r *repairerImpl) VerifyRebuilt(ctx context.Context, repairID int64, progre
 	verifiedCanonical := 0
 	for i := range manifest.Blocks {
 		block := &manifest.Blocks[i]
-		if err := r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+		if err := r.requirePinnedSingleBlockObjectVersionForManifest(ctx, manifest, block); err != nil {
 			return nil, xerrors.Errorf("single-block object changed during repair at height %d: %w", block.Height, err)
 		}
 		payload := makePayloadCandidate(manifest, block, newObjectKey, newVersion)
@@ -364,7 +563,7 @@ func (r *repairerImpl) Complete(ctx context.Context, repairID int64, progress Pr
 	verifier := retirement.NewPinnedPayloadVerifier(r.store)
 	for i := range manifest.Blocks {
 		block := &manifest.Blocks[i]
-		if err := r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion); err != nil {
+		if err := r.requirePinnedSingleBlockObjectVersionForManifest(ctx, manifest, block); err != nil {
 			return nil, xerrors.Errorf("single-block object changed before completion at height %d: %w", block.Height, err)
 		}
 		payload := makePayloadCandidate(manifest, block, manifest.NewConsolidatedObjectKey, manifest.NewConsolidatedObjectVersion)
@@ -375,7 +574,7 @@ func (r *repairerImpl) Complete(ctx context.Context, repairID int64, progress Pr
 		if singleInspection.CanonicalSHA256 != block.PayloadSHA256 {
 			return nil, xerrors.Errorf("single-block payload digest changed before completion at height %d", block.Height)
 		}
-		if block.Canonical {
+		if manifest.NewConsolidatedObjectKey != "" && block.ActiveObjectKey == manifest.NewConsolidatedObjectKey {
 			cleanInspection, err := verifier.InspectConsolidated(ctx, payload)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to verify rebuilt CSCB payload before completion at height %d: %w", block.Height, err)
@@ -522,6 +721,17 @@ func (r *repairerImpl) requirePinnedSingleBlockObjectVersion(ctx context.Context
 	return nil
 }
 
+func (r *repairerImpl) requirePinnedSingleBlockObjectVersionForManifest(
+	ctx context.Context,
+	manifest *Manifest,
+	block *Block,
+) error {
+	if manifest.CanonicalBlockCount == 0 {
+		return r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion)
+	}
+	return r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion)
+}
+
 func currentSingleBlockObjectVersion(topology retirement.ObjectVersionTopology) (ObjectVersion, error) {
 	if len(topology.Versions) == 0 || len(topology.DeleteMarkers) != 0 {
 		return ObjectVersion{}, xerrors.Errorf(
@@ -597,6 +807,45 @@ func rebuiltObjectKey(manifest *Manifest) (string, error) {
 		return "", xerrors.Errorf("rebuilt CSCB reused dirty object key %q", objectKey)
 	}
 	return objectKey, nil
+}
+
+func validateRebuiltPlacements(
+	manifest *Manifest,
+	objectKey string,
+	placements []RebuiltPlacement,
+) (map[int64]RebuiltPlacement, error) {
+	if manifest == nil || len(placements) != len(manifest.Blocks) {
+		return nil, xerrors.Errorf(
+			"rebuilt CSCB placement count mismatch: expected=%d actual=%d",
+			len(manifest.Blocks),
+			len(placements),
+		)
+	}
+	blocksByID := make(map[int64]Block, len(manifest.Blocks))
+	for _, block := range manifest.Blocks {
+		blocksByID[block.BlockMetadataID] = block
+	}
+	placementsByID := make(map[int64]RebuiltPlacement, len(placements))
+	for _, placement := range placements {
+		block, ok := blocksByID[placement.BlockMetadataID]
+		if !ok {
+			return nil, xerrors.Errorf("rebuilt CSCB returned unexpected metadata_id=%d", placement.BlockMetadataID)
+		}
+		if _, ok := placementsByID[placement.BlockMetadataID]; ok {
+			return nil, xerrors.Errorf("rebuilt CSCB returned duplicate metadata_id=%d", placement.BlockMetadataID)
+		}
+		if placement.Height != block.Height || placement.Hash != block.Hash ||
+			placement.ObjectFormat != api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH ||
+			placement.ByteLength == 0 || placement.UncompressedLength == 0 {
+			return nil, xerrors.Errorf(
+				"rebuilt CSCB placement is invalid for metadata_id=%d object=%q",
+				placement.BlockMetadataID,
+				objectKey,
+			)
+		}
+		placementsByID[placement.BlockMetadataID] = placement
+	}
+	return placementsByID, nil
 }
 
 func makePayloadCandidate(

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	completedOutcome                = "old_consolidated_object_retained_unreferenced"
-	alreadyCleanOutcome             = OutcomeAlreadyCleanStorageNeutral
-	maxSingleBlockVersionsToInspect = 10
+	completedOutcome    = "old_consolidated_object_retained_unreferenced"
+	alreadyCleanOutcome = OutcomeAlreadyCleanStorageNeutral
 )
 
 type repairerImpl struct {
@@ -489,47 +488,9 @@ func (r *repairerImpl) inspectSingleBlockObjectVersion(
 	if err != nil {
 		return ObjectVersion{}, xerrors.Errorf("unsafe single-block object topology: key=%q: %w", candidate.Key, err)
 	}
-	if len(topology.Versions) == 1 {
-		return current, nil
-	}
-	if len(topology.Versions) > maxSingleBlockVersionsToInspect {
-		return ObjectVersion{}, xerrors.Errorf(
-			"too many single-block object versions to safely inspect: key=%q count=%d max=%d",
-			candidate.Key,
-			len(topology.Versions),
-			maxSingleBlockVersionsToInspect,
-		)
-	}
-
-	// Retries historically created redundant single-block versions whose raw
-	// Solana JSON serialization can differ while representing the same block.
-	// Verify every immutable version through the semantic block digest before
-	// pinning the current one.
-	verifier := retirement.NewPinnedPayloadVerifier(r.store)
-	currentCandidate := candidate
-	currentCandidate.VersionID = current.VersionID
-	currentInspection, err := verifier.InspectSingleBlock(ctx, currentCandidate)
-	if err != nil {
-		return ObjectVersion{}, xerrors.Errorf("failed to read current single-block object version %q: %w", current.VersionID, err)
-	}
-	for _, version := range topology.Versions {
-		if version.VersionID == current.VersionID {
-			continue
-		}
-		historicalCandidate := candidate
-		historicalCandidate.VersionID = version.VersionID
-		historicalInspection, err := verifier.InspectSingleBlock(ctx, historicalCandidate)
-		if err != nil {
-			return ObjectVersion{}, xerrors.Errorf("failed to read historical single-block object version %q: %w", version.VersionID, err)
-		}
-		if historicalInspection.SemanticSHA256 != currentInspection.SemanticSHA256 {
-			return ObjectVersion{}, xerrors.Errorf(
-				"single-block object versions contain different semantic block payloads: current=%q historical=%q",
-				current.VersionID,
-				version.VersionID,
-			)
-		}
-	}
+	// Historical versions are not read by Chainstorage and are not repair
+	// inputs. The caller pins and verifies the current immutable version against
+	// the source CSCB before changing any metadata.
 	return current, nil
 }
 

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"strings"
 	"testing"
 	"time"
 
@@ -332,6 +333,122 @@ func TestRequirePinnedSingleBlockObjectVersionAllowsHistoricalDuplicateRemoval(t
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
 	require.NoError(t, repairer.requirePinnedSingleBlockObjectVersion(context.Background(), "single/1000.zstd", pinned))
+}
+
+func TestRestoreZeroCanonicalRepairRejectsHistoricalSingleBlockVersion(t *testing.T) {
+	manifest := completionManifest(t)
+	manifest.State = StatePrepared
+	repository := &phaseBoundaryRepository{manifest: manifest}
+	store := &completionObjectStore{topologies: map[string]retirement.ObjectVersionTopology{
+		manifest.OldConsolidatedObjectKey: {
+			Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.OldConsolidatedObjectVersion)},
+		},
+		manifest.Blocks[0].SingleBlockObjectKey: {
+			Versions: []retirement.ObjectVersion{
+				objectTopologyVersion(manifest.Blocks[0].SingleBlockObjectVersion),
+				{VersionID: "historical-version", ETag: "historical-etag", Bytes: 99},
+			},
+		},
+	}}
+
+	_, err := NewRepairer(repository, store, manifest.Bucket).Restore(context.Background(), manifest.ID, nil)
+	require.ErrorContains(t, err, "expected one data version and zero delete markers")
+	require.False(t, repository.restoreCalled)
+}
+
+func TestVisitPinnedPayloadsReadsPinnedCurrentVersionAndStripsStoragePlacement(t *testing.T) {
+	manifest := phaseBoundaryManifest(t, StatePrepared)
+	block := &manifest.Blocks[0]
+	rawBlock := &api.Block{Metadata: &api.BlockMetadata{
+		Tag:                block.Tag,
+		Height:             block.Height,
+		Hash:               block.Hash,
+		ObjectKeyMain:      block.SingleBlockObjectKey,
+		ObjectFormat:       api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_SINGLE_BLOCK,
+		ByteOffset:         10,
+		ByteLength:         20,
+		UncompressedLength: 30,
+	}}
+	normalized := storageutils.CloneBlockWithoutStoragePlacement(rawBlock)
+	normalizedPayload, err := (proto.MarshalOptions{Deterministic: true}).Marshal(normalized)
+	require.NoError(t, err)
+	digest := sha256.Sum256(normalizedPayload)
+	block.PayloadSHA256 = hex.EncodeToString(digest[:])
+	payload, err := proto.Marshal(rawBlock)
+	require.NoError(t, err)
+	compressed, err := storageutils.Compress(payload, api.Compression_GZIP)
+	require.NoError(t, err)
+	block.SingleBlockObjectVersion.Bytes = uint64(len(compressed))
+
+	repository := &phaseBoundaryRepository{manifest: manifest}
+	store := &completionObjectStore{
+		topologies: map[string]retirement.ObjectVersionTopology{
+			manifest.OldConsolidatedObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.OldConsolidatedObjectVersion)},
+			},
+			block.SingleBlockObjectKey: {
+				Versions: []retirement.ObjectVersion{
+					objectTopologyVersion(block.SingleBlockObjectVersion),
+					{VersionID: "historical-version", ETag: "historical-etag", Bytes: 99},
+				},
+			},
+		},
+		objects: map[string][]byte{block.SingleBlockObjectKey: compressed},
+	}
+
+	var pinned PinnedPayload
+	err = NewRepairer(repository, store, manifest.Bucket).VisitPinnedPayloads(
+		context.Background(),
+		manifest.ID,
+		nil,
+		func(payload PinnedPayload) error {
+			pinned = payload
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{block.SingleBlockObjectVersion.VersionID}, store.readVersionIDs)
+	require.Equal(t, block.BlockMetadataID, pinned.BlockMetadataID)
+	require.Equal(t, block.Tag, pinned.Metadata.GetTag())
+	require.Equal(t, block.Height, pinned.Metadata.GetHeight())
+	require.Equal(t, block.Hash, pinned.Metadata.GetHash())
+	var rebuilt api.Block
+	require.NoError(t, proto.Unmarshal(pinned.RawBlockPayload, &rebuilt))
+	require.False(t, storageutils.HasBlockStoragePlacement(&rebuilt))
+}
+
+func TestVisitPinnedPayloadsRejectsPersistedDigestMismatch(t *testing.T) {
+	manifest := phaseBoundaryManifest(t, StatePrepared)
+	block := &manifest.Blocks[0]
+	rawBlock := &api.Block{Metadata: &api.BlockMetadata{
+		Tag:    block.Tag,
+		Height: block.Height,
+		Hash:   block.Hash,
+	}}
+	payload, err := proto.Marshal(rawBlock)
+	require.NoError(t, err)
+	compressed, err := storageutils.Compress(payload, api.Compression_GZIP)
+	require.NoError(t, err)
+	block.SingleBlockObjectVersion.Bytes = uint64(len(compressed))
+	block.PayloadSHA256 = strings.Repeat("0", 64)
+
+	repository := &phaseBoundaryRepository{manifest: manifest}
+	store := &completionObjectStore{
+		topologies: map[string]retirement.ObjectVersionTopology{
+			manifest.OldConsolidatedObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(manifest.OldConsolidatedObjectVersion)},
+			},
+			block.SingleBlockObjectKey: {
+				Versions: []retirement.ObjectVersion{objectTopologyVersion(block.SingleBlockObjectVersion)},
+			},
+		},
+		objects: map[string][]byte{block.SingleBlockObjectKey: compressed},
+	}
+
+	err = NewRepairer(repository, store, manifest.Bucket).VisitPinnedPayloads(
+		context.Background(), manifest.ID, nil, func(PinnedPayload) error { return nil },
+	)
+	require.ErrorContains(t, err, "single-block payload digest changed before rebuild")
 }
 
 func TestRepairPhasesRejectSingleBlockTopologyDriftBeforeMutation(t *testing.T) {
@@ -913,8 +1030,9 @@ func (r *completionRepository) CompleteRetainingOldObject(
 
 type completionObjectStore struct {
 	retirement.ObjectStore
-	topologies map[string]retirement.ObjectVersionTopology
-	objects    map[string][]byte
+	topologies     map[string]retirement.ObjectVersionTopology
+	objects        map[string][]byte
+	readVersionIDs []string
 }
 
 func (s *completionObjectStore) ListObjectVersions(
@@ -929,8 +1047,9 @@ func (s *completionObjectStore) ReadObjectVersion(
 	_ context.Context,
 	_ string,
 	key string,
-	_ string,
+	versionID string,
 ) ([]byte, error) {
+	s.readVersionIDs = append(s.readVersionIDs, versionID)
 	return s.objects[key], nil
 }
 

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -228,10 +228,10 @@ func TestPrepareNextCompletesAlreadyCleanCSCBWithoutRestore(t *testing.T) {
 	require.True(t, repository.alreadyClean)
 }
 
-func TestInspectSingleBlockObjectVersionAllowsSemanticallyIdenticalDuplicateVersions(t *testing.T) {
+func TestInspectSingleBlockObjectVersionPinsCurrentWithoutReadingHistoricalPayloads(t *testing.T) {
 	candidate := singleBlockVersionCandidate()
 	currentPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","transactions":[]}`)
-	historicalPayload := singleBlockVersionPayload(t, candidate, "{\n  \"transactions\": [],\n  \"blockhash\": \"block-hash\"\n}")
+	historicalPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","transactions":["stale"]}`)
 	require.NotEqual(t, currentPayload, historicalPayload)
 	store := &versionedObjectStore{
 		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
@@ -252,7 +252,7 @@ func TestInspectSingleBlockObjectVersionAllowsSemanticallyIdenticalDuplicateVers
 		ETag:      "current-etag",
 		Bytes:     uint64(len(currentPayload)),
 	}, version)
-	require.Equal(t, []string{"current-version", "historical-version"}, store.readVersionIDs)
+	require.Empty(t, store.readVersionIDs)
 }
 
 func TestInspectSingleBlockObjectVersionDoesNotReadSingleVersionTwice(t *testing.T) {
@@ -270,9 +270,9 @@ func TestInspectSingleBlockObjectVersionDoesNotReadSingleVersionTwice(t *testing
 	require.Empty(t, store.readVersionIDs)
 }
 
-func TestInspectSingleBlockObjectVersionRejectsTooManyVersionsBeforeReading(t *testing.T) {
+func TestInspectSingleBlockObjectVersionAllowsManyImmutableVersionsWithoutReading(t *testing.T) {
 	candidate := singleBlockVersionCandidate()
-	versions := make([]retirement.ObjectVersion, maxSingleBlockVersionsToInspect+1)
+	versions := make([]retirement.ObjectVersion, 20)
 	for i := range versions {
 		versions[i] = retirement.ObjectVersion{
 			VersionID: fmt.Sprintf("version-%d", i),
@@ -286,29 +286,10 @@ func TestInspectSingleBlockObjectVersionRejectsTooManyVersionsBeforeReading(t *t
 	}
 	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
 
-	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
-	require.ErrorContains(t, err, "too many single-block object versions to safely inspect")
+	version, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
+	require.NoError(t, err)
+	require.Equal(t, "version-0", version.VersionID)
 	require.Empty(t, store.readVersionIDs)
-}
-
-func TestInspectSingleBlockObjectVersionRejectsDifferentDuplicatePayloads(t *testing.T) {
-	candidate := singleBlockVersionCandidate()
-	currentPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","value":1}`)
-	historicalPayload := singleBlockVersionPayload(t, candidate, `{"blockhash":"block-hash","value":2}`)
-	store := &versionedObjectStore{
-		topology: retirement.ObjectVersionTopology{Versions: []retirement.ObjectVersion{
-			{VersionID: "current-version", ETag: "current-etag", Bytes: uint64(len(currentPayload)), IsLatest: true},
-			{VersionID: "historical-version", ETag: "historical-etag", Bytes: uint64(len(historicalPayload))},
-		}},
-		objects: map[string][]byte{
-			"current-version":    currentPayload,
-			"historical-version": historicalPayload,
-		},
-	}
-	repairer := &repairerImpl{store: store, bucket: "repair-bucket"}
-
-	_, err := repairer.inspectSingleBlockObjectVersion(context.Background(), candidate)
-	require.ErrorContains(t, err, "versions contain different semantic block payloads")
 }
 
 func TestInspectSingleBlockObjectVersionRejectsDeleteMarker(t *testing.T) {

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -3,6 +3,8 @@ package cscbrepair
 import (
 	"context"
 	"time"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
 type (
@@ -14,6 +16,22 @@ type (
 		VersionID string
 		ETag      string
 		Bytes     uint64
+	}
+
+	PinnedPayload struct {
+		BlockMetadataID int64
+		Metadata        *api.BlockMetadata
+		RawBlockPayload []byte
+	}
+
+	RebuiltPlacement struct {
+		BlockMetadataID    int64
+		Height             uint64
+		Hash               string
+		ObjectFormat       api.BlockObjectFormat
+		ByteOffset         uint64
+		ByteLength         uint64
+		UncompressedLength uint64
 	}
 
 	Block struct {
@@ -82,6 +100,7 @@ type (
 		RestoreToSingleBlock(ctx context.Context, repairID int64) (*Manifest, error)
 		GetRebuilt(ctx context.Context, repairID int64) (*Manifest, error)
 		RecordVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion) (*Manifest, error)
+		PromoteVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion, placements []RebuiltPlacement, singleBlockObjectRetention time.Duration) (*Manifest, error)
 		CompleteRetainingOldObject(ctx context.Context, repairID int64, outcome string) (*Manifest, error)
 	}
 
@@ -92,6 +111,8 @@ type (
 		Restore(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
 		Get(ctx context.Context, repairID int64) (*Manifest, error)
 		VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
+		VisitPinnedPayloads(ctx context.Context, repairID int64, progress Progress, visit func(PinnedPayload) error) error
+		VerifyAndPromote(ctx context.Context, repairID int64, objectKey string, placements []RebuiltPlacement, singleBlockObjectRetention time.Duration, progress Progress) (*Manifest, error)
 		Complete(ctx context.Context, repairID int64, progress Progress) (*Manifest, error)
 	}
 )

--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -32,6 +32,7 @@ type (
 	}
 
 	PinnedPayloadVerifier interface {
+		ReadSingleBlock(ctx context.Context, candidate Candidate) (*api.Block, PinnedPayloadInspection, error)
 		InspectSingleBlock(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error)
 		InspectConsolidated(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error)
 	}
@@ -75,31 +76,39 @@ func (v *payloadVerifier) Verify(ctx context.Context, candidate Candidate) (stri
 }
 
 func (v *payloadVerifier) InspectSingleBlock(ctx context.Context, candidate Candidate) (PinnedPayloadInspection, error) {
+	_, inspection, err := v.ReadSingleBlock(ctx, candidate)
+	return inspection, err
+}
+
+func (v *payloadVerifier) ReadSingleBlock(
+	ctx context.Context,
+	candidate Candidate,
+) (*api.Block, PinnedPayloadInspection, error) {
 	singleBlockCompressed, err := v.store.ReadObjectVersion(ctx, candidate.Bucket, candidate.Key, candidate.VersionID)
 	if err != nil {
-		return PinnedPayloadInspection{}, err
+		return nil, PinnedPayloadInspection{}, err
 	}
 	singleBlockPayload, err := storageutils.Decompress(singleBlockCompressed, storageutils.GetCompressionType(candidate.Key))
 	if err != nil {
-		return PinnedPayloadInspection{}, xerrors.Errorf("failed to decompress pinned single-block object: %w", err)
+		return nil, PinnedPayloadInspection{}, xerrors.Errorf("failed to decompress pinned single-block object: %w", err)
 	}
 	var singleBlockBlock api.Block
 	if err := proto.Unmarshal(singleBlockPayload, &singleBlockBlock); err != nil {
-		return PinnedPayloadInspection{}, xerrors.Errorf("failed to parse pinned single-block block payload: %w", err)
+		return nil, PinnedPayloadInspection{}, xerrors.Errorf("failed to parse pinned single-block block payload: %w", err)
 	}
 	if err := validatePayloadIdentity(&singleBlockBlock, candidate); err != nil {
-		return PinnedPayloadInspection{}, xerrors.Errorf("pinned single-block block identity mismatch: %w", err)
+		return nil, PinnedPayloadInspection{}, xerrors.Errorf("pinned single-block block identity mismatch: %w", err)
 	}
 	normalized := storageutils.CloneBlockWithoutStoragePlacement(&singleBlockBlock)
 	digest, err := canonicalBlockDigest(normalized)
 	if err != nil {
-		return PinnedPayloadInspection{}, err
+		return nil, PinnedPayloadInspection{}, err
 	}
 	semanticDigest, err := semanticBlockDigest(normalized)
 	if err != nil {
-		return PinnedPayloadInspection{}, err
+		return nil, PinnedPayloadInspection{}, err
 	}
-	return PinnedPayloadInspection{
+	return &singleBlockBlock, PinnedPayloadInspection{
 		CanonicalSHA256:     digest,
 		SemanticSHA256:      semanticDigest,
 		HasStoragePlacement: storageutils.HasBlockStoragePlacement(&singleBlockBlock),

--- a/internal/workflow/activity/batch_consolidator.go
+++ b/internal/workflow/activity/batch_consolidator.go
@@ -379,39 +379,49 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 	)
 	logger.Info("resuming CSCB repair")
 
-	if manifest.State == cscbrepair.StatePrepared {
+	if manifest.State == cscbrepair.StatePrepared && manifest.CanonicalBlockCount == 0 {
 		manifest, err = repairer.Restore(ctx, manifest.ID, progress)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore CSCB repair to single-block metadata: %w", err)
 		}
 	}
-	if manifest.State == cscbrepair.StateRestored && manifest.CanonicalBlockCount > 0 {
-		expectedRecords := make(map[int64]cscbrepair.Block, manifest.CanonicalBlockCount)
-		for _, block := range manifest.Blocks {
-			if block.Canonical {
-				expectedRecords[block.BlockMetadataID] = block
+	if (manifest.State == cscbrepair.StatePrepared || manifest.State == cscbrepair.StateRestored) &&
+		manifest.CanonicalBlockCount > 0 {
+		payloads, cleanup, err := a.buildPinnedRepairPayloads(ctx, repairer, manifest, progress)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanup()
+		uploadCtx := blobstorage.WithConsolidatedUploadProgress(ctx, func(stage string, details ...any) {
+			heartbeatDetails := append([]any{"batch_consolidator.repair." + stage}, details...)
+			sdkactivity.RecordHeartbeat(ctx, heartbeatDetails...)
+		})
+		objectKey, uploadedPlacements, err := a.blobStorage.UploadConsolidated(uploadCtx, payloads)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to upload rebuilt normalized CSCB: %w", err)
+		}
+		placements := make([]cscbrepair.RebuiltPlacement, len(uploadedPlacements))
+		for i, placement := range uploadedPlacements {
+			placements[i] = cscbrepair.RebuiltPlacement{
+				BlockMetadataID:    placement.MetadataID,
+				Height:             placement.Height,
+				Hash:               placement.Hash,
+				ObjectFormat:       placement.ObjectFormat,
+				ByteOffset:         placement.ByteOffset,
+				ByteLength:         placement.ByteLength,
+				UncompressedLength: placement.UncompressedLength,
 			}
 		}
-		normalResponse, err := a.executeShadowDualWriteWithExpected(ctx, &BatchConsolidatorRequest{
-			Mode:        config.ConsolidationModeHistoricalBackfill,
-			Tag:         manifest.Tag,
-			StartHeight: manifest.StartHeight,
-			EndHeight:   manifest.EndHeight,
-			MaxBlocks:   request.MaxBlocks,
-		}, expectedRecords)
+		manifest, err = repairer.VerifyAndPromote(
+			ctx,
+			manifest.ID,
+			objectKey,
+			placements,
+			a.config.AWS.Storage.Consolidation.SingleBlockObjectRetention,
+			progress,
+		)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to rebuild normalized CSCB: %w", err)
-		}
-		if normalResponse.ScannedBlocks != 0 && normalResponse.ScannedBlocks != manifest.CanonicalBlockCount {
-			return nil, xerrors.Errorf(
-				"CSCB repair rebuilt unexpected canonical row count: expected=%d actual=%d",
-				manifest.CanonicalBlockCount,
-				normalResponse.ScannedBlocks,
-			)
-		}
-		manifest, err = repairer.VerifyRebuilt(ctx, manifest.ID, progress)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to verify rebuilt CSCB: %w", err)
+			return nil, xerrors.Errorf("failed to verify and atomically promote rebuilt CSCB: %w", err)
 		}
 	}
 	if manifest.State == cscbrepair.StateRestored || manifest.State == cscbrepair.StateVerified {
@@ -430,9 +440,13 @@ func (a *BatchConsolidator) executeRepairExistingCSCB(
 		zap.String("new_object_key", manifest.NewConsolidatedObjectKey),
 		zap.String("old_object_outcome", manifest.Outcome),
 	)
-	consolidatedBlocks := manifest.CanonicalBlockCount
-	promotedBlocks := manifest.CanonicalBlockCount
+	consolidatedBlocks := manifest.TotalBlockCount
+	promotedBlocks := manifest.TotalBlockCount
 	objectKey := manifest.NewConsolidatedObjectKey
+	if objectKey == "" {
+		consolidatedBlocks = 0
+		promotedBlocks = 0
+	}
 	if manifest.Outcome == cscbrepair.OutcomeAlreadyCleanStorageNeutral {
 		consolidatedBlocks = 0
 		promotedBlocks = 0
@@ -888,6 +902,53 @@ func promotionSafeEndHeight(latestHeight uint64, safePromotionLag uint64) (uint6
 		return safeHeight, safeHeight, true
 	}
 	return safeHeight + 1, safeHeight, true
+}
+
+func (a *BatchConsolidator) buildPinnedRepairPayloads(
+	ctx context.Context,
+	repairer cscbrepair.Repairer,
+	manifest *cscbrepair.Manifest,
+	progress cscbrepair.Progress,
+) ([]blobstorage.ConsolidatedBlockPayload, func(), error) {
+	payloads := make([]blobstorage.ConsolidatedBlockPayload, 0, manifest.TotalBlockCount)
+	tempFiles := make([]string, 0, manifest.TotalBlockCount)
+	cleanup := func() {
+		for _, path := range tempFiles {
+			if path != "" {
+				_ = os.Remove(path)
+			}
+		}
+	}
+	err := repairer.VisitPinnedPayloads(ctx, manifest.ID, progress, func(pinned cscbrepair.PinnedPayload) error {
+		source, path, length, err := writeRawBlockPayloadTempFile(
+			pinned.RawBlockPayload,
+			a.config.AWS.Storage.Consolidation.LocalSpillDir,
+		)
+		if err != nil {
+			return err
+		}
+		tempFiles = append(tempFiles, path)
+		payloads = append(payloads, blobstorage.ConsolidatedBlockPayload{
+			Metadata:           pinned.Metadata,
+			MetadataID:         pinned.BlockMetadataID,
+			RawBlockPayload:    source,
+			UncompressedLength: length,
+		})
+		return nil
+	})
+	if err != nil {
+		cleanup()
+		return nil, nil, xerrors.Errorf("failed to build normalized CSCB from pinned versions: %w", err)
+	}
+	if uint64(len(payloads)) != manifest.TotalBlockCount {
+		cleanup()
+		return nil, nil, xerrors.Errorf(
+			"CSCB repair pinned payload count mismatch: expected=%d actual=%d",
+			manifest.TotalBlockCount,
+			len(payloads),
+		)
+	}
+	return payloads, cleanup, nil
 }
 
 func (a *BatchConsolidator) buildPayloads(

--- a/internal/workflow/activity/batch_consolidator_repair_test.go
+++ b/internal/workflow/activity/batch_consolidator_repair_test.go
@@ -2,16 +2,20 @@ package activity
 
 import (
 	"context"
+	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/storage/cscbrepair"
-	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	storageutils "github.com/coinbase/chainstorage/internal/storage/utils"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
-func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVerifies() {
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRebuildsPinnedPayloadsAndPromotesAtomically() {
 	require := testutil.Require(s.T())
 	records, blocks := makeConsolidatorFixture(1, 1000)
 	request := &BatchConsolidatorRequest{
@@ -25,31 +29,24 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVe
 	oldKey := "consolidated/dirty.cscb.zstd"
 	newKey := "consolidated/clean.cscb.zstd"
 	prepared := repairActivityManifest(cscbrepair.StatePrepared, oldKey, "")
-	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
 	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
 	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
 	fake := &repairActivityFake{
 		prepared:  prepared,
-		restored:  restored,
 		verified:  verified,
 		completed: completed,
+		pinnedPayloads: []cscbrepair.PinnedPayload{{
+			BlockMetadataID: records[0].ID,
+			Metadata:        records[0].Metadata,
+			RawBlockPayload: marshalRepairBlock(s.T(), blocks[0]),
+		}},
 	}
 	s.batchConsolidator.repairer = fake
 	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
 
-	gomock.InOrder(
-		s.metaStorage.EXPECT().
-			GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
-			Return(records, nil),
-		s.blobStorage.EXPECT().Download(gomock.Any(), records[0].Metadata).Return(blocks[0], nil),
-		s.blobStorage.EXPECT().
-			UploadConsolidated(gomock.Any(), gomock.Any()).
-			Return(newKey, makeConsolidatorPlacements(records), nil),
-		s.metaStorage.EXPECT().PersistBlockConsolidationShadows(gomock.Any(), gomock.Any()).Return(nil),
-		s.metaStorage.EXPECT().
-			PromoteBlockConsolidationShadows(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100), config.DefaultSingleBlockObjectRetention).
-			Return(&metastorage.ConsolidationPromotionResult{Blocks: 1}, nil),
-	)
+	s.blobStorage.EXPECT().
+		UploadConsolidated(gomock.Any(), gomock.Any()).
+		Return(newKey, makeConsolidatorPlacements(records), nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), request)
 	require.NoError(err)
@@ -63,22 +60,16 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRestoresRebuildsAndVe
 		OldObjectKey:       oldKey,
 		RepairedObjects:    1,
 	}, response)
-	require.Equal([]string{"prepare", "restore", "verify", "complete"}, fake.calls)
+	require.Equal([]string{"prepare", "visit_pinned", "verify_promote", "complete"}, fake.calls)
 	require.Equal(testRepairExecutionKey, fake.executionKey)
 }
 
-func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRejectsNonExactRebuildBeforeUpload() {
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRejectsMissingPinnedPayloadBeforeUpload() {
 	require := testutil.Require(s.T())
-	records, _ := makeConsolidatorFixture(1, 1000)
 	oldKey := "consolidated/dirty.cscb.zstd"
-	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
-	restored.Blocks[0].BlockMetadataID = 999
-	fake := &repairActivityFake{prepared: restored}
+	prepared := repairActivityManifest(cscbrepair.StatePrepared, oldKey, "")
+	fake := &repairActivityFake{prepared: prepared}
 	s.batchConsolidator.repairer = fake
-
-	s.metaStorage.EXPECT().
-		GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
-		Return(records, nil)
 
 	_, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
 		Mode:               config.ConsolidationModeRepairExistingCSCB,
@@ -88,28 +79,34 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRejectsNonExactRebuil
 		MaxBlocks:          100,
 		RepairExecutionKey: testRepairExecutionKey,
 	})
-	require.ErrorContains(err, "unexpected metadata_id=10")
-	require.Equal([]string{"prepare"}, fake.calls)
+	require.ErrorContains(err, "pinned payload count mismatch")
+	require.Equal([]string{"prepare", "visit_pinned"}, fake.calls)
 }
 
-func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBResumesAfterShadowsPersisted() {
+func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBResumesRestoredManifestWithPinnedPayload() {
 	require := testutil.Require(s.T())
+	records, blocks := makeConsolidatorFixture(1, 1000)
 	oldKey := "consolidated/dirty.cscb.zstd"
 	newKey := "consolidated/clean.cscb.zstd"
 	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
 	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
 	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
-	fake := &repairActivityFake{prepared: restored, verified: verified, completed: completed}
+	fake := &repairActivityFake{
+		prepared:  restored,
+		verified:  verified,
+		completed: completed,
+		pinnedPayloads: []cscbrepair.PinnedPayload{{
+			BlockMetadataID: records[0].ID,
+			Metadata:        records[0].Metadata,
+			RawBlockPayload: marshalRepairBlock(s.T(), blocks[0]),
+		}},
+	}
 	s.batchConsolidator.repairer = fake
+	s.batchConsolidator.config.AWS.Storage.Consolidation.LocalSpillDir = s.T().TempDir()
 
-	gomock.InOrder(
-		s.metaStorage.EXPECT().
-			GetBlocksMissingConsolidationShadow(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100)).
-			Return(nil, nil),
-		s.metaStorage.EXPECT().
-			PromoteBlockConsolidationShadows(gomock.Any(), uint32(2), uint64(1000), uint64(1001), uint64(100), config.DefaultSingleBlockObjectRetention).
-			Return(&metastorage.ConsolidationPromotionResult{Blocks: 1}, nil),
-	)
+	s.blobStorage.EXPECT().
+		UploadConsolidated(gomock.Any(), gomock.Any()).
+		Return(newKey, makeConsolidatorPlacements(records), nil)
 
 	response, err := s.batchConsolidator.Execute(s.env.BackgroundContext(), &BatchConsolidatorRequest{
 		Mode:               config.ConsolidationModeRepairExistingCSCB,
@@ -121,7 +118,7 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBResumesAfterShadowsPe
 	})
 	require.NoError(err)
 	require.Equal(uint64(1), response.RepairedObjects)
-	require.Equal([]string{"prepare", "verify", "complete"}, fake.calls)
+	require.Equal([]string{"prepare", "visit_pinned", "verify_promote", "complete"}, fake.calls)
 }
 
 func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBCompletesAllNonCanonicalObjectWithoutRebuild() {
@@ -250,6 +247,7 @@ type repairActivityFake struct {
 	objectKey           string
 	candidateObjectKeys []string
 	candidateLimit      int
+	pinnedPayloads      []cscbrepair.PinnedPayload
 }
 
 func (f *repairActivityFake) PrepareNext(_ context.Context, executionKey string, _ uint32, _ uint64, _ uint64, _ uint64, _ cscbrepair.Progress) (*cscbrepair.Manifest, error) {
@@ -280,9 +278,43 @@ func (f *repairActivityFake) VerifyRebuilt(context.Context, int64, cscbrepair.Pr
 	return f.verified, nil
 }
 
+func (f *repairActivityFake) VisitPinnedPayloads(
+	_ context.Context,
+	_ int64,
+	_ cscbrepair.Progress,
+	visit func(cscbrepair.PinnedPayload) error,
+) error {
+	f.calls = append(f.calls, "visit_pinned")
+	for _, payload := range f.pinnedPayloads {
+		if err := visit(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *repairActivityFake) VerifyAndPromote(
+	context.Context,
+	int64,
+	string,
+	[]cscbrepair.RebuiltPlacement,
+	time.Duration,
+	cscbrepair.Progress,
+) (*cscbrepair.Manifest, error) {
+	f.calls = append(f.calls, "verify_promote")
+	return f.verified, nil
+}
+
 func (f *repairActivityFake) Complete(context.Context, int64, cscbrepair.Progress) (*cscbrepair.Manifest, error) {
 	f.calls = append(f.calls, "complete")
 	return f.completed, nil
 }
 
 const testRepairExecutionKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func marshalRepairBlock(t *testing.T, block *api.Block) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(storageutils.CloneBlockWithoutStoragePlacement(block))
+	testutil.Require(t).NoError(err)
+	return raw
+}


### PR DESCRIPTION
## Summary

- pin the current immutable single-block VersionID and compare it semantically with the active dirty CSCB before rebuilding
- rebuild a storage-neutral, content-addressed CSCB directly from the exact pinned current payloads while the dirty CSCB remains active
- verify every rebuilt placement and payload, then atomically repoint all affected PostgreSQL rows and shadows in one transaction
- start a fresh 72-hour single-block retention clock at atomic promotion and retain the old dirty CSCB as an unreferenced object
- keep zero-canonical repairs fail-closed unless each single-block key has exactly one data version and zero delete markers

## Why

After deploying `92a4192`, `workflow.batch_consolidator/repair_existing_cscb_431572000_431647000_p20_r2_20260719T1232Z` failed because historical S3 versions can contain stale Solana payloads. At height `431634001`, the current version and active CSCB read were byte-for-byte identical after metadata overlay (16,110,309 bytes, SHA-256 `e23fa28bf99c665cf30a9e32d7871e14aa4bdff490723dcc4db53b29fb20bbaf`), while an older S3 version differed.

The prior restore-first flow would expose an unversioned single-block key before rebuilding. This PR keeps the dirty CSCB active until the clean replacement has been fully uploaded and verified, then performs the metadata transition atomically.

Historical single-block versions are not read or deleted by this change. Retirement remains fail-closed for multi-version keys until a separate manifest-backed all-version cleanup is implemented. No production S3, database, or workflow mutation is performed by this PR.

## Verification

- `TEST_TYPE=unit GOCACHE=/tmp/codex-chainstorage-go-cache go test ./... -count=1`
- `go test -race ./internal/storage/cscbrepair ./internal/storage/retirement ./internal/workflow/activity -run 'TestBatchConsolidatorTestSuite/TestRepairExistingCSCB|TestVisitPinnedPayloads|TestRestoreZeroCanonical|TestIntegrationCSCBRepairFullLifecycle' -count=1`
- `go vet ./internal/storage/cscbrepair ./internal/storage/retirement ./internal/workflow/activity`
- `CI=1 make integration TARGET=internal/storage/cscbrepair TEST_FILTER=TestIntegrationCSCBRepairFullLifecycle` against local Docker PostgreSQL and LocalStack
- `git diff --check`

Linear: https://linear.app/cipherowl/issue/INF-1133
