### PR TITLE
fix(INF-1133): complete CSCB repair promotion atomically

### DIFF
--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -1,6 +1,7 @@
 package cscbrepair_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -207,10 +208,65 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 
 	repairer := cscbrepair.NewRepairer(repository, store, bucket)
 	executionKey := repairSHA256(fmt.Sprintf("repair-main-%d", unique))
-	manifest, err := repairer.PrepareObject(ctx, executionKey, tag, height, height+1, 1, dirtyKey, nil)
+
+	// A writer that acquired the upload guard before repair preparation must
+	// finish its S3 PUT before the repair can fence and pin the current version.
+	preFenceGuard, err := meta.AcquireSingleBlockUploadGuard(ctx, tag, height, block.Metadata.Hash)
 	require.NoError(err)
+	require.False(preFenceGuard.RetirementFenced())
+	oldCurrentSingleBlockVersion := currentSingleBlockVersion
+	guardedPayload, err := store.ReadObjectVersion(ctx, bucket, singleBlockKey, oldCurrentSingleBlockVersion.VersionID)
+	require.NoError(err)
+	type prepareResult struct {
+		manifest *cscbrepair.Manifest
+		err      error
+	}
+	prepared := make(chan prepareResult, 1)
+	go func() {
+		preparedManifest, prepareErr := repairer.PrepareObject(
+			ctx,
+			executionKey,
+			tag,
+			height,
+			height+1,
+			1,
+			dirtyKey,
+			nil,
+		)
+		prepared <- prepareResult{manifest: preparedManifest, err: prepareErr}
+	}()
+	select {
+	case result := <-prepared:
+		require.Failf("repair preparation bypassed in-flight upload guard", "result=%+v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+	guardedPut, err := rawS3.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(singleBlockKey),
+		Body:   bytes.NewReader(guardedPayload),
+	})
+	require.NoError(err)
+	require.NotNil(guardedPut.VersionId)
+	require.NoError(preFenceGuard.Release())
+	preparedResult := <-prepared
+	require.NoError(preparedResult.err)
+	manifest := preparedResult.manifest
 	require.NotNil(manifest)
 	repairID = manifest.ID
+	postWriterTopology, err := store.ListObjectVersions(ctx, bucket, singleBlockKey)
+	require.NoError(err)
+	for _, version := range postWriterTopology.Versions {
+		if version.VersionID == aws.ToString(guardedPut.VersionId) {
+			currentSingleBlockVersion = version
+		}
+	}
+	require.Equal(aws.ToString(guardedPut.VersionId), currentSingleBlockVersion.VersionID)
+	_, err = rawS3.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket:    aws.String(bucket),
+		Key:       aws.String(singleBlockKey),
+		VersionId: aws.String(oldCurrentSingleBlockVersion.VersionID),
+	})
+	require.NoError(err)
 	require.Equal(cscbrepair.StatePrepared, manifest.State)
 	require.Equal(dirtyKey, manifest.OldConsolidatedObjectKey)
 	require.Len(manifest.Blocks, 1)
@@ -334,22 +390,27 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 		UncompressedLength: cleanPlacement.UncompressedLength,
 	}}, 72*time.Hour, nil)
 	require.NoError(err)
-	require.Equal(cscbrepair.StateVerified, manifest.State)
+	require.Equal(cscbrepair.StateCompleted, manifest.State)
 	require.Equal(cleanKey, manifest.NewConsolidatedObjectKey)
 	require.NotZero(manifest.NewConsolidatedObjectVersion.Bytes)
 	require.NotNil(manifest.RestoredAt)
 	require.NotNil(manifest.VerifiedAt)
+	require.NotNil(manifest.CompletedAt)
+	require.Equal("old_consolidated_object_retained_unreferenced", manifest.Outcome)
 	var retentionStartedAt, singleBlockDeleteAfter time.Time
 	require.NoError(db.QueryRowContext(ctx, `
 		SELECT single_block_retention_started_at, single_block_delete_after
 		FROM block_consolidation_shadow
 		WHERE block_metadata_id = $1`, blockMetadataID).Scan(&retentionStartedAt, &singleBlockDeleteAfter))
 	require.False(retentionStartedAt.Before(*manifest.RestoredAt))
