### PR TITLE
fix(INF-1133): isolate CSCB repair ranges

### DIFF
--- a/internal/storage/cscbrepair/full_lifecycle_integration_test.go
+++ b/internal/storage/cscbrepair/full_lifecycle_integration_test.go
@@ -37,6 +37,98 @@ import (
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
+func TestIntegrationCSCBRepairPendingRangeIsolation(t *testing.T) {
+	if os.Getenv("TEST_TYPE") != "integration" {
+		t.Skip("integration test")
+	}
+	require := require.New(t)
+	ctx := context.Background()
+	unique := time.Now().UTC().UnixNano()
+	tag := uint32(1_600_000_000 + unique%100_000_000)
+	startHeight := uint64(8_500_000_000 + unique%100_000_000)
+	endHeight := startHeight + 1_000
+
+	cfg, err := config.New(
+		config.WithEnvironment(config.EnvLocal),
+		config.WithBlockchain(common.Blockchain_BLOCKCHAIN_SOLANA),
+		config.WithNetwork(common.Network_NETWORK_SOLANA_MAINNET),
+	)
+	require.NoError(err)
+	if cfg.AWS.Postgres == nil {
+		t.Skip("Postgres is not configured")
+	}
+	configureRepairTestEnvironment(t, cfg.AWS.Postgres)
+	db, err := openRepairDB(ctx, cfg.AWS.Postgres)
+	require.NoError(err)
+	defer func() { _ = db.Close() }()
+	goose.SetBaseFS(metapostgres.GetEmbeddedMigrations())
+	require.NoError(goose.SetDialect("postgres"))
+	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+
+	type pendingRange struct {
+		key   string
+		start uint64
+		end   uint64
+	}
+	insertPending := func(tag uint32, pending pendingRange) {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO cscb_repair_manifest (
+				tag, state, bucket, old_consolidated_object_key_main,
+				start_height, end_height, canonical_block_count, total_block_count, row_set_sha256
+			) VALUES ($1, $2, $3, $4, $5, $6, 0, 0, $7)`,
+			tag,
+			cscbrepair.StatePreparing,
+			"range-isolation-bucket",
+			pending.key,
+			pending.start,
+			pending.end,
+			repairSHA256(pending.key),
+		)
+		require.NoError(err)
+	}
+	inRangeKey := fmt.Sprintf("consolidated/in-range-%d.cscb.zstd", unique)
+	pendingRanges := []pendingRange{
+		{key: fmt.Sprintf("consolidated/below-%d.cscb.zstd", unique), start: startHeight - 1_000, end: startHeight},
+		{key: fmt.Sprintf("consolidated/above-%d.cscb.zstd", unique), start: endHeight, end: endHeight + 1_000},
+		{key: inRangeKey, start: startHeight, end: endHeight},
+	}
+	for _, pending := range pendingRanges {
+		insertPending(tag, pending)
+	}
+
+	repository := cscbrepair.NewPostgresRepository(db)
+	pending, err := repository.FindPending(ctx, tag, startHeight, endHeight)
+	require.NoError(err)
+	require.NotNil(pending)
+	require.Equal(inRangeKey, pending.OldConsolidatedObjectKey)
+
+	objectKeys, err := repository.ListCandidateObjectKeys(ctx, tag, startHeight, endHeight, 10)
+	require.NoError(err)
+	require.Equal([]string{inRangeKey}, objectKeys)
+
+	emptyStart := endHeight + 2_000
+	pending, err = repository.FindPending(ctx, tag, emptyStart, emptyStart+1_000)
+	require.NoError(err)
+	require.Nil(pending)
+	objectKeys, err = repository.ListCandidateObjectKeys(ctx, tag, emptyStart, emptyStart+1_000, 10)
+	require.NoError(err)
+	require.Empty(objectKeys)
+
+	crossingTag := tag + 1
+	crossingKey := fmt.Sprintf("consolidated/cross-right-%d.cscb.zstd", unique)
+	insertPending(crossingTag, pendingRange{
+		key:   crossingKey,
+		start: startHeight + 500,
+		end:   endHeight + 1,
+	})
+	pending, err = repository.FindPending(ctx, crossingTag, startHeight, endHeight)
+	require.NoError(err)
+	require.NotNil(pending)
+	require.Equal(crossingKey, pending.OldConsolidatedObjectKey)
+	_, err = repository.ListCandidateObjectKeys(ctx, crossingTag, startHeight, endHeight, 10)
+	require.ErrorContains(err, "exceeds approved range")
+}
+
 func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	if os.Getenv("TEST_TYPE") != "integration" {
 		t.Skip("integration test")
@@ -408,9 +500,12 @@ func TestIntegrationCSCBRepairFullLifecycle(t *testing.T) {
 	require.NoError(err)
 	require.Equal(cleanKey, activeAfterPromotion.ObjectKeyMain)
 	require.Equal(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH, activeAfterPromotion.ObjectFormat)
-	pendingAfterPromotion, err := repository.FindPending(ctx, tag)
+	pendingAfterPromotion, err := repository.FindPending(ctx, tag, height, height+1)
 	require.NoError(err)
 	require.Nil(pendingAfterPromotion, "rollback must not resume a mixed placement after atomic promotion")
+	candidatesAfterPromotion, err := repository.ListCandidateObjectKeys(ctx, tag, height, height+1, 10)
+	require.NoError(err)
+	require.Empty(candidatesAfterPromotion, "rerunning a completed repair range must terminate without new work")
 
 	manifest, err = repairer.Complete(ctx, manifest.ID, nil)
 	require.NoError(err)

--- a/internal/storage/cscbrepair/postgres_repository.go
+++ b/internal/storage/cscbrepair/postgres_repository.go
@@ -79,18 +79,32 @@ func (r *PostgresRepository) FindByExecutionKey(
 func (r *PostgresRepository) FindPending(
 	ctx context.Context,
 	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
 ) (*Manifest, error) {
 	if err := r.validateDB(); err != nil {
 		return nil, err
+	}
+	if endHeight <= startHeight {
+		return nil, xerrors.New("valid CSCB repair range is required")
 	}
 	query := fmt.Sprintf(`
 			SELECT %s
 			FROM cscb_repair_manifest
 			WHERE tag = $1
 				AND state <> $2
+				AND end_height > $3
+				AND start_height < $4
 			ORDER BY id ASC
 			LIMIT 1`, manifestColumns)
-	manifest, err := scanManifest(r.db.QueryRowContext(ctx, query, tag, StateCompleted))
+	manifest, err := scanManifest(r.db.QueryRowContext(
+		ctx,
+		query,
+		tag,
+		StateCompleted,
+		startHeight,
+		endHeight,
+	))
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -199,8 +213,10 @@ func (r *PostgresRepository) ListCandidateObjectKeys(
 		FROM cscb_repair_manifest
 		WHERE tag = $1
 			AND state <> $2
+			AND end_height > $3
+			AND start_height < $4
 		ORDER BY end_height DESC, old_consolidated_object_key_main DESC
-		LIMIT $3`, tag, StateCompleted, limit)
+		LIMIT $5`, tag, StateCompleted, startHeight, endHeight, limit)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list pending CSCB repair candidates: %w", err)
 	}

--- a/internal/storage/cscbrepair/repairer.go
+++ b/internal/storage/cscbrepair/repairer.go
@@ -120,7 +120,7 @@ func (r *repairerImpl) prepare(
 	}
 	var pending *Manifest
 	if objectKey == "" {
-		pending, err = r.repository.FindPending(ctx, tag)
+		pending, err = r.repository.FindPending(ctx, tag, startHeight, endHeight)
 	} else {
 		pending, err = r.repository.FindByObjectKey(ctx, tag, objectKey)
 	}

--- a/internal/storage/cscbrepair/repairer_test.go
+++ b/internal/storage/cscbrepair/repairer_test.go
@@ -772,7 +772,7 @@ func (r *candidateListRepository) ListCandidateObjectKeys(_ context.Context, _ u
 	return r.objectKeys, nil
 }
 
-func (r *pendingRepairRepository) FindPending(context.Context, uint32) (*Manifest, error) {
+func (r *pendingRepairRepository) FindPending(context.Context, uint32, uint64, uint64) (*Manifest, error) {
 	return r.pending, nil
 }
 
@@ -839,7 +839,7 @@ func (r *preparationRepository) FindByExecutionKey(_ context.Context, executionK
 	return nil, false, nil
 }
 
-func (r *preparationRepository) FindPending(context.Context, uint32) (*Manifest, error) {
+func (r *preparationRepository) FindPending(context.Context, uint32, uint64, uint64) (*Manifest, error) {
 	return nil, nil
 }
 

--- a/internal/storage/cscbrepair/types.go
+++ b/internal/storage/cscbrepair/types.go
@@ -87,7 +87,7 @@ type (
 
 	Repository interface {
 		FindByExecutionKey(ctx context.Context, executionKey string) (*Manifest, bool, error)
-		FindPending(ctx context.Context, tag uint32) (*Manifest, error)
+		FindPending(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
 		FindByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)
 		FindNextCandidate(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64) (*Manifest, error)
 		FindCandidateByObjectKey(ctx context.Context, tag uint32, objectKey string) (*Manifest, error)


### PR DESCRIPTION
## Summary

- scope pending repair-manifest discovery to the workflow approved range
- ignore disjoint pending backlog while retaining fail-closed rejection for manifests that cross a requested boundary
- keep legacy serial and current parallel repair selection consistent
- verify a completed range returns no candidates on rerun

## Production failure

The one-object workflow for `[431646000,431647000)` repaired and promoted its object, then queried the global pending backlog and selected adjacent `[431645000,431646000)`. That unrelated manifest failed the approved-range check and made the workflow terminally `FAILED`.

The repository queries now select only pending manifests that overlap the requested half-open range. Existing containment validation still rejects a genuinely crossing manifest.

## Validation

- reproduced the production error before the fix with Docker PostgreSQL
- `PATH=/Users/boyangxu/go/bin:$PATH make test TARGET=internal/storage/cscbrepair/...`
- `TEST_TYPE=unit go test ./internal/storage/cscbrepair ./internal/workflow/... -count=1`
- Docker PostgreSQL + LocalStack S3: `TestIntegrationCSCBRepairPendingRangeIsolation`
- Docker PostgreSQL + LocalStack S3: `TestIntegrationCSCBRepairFullLifecycle`

No database migration is required.

Linear: [INF-1133](https://linear.app/cipherowl/issue/INF-1133)