### PR TITLE
fix(INF-1133): normalize optional Solana metadata

### DIFF
--- a/internal/storage/retirement/payload_verifier.go
+++ b/internal/storage/retirement/payload_verifier.go
@@ -192,6 +192,7 @@ func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
 		}
 		return nil, xerrors.Errorf("failed to finish parsing embedded Solana block JSON: %w", err)
 	}
+	normalizeSolanaOptionalTransactionMetadata(value)
 	canonicalHeader, err := json.Marshal(value)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to canonicalize embedded Solana block JSON: %w", err)
@@ -199,6 +200,36 @@ func canonicalizeEmbeddedBlockPayload(block *api.Block) (*api.Block, error) {
 	canonical := proto.Clone(block).(*api.Block)
 	canonical.GetSolana().Header = canonicalHeader
 	return canonical, nil
+}
+
+func normalizeSolanaOptionalTransactionMetadata(value any) {
+	// Solana RPC providers omit these optional collections or emit them as []
+	// or null. Chainstorage's native parser treats all three as zero entries.
+	block, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	transactions, ok := block["transactions"].([]any)
+	if !ok {
+		return
+	}
+	for _, transactionValue := range transactions {
+		transaction, ok := transactionValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		metadata, ok := transaction["meta"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, field := range []string{"innerInstructions", "logMessages"} {
+			value, exists := metadata[field]
+			items, isArray := value.([]any)
+			if !exists || value == nil || (isArray && len(items) == 0) {
+				metadata[field] = nil
+			}
+		}
+	}
 }
 
 func decodeUniqueJSONValue(decoder *json.Decoder) (any, error) {

--- a/internal/storage/retirement/payload_verifier_test.go
+++ b/internal/storage/retirement/payload_verifier_test.go
@@ -123,6 +123,61 @@ func TestPayloadDigestsPreservePersistedFormatAndCanonicalizeSemanticComparison(
 	require.Equal(t, firstSemanticDigest, secondSemanticDigest)
 }
 
+func TestSemanticBlockDigestCanonicalizesEmptyOptionalSolanaTransactionMetadata(t *testing.T) {
+	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
+	emptyArrays := solanaPayloadBlock(candidate, `{
+		"blockhash":"block-hash",
+		"transactions":[{"meta":{"innerInstructions":[],"logMessages":[]}}]
+	}`)
+	nulls := solanaPayloadBlock(candidate, `{
+		"blockhash":"block-hash",
+		"transactions":[{"meta":{"innerInstructions":null,"logMessages":null}}]
+	}`)
+	omitted := solanaPayloadBlock(candidate, `{
+		"blockhash":"block-hash",
+		"transactions":[{"meta":{}}]
+	}`)
+
+	emptyArrayDigest, err := semanticBlockDigest(emptyArrays)
+	require.NoError(t, err)
+	nullDigest, err := semanticBlockDigest(nulls)
+	require.NoError(t, err)
+	omittedDigest, err := semanticBlockDigest(omitted)
+	require.NoError(t, err)
+	require.Equal(t, emptyArrayDigest, nullDigest)
+	require.Equal(t, emptyArrayDigest, omittedDigest)
+}
+
+func TestSemanticBlockDigestPreservesMeaningfulSolanaJSONDifferences(t *testing.T) {
+	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
+	tests := map[string]struct {
+		first  string
+		second string
+	}{
+		"non-empty log messages": {
+			first:  `{"transactions":[{"meta":{"logMessages":["program success"]}}]}`,
+			second: `{"transactions":[{"meta":{"logMessages":null}}]}`,
+		},
+		"non-empty inner instructions": {
+			first:  `{"transactions":[{"meta":{"innerInstructions":[{"index":1,"instructions":[]}]}}]}`,
+			second: `{"transactions":[{"meta":{"innerInstructions":null}}]}`,
+		},
+		"unrelated null and empty array": {
+			first:  `{"transactions":[],"unknown":[]}`,
+			second: `{"transactions":[],"unknown":null}`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			firstDigest, err := semanticBlockDigest(solanaPayloadBlock(candidate, test.first))
+			require.NoError(t, err)
+			secondDigest, err := semanticBlockDigest(solanaPayloadBlock(candidate, test.second))
+			require.NoError(t, err)
+			require.NotEqual(t, firstDigest, secondDigest)
+		})
+	}
+}
+
 func TestSemanticBlockDigestRejectsDifferentSolanaJSON(t *testing.T) {
 	candidate := Candidate{Tag: 2, Height: 429600000, Hash: "block-hash"}
 	first := solanaPayloadBlock(candidate, `{"blockhash":"block-hash","slot":429600000}`)


### PR DESCRIPTION
## Summary

- normalize only Solana `transactions[*].meta.innerInstructions` and `logMessages` across omitted, `null`, and empty-array representations for semantic CSCB repair comparison
- preserve strict comparison for non-empty values, unrelated fields, block identity, and deterministic protobuf payloads
- leave the persisted canonical payload digest unchanged for upgrade and rollback compatibility

## Root cause

The terminal repair run `workflow.batch_consolidator/repair_existing_cscb_431572000_431646000_p20_r3_20260720T0514Z` (`019f7df6-4db3-70e5-a693-e2d24fa8e479`) failed all 20 object activities after three attempts with `single-block and CSCB payloads differ`. There were no range-selection, transport, or timeout failures in that run.

Pinned production inspection reproduced the same representation-only delta in three independent CSCB objects:

| Height | CSCB-era single-block version | Current single-block version | Exact normalized delta |
| --- | --- | --- | --- |
| 431631017 | historical version preceding CSCB creation | later version after CSCB creation | transaction 434: `innerInstructions` and `logMessages` changed from `[]` to `null` |
| 431634001 | `om4_4EiC._VXDjt6OgqJsjByzVkzj8YH` | `6am_4gVhh64DNrRZhxS6xxKrs5ISXMeD` | transaction 1392: the same two fields changed from `[]` to `null` |
| 431642015 | historical version preceding CSCB creation | later version after CSCB creation | transaction 21: the same two fields changed from `[]` to `null` |

For each sample, tag, height, block hash, parent hash, and every other normalized field matched. The current deterministic protobuf was exactly four bytes larger. Chainstorage's native Solana parser stores both fields as slices, so omitted, `null`, and `[]` all parse to zero entries.

The semantic digest added in #177 canonicalized JSON object ordering but did not encode this parser-level equivalence. This change completes that narrow contract; it does not weaken general JSON comparison.

## Validation

- `go test ./internal/blockchain/parser/solana ./internal/storage/retirement ./internal/storage/cscbrepair`
- `go vet ./internal/blockchain/parser/solana ./internal/storage/retirement ./internal/storage/cscbrepair`
- production-derived replay through the product `semanticBlockDigest` for heights 431631017, 431634001, and 431642015
- Go 1.26.3 Docker integration against disposable PostgreSQL 13 and LocalStack:
  - retirement repository state machine
  - full retirement storage lifecycle
  - CSCB repair pending-range isolation
  - full CSCB repair lifecycle
  - CSCB repair reference-index migration

All passed. The failed production workflow was not restarted and no production mutation was performed during diagnosis.

Linear: https://linear.app/cipherowl/issue/INF-1133