-	require.WithinDuration(retentionStartedAt.Add(72*time.Hour), singleBlockDeleteAfter, time.Microsecond)
+	require.WithinDuration(retentionStartedAt.Add(73*time.Hour), singleBlockDeleteAfter, time.Microsecond)
 	activeAfterPromotion, err := meta.GetBlockByHeight(ctx, tag, height)
 	require.NoError(err)
 	require.Equal(cleanKey, activeAfterPromotion.ObjectKeyMain)
 	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, activeAfterPromotion.ObjectFormat)
+	pendingAfterPromotion, err := repository.FindPending(ctx, tag)
+	require.NoError(err)
+	require.Nil(pendingAfterPromotion, "rollback must not resume a mixed placement after atomic promotion")
 
 	manifest, err = repairer.Complete(ctx, manifest.ID, nil)
 	require.NoError(err)

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -25,6 +25,8 @@ const manifestColumns = `
 	outcome, prepared_at, restored_at, verified_at,
 	completed_at`
 
+const repairPromotionRetentionCommitGrace = time.Hour
+
 type (
 	PostgresRepository struct {
 		db *sql.DB
@@ -1067,7 +1069,7 @@ func (r *PostgresRepository) RecordVerified(
 	return verified, nil
 }
 
-func (r *PostgresRepository) PromoteVerified(
+func (r *PostgresRepository) PromoteCompleted(
 	ctx context.Context,
 	repairID int64,
 	objectKey string,
@@ -1094,10 +1096,10 @@ func (r *PostgresRepository) PromoteVerified(
 	if err != nil {
 		return nil, err
 	}
-	if manifest.State == StateVerified || manifest.State == StateCompleted {
+	if manifest.State == StateCompleted {
 		if manifest.NewConsolidatedObjectKey != objectKey ||
 			manifest.NewConsolidatedObjectVersion != object {
-			return nil, xerrors.Errorf("verified CSCB repair identity changed for repair id %d", manifest.ID)
+			return nil, xerrors.Errorf("completed CSCB repair identity changed for repair id %d", manifest.ID)
 		}
 		if err := tx.Commit(); err != nil {
 			return nil, xerrors.Errorf("failed to commit idempotent atomic CSCB repair promotion: %w", err)
@@ -1145,7 +1147,7 @@ func (r *PostgresRepository) PromoteVerified(
 		manifest.State = StateRestored
 		manifest.RestoredAt = &promotionTime
 	}
-	deleteAfter := promotionTime.Add(singleBlockObjectRetention)
+	deleteAfter := promotionTime.Add(singleBlockObjectRetention + repairPromotionRetentionCommitGrace)
 
 	for _, block := range manifest.Blocks {
 		placement := placementsByID[block.BlockMetadataID]
@@ -1268,20 +1270,42 @@ func (r *PostgresRepository) PromoteVerified(
 	if err := requireRowsAffected(result, 1, "mark atomically promoted CSCB repair verified"); err != nil {
 		return nil, err
 	}
-	verified, err := loadManifest(ctx, tx, manifest.ID, false)
+	const markCompleted = `
+		UPDATE cscb_repair_manifest
+		SET state = $2,
+			outcome = $3,
+			completed_at = $4,
+			updated_at = $4
+		WHERE id = $1 AND state = $5`
+	result, err = tx.ExecContext(
+		ctx,
+		markCompleted,
+		manifest.ID,
+		StateCompleted,
+		completedOutcome,
+		promotionTime,
+		StateVerified,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to complete atomically promoted CSCB repair: %w", err)
+	}
+	if err := requireRowsAffected(result, 1, "complete atomically promoted CSCB repair"); err != nil {
+		return nil, err
+	}
+	completed, err := loadManifest(ctx, tx, manifest.ID, false)
 	if err != nil {
 		return nil, err
 	}
-	if err := loadRebuiltBlocks(ctx, tx, verified); err != nil {
+	if err := loadRebuiltBlocks(ctx, tx, completed); err != nil {
 		return nil, err
 	}
-	if err := validateRebuiltMetadata(verified, objectKey); err != nil {
+	if err := validateRebuiltMetadata(completed, objectKey); err != nil {
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, xerrors.Errorf("failed to commit atomic CSCB repair promotion: %w", err)
 	}
-	return verified, nil
+	return completed, nil
 }
 
 func (r *PostgresRepository) CompleteRetainingOldObject(

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -447,7 +447,7 @@ func (r *repairerImpl) VerifyAndPromote(
 	if err := r.requirePinnedObjectVersion(ctx, objectKey, newVersion); err != nil {
 		return nil, xerrors.Errorf("rebuilt CSCB changed before atomic promotion: %w", err)
 	}
-	verified, err := r.repository.PromoteVerified(
+	completed, err := r.repository.PromoteCompleted(
 		ctx,
 		manifest.ID,
 		objectKey,
@@ -456,10 +456,10 @@ func (r *repairerImpl) VerifyAndPromote(
 		singleBlockObjectRetention,
 	)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to atomically promote verified CSCB repair: %w", err)
+		return nil, xerrors.Errorf("failed to atomically promote and complete CSCB repair: %w", err)
 	}
-	reportProgress(progress, "promoted_verified", len(verified.Blocks), len(verified.Blocks), verified.EndHeight-1)
-	return verified, nil
+	reportProgress(progress, "promoted_completed", len(completed.Blocks), len(completed.Blocks), completed.EndHeight-1)
+	return completed, nil
 }
 
 func (r *repairerImpl) VerifyRebuilt(ctx context.Context, repairID int64, progress Progress) (*Manifest, error) {
@@ -723,12 +723,9 @@ func (r *repairerImpl) requirePinnedSingleBlockObjectVersion(ctx context.Context
 
 func (r *repairerImpl) requirePinnedSingleBlockObjectVersionForManifest(
 	ctx context.Context,
-	manifest *Manifest,
+	_ *Manifest,
 	block *Block,
 ) error {
-	if manifest.CanonicalBlockCount == 0 {
-		return r.requirePinnedObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion)
-	}
 	return r.requirePinnedSingleBlockObjectVersion(ctx, block.SingleBlockObjectKey, block.SingleBlockObjectVersion)
 }
 

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -335,7 +335,7 @@ func TestRequirePinnedSingleBlockObjectVersionAllowsHistoricalDuplicateRemoval(t
 	require.NoError(t, repairer.requirePinnedSingleBlockObjectVersion(context.Background(), "single/1000.zstd", pinned))
 }
 
-func TestRestoreZeroCanonicalRepairRejectsHistoricalSingleBlockVersion(t *testing.T) {
+func TestRestoreZeroCanonicalRepairResumesWithHistoricalSingleBlockVersion(t *testing.T) {
 	manifest := completionManifest(t)
 	manifest.State = StatePrepared
 	repository := &phaseBoundaryRepository{manifest: manifest}
@@ -352,8 +352,8 @@ func TestRestoreZeroCanonicalRepairRejectsHistoricalSingleBlockVersion(t *testin
 	}}
 
 	_, err := NewRepairer(repository, store, manifest.Bucket).Restore(context.Background(), manifest.ID, nil)
-	require.ErrorContains(t, err, "expected one data version and zero delete markers")
-	require.False(t, repository.restoreCalled)
+	require.NoError(t, err)
+	require.True(t, repository.restoreCalled)
 }
 
 func TestVisitPinnedPayloadsReadsPinnedCurrentVersionAndStripsStoragePlacement(t *testing.T) {

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -100,7 +100,7 @@ type (
 		RestoreToSingleBlock(ctx context.Context, repairID int64) (*Manifest, error)
 		GetRebuilt(ctx context.Context, repairID int64) (*Manifest, error)
 		RecordVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion) (*Manifest, error)
-		PromoteVerified(ctx context.Context, repairID int64, objectKey string, object ObjectVersion, placements []RebuiltPlacement, singleBlockObjectRetention time.Duration) (*Manifest, error)
+		PromoteCompleted(ctx context.Context, repairID int64, objectKey string, object ObjectVersion, placements []RebuiltPlacement, singleBlockObjectRetention time.Duration) (*Manifest, error)
 		CompleteRetainingOldObject(ctx context.Context, repairID int64, outcome string) (*Manifest, error)
 	}
 

--- a/internal/workflow/activity/batch_consolidator_repair_test.go
+++ b/internal/workflow/activity/batch_consolidator_repair_test.go
@@ -29,11 +29,10 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRebuildsPinnedPayload
 	oldKey := "consolidated/dirty.cscb.zstd"
 	newKey := "consolidated/clean.cscb.zstd"
 	prepared := repairActivityManifest(cscbrepair.StatePrepared, oldKey, "")
-	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
 	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
 	fake := &repairActivityFake{
 		prepared:  prepared,
-		verified:  verified,
+		verified:  completed,
 		completed: completed,
 		pinnedPayloads: []cscbrepair.PinnedPayload{{
 			BlockMetadataID: records[0].ID,
@@ -60,7 +59,7 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBRebuildsPinnedPayload
 		OldObjectKey:       oldKey,
 		RepairedObjects:    1,
 	}, response)
-	require.Equal([]string{"prepare", "visit_pinned", "verify_promote", "complete"}, fake.calls)
+	require.Equal([]string{"prepare", "visit_pinned", "verify_promote"}, fake.calls)
 	require.Equal(testRepairExecutionKey, fake.executionKey)
 }
 
@@ -89,11 +88,10 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBResumesRestoredManife
 	oldKey := "consolidated/dirty.cscb.zstd"
 	newKey := "consolidated/clean.cscb.zstd"
 	restored := repairActivityManifest(cscbrepair.StateRestored, oldKey, "")
-	verified := repairActivityManifest(cscbrepair.StateVerified, oldKey, newKey)
 	completed := repairActivityManifest(cscbrepair.StateCompleted, oldKey, newKey)
 	fake := &repairActivityFake{
 		prepared:  restored,
-		verified:  verified,
+		verified:  completed,
 		completed: completed,
 		pinnedPayloads: []cscbrepair.PinnedPayload{{
 			BlockMetadataID: records[0].ID,
@@ -118,7 +116,7 @@ func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBResumesRestoredManife
 	})
 	require.NoError(err)
 	require.Equal(uint64(1), response.RepairedObjects)
-	require.Equal([]string{"prepare", "visit_pinned", "verify_promote", "complete"}, fake.calls)
+	require.Equal([]string{"prepare", "visit_pinned", "verify_promote"}, fake.calls)
 }
 
 func (s *BatchConsolidatorTestSuite) TestRepairExistingCSCBCompletesAllNonCanonicalObjectWithoutRebuild() {


### PR DESCRIPTION
## Summary

- make rebuilt-CSCB promotion and terminal manifest completion one PostgreSQL transaction, so rollback never sees promoted metadata in a resumable intermediate state
- preserve resume compatibility for prepared zero-canonical manifests after historical single-block versions appear
- add one hour of commit grace after the configured single-block retention interval
- prove repair preparation serializes with the existing single-block upload guard and pins the writer's final current version

## Safety

- no schema migration
- no S3 deletion behavior added
- existing `verified` manifests remain resumable through the compatibility completion path
- upload fencing uses the existing shared retirement advisory lock; no network calls are placed inside the database transaction

## Verification

- `go test ./internal/storage/cscbrepair ./internal/workflow/activity -count=1`
- `go test -race ./internal/storage/cscbrepair ./internal/workflow/activity -count=1`
- `go vet ./internal/storage/cscbrepair ./internal/workflow/activity`
- `CI=1 make integration TARGET=internal/storage/cscbrepair TEST_FILTER=TestIntegrationCSCBRepairFullLifecycle`
- `TEST_TYPE=unit go test ./... -count=1`
- `gofmt -d` on all changed Go files
- `git diff --check`

Linear: https://linear.app/cipherowl/issue/INF-1133
