### PR TITLE
fix(INF-1126): retire all single-block object versions

### DIFF
--- a/internal/storage/metastorage/postgres/db/migrations/20260721000001_support_multi_version_retirement.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260721000001_support_multi_version_retirement.sql
@@ -1,0 +1,88 @@
+-- +goose Up
+ALTER TABLE block_single_block_retention
+    ADD COLUMN single_block_delete_marker_version_ids TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- +goose StatementBegin
+CREATE FUNCTION validate_single_block_retirement_version_ids(version_ids TEXT[], allow_empty BOOLEAN)
+RETURNS BOOLEAN AS $$
+    SELECT version_ids IS NOT NULL
+        AND (allow_empty OR cardinality(version_ids) > 0)
+        AND NOT EXISTS (
+            SELECT 1
+            FROM unnest(version_ids) AS version_id
+            WHERE version_id IS NULL
+                OR BTRIM(version_id) = ''
+                OR LOWER(BTRIM(version_id)) = 'null'
+        )
+        AND cardinality(version_ids) = (
+            SELECT COUNT(DISTINCT version_id)
+            FROM unnest(version_ids) AS version_id
+        );
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+-- +goose StatementEnd
+
+ALTER TABLE block_single_block_retention
+    DROP CONSTRAINT block_single_block_retention_single_block_object_version__check,
+    DROP CONSTRAINT block_single_block_retention_immutable_version_ids_check,
+    ADD CONSTRAINT block_single_block_retention_immutable_version_ids_check CHECK (
+        validate_single_block_retirement_version_ids(single_block_object_version_ids, FALSE)
+        AND validate_single_block_retirement_version_ids(single_block_delete_marker_version_ids, TRUE)
+        AND consolidated_object_version_id IS NOT NULL
+        AND BTRIM(consolidated_object_version_id) <> ''
+        AND LOWER(BTRIM(consolidated_object_version_id)) <> 'null'
+    );
+
+-- +goose StatementBegin
+CREATE FUNCTION enforce_single_block_retirement_delete_markers_immutable()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.single_block_delete_marker_version_ids IS DISTINCT FROM OLD.single_block_delete_marker_version_ids THEN
+        RAISE EXCEPTION 'cannot change pinned retirement delete-marker versions for block_metadata id %', OLD.block_metadata_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER block_single_block_retention_delete_markers_immutable_trigger
+BEFORE UPDATE OF single_block_delete_marker_version_ids ON block_single_block_retention
+FOR EACH ROW
+EXECUTE FUNCTION enforce_single_block_retirement_delete_markers_immutable();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM block_single_block_retention
+        WHERE cardinality(single_block_object_version_ids) <> 1
+            OR cardinality(single_block_delete_marker_version_ids) <> 0
+    ) THEN
+        RAISE EXCEPTION 'cannot roll back multi-version retirement while multi-version manifests exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS block_single_block_retention_delete_markers_immutable_trigger
+    ON block_single_block_retention;
+DROP FUNCTION IF EXISTS enforce_single_block_retirement_delete_markers_immutable();
+
+ALTER TABLE block_single_block_retention
+    DROP CONSTRAINT block_single_block_retention_immutable_version_ids_check,
+    ADD CONSTRAINT block_single_block_retention_single_block_object_version__check CHECK (
+        cardinality(single_block_object_version_ids) = 1
+        AND single_block_object_version_ids[1] <> ''
+    ),
+    ADD CONSTRAINT block_single_block_retention_immutable_version_ids_check CHECK (
+        cardinality(single_block_object_version_ids) = 1
+        AND single_block_object_version_ids[1] IS NOT NULL
+        AND BTRIM(single_block_object_version_ids[1]) <> ''
+        AND LOWER(BTRIM(single_block_object_version_ids[1])) <> 'null'
+        AND consolidated_object_version_id IS NOT NULL
+        AND BTRIM(consolidated_object_version_id) <> ''
+        AND LOWER(BTRIM(consolidated_object_version_id)) <> 'null'
+    ),
+    DROP COLUMN single_block_delete_marker_version_ids;
+
+DROP FUNCTION IF EXISTS validate_single_block_retirement_version_ids(TEXT[], BOOLEAN);

--- a/internal/storage/retirement/full_lifecycle_integration_test.go
+++ b/internal/storage/retirement/full_lifecycle_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	awss3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/pressly/goose/v3"
@@ -53,6 +55,7 @@ func TestIntegrationRetirementFullStorageLifecycle(t *testing.T) {
 	cfg.AWS.Bucket = bucket
 	cfg.AWS.IsLocalStack = true
 	cfg.AWS.IsResetLocal = true
+	localStackEndpoint := retirementLocalStackEndpoint(t, cfg.AWS.Postgres)
 	cfg.Chain.BlockStartHeight = height
 
 	db, err := openLifecycleDB(ctx, cfg.AWS.Postgres)
@@ -77,6 +80,7 @@ func TestIntegrationRetirementFullStorageLifecycle(t *testing.T) {
 		chains3.Module,
 		metastorage.Module,
 		blobstorage.Module,
+		fx.Replace(newRetirementLocalStackConfig(ctx, localStackEndpoint)),
 		fx.Populate(&meta, &blob, &singleBlockUploader, &s3Session),
 	)
 	defer app.Close()
@@ -112,6 +116,14 @@ func TestIntegrationRetirementFullStorageLifecycle(t *testing.T) {
 	singleBlockKey, err := singleBlockUploader.Upload(ctx, block, api.Compression_GZIP)
 	require.NoError(err)
 	require.NotEmpty(singleBlockKey)
+	singleBlockObject, err := rawS3.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(singleBlockKey),
+	})
+	require.NoError(err)
+	singleBlockBytes, err := io.ReadAll(singleBlockObject.Body)
+	require.NoError(err)
+	require.NoError(singleBlockObject.Body.Close())
 	block.Metadata.ObjectKeyMain = singleBlockKey
 	require.NoError(meta.PersistBlockMetas(ctx, true, []*api.BlockMetadata{block.Metadata}, nil))
 
@@ -173,6 +185,18 @@ func TestIntegrationRetirementFullStorageLifecycle(t *testing.T) {
 	require.NoError(err)
 	require.True(proto.Equal(storageutils.CloneBlockWithoutStoragePlacement(block), storageutils.CloneBlockWithoutStoragePlacement(parsedCSCB)))
 
+	_, err = rawS3.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(singleBlockKey),
+		Body:   bytes.NewReader(singleBlockBytes),
+	})
+	require.NoError(err)
+	_, err = rawS3.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(singleBlockKey),
+	})
+	require.NoError(err)
+
 	policy := retentionSafeBucketPolicy(bucket)
 	_, err = rawS3.PutBucketPolicy(ctx, &awss3.PutBucketPolicyInput{Bucket: aws.String(bucket), Policy: aws.String(policy)})
 	require.NoError(err)
@@ -205,6 +229,8 @@ func TestIntegrationRetirementFullStorageLifecycle(t *testing.T) {
 	require.Len(report.Items, 1)
 	require.Equal(retirement.ActionDeleteObjectVersion, report.Items[0].Action)
 	require.Empty(report.Items[0].SkipReason)
+	require.Equal(2, report.Items[0].SingleBlockVersions)
+	require.Equal(1, report.Items[0].DeleteMarkers)
 	require.True(report.SafetyGates.CSCBWriteOncePolicyVerified)
 
 	snapshot, err := store.InspectObjectRetentionSafety(ctx, bucket, consolidatedKey)
@@ -325,6 +351,36 @@ func openLifecycleDB(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, 
 		return nil, err
 	}
 	return db, nil
+}
+
+func retirementLocalStackEndpoint(t *testing.T, postgres *config.PostgresConfig) string {
+	t.Helper()
+	switch postgres.Host {
+	case "localhost", "127.0.0.1", "::1":
+		return "http://localhost:4566"
+	case "postgres":
+		return "http://localstack:4566"
+	default:
+		t.Fatalf("refusing to run retirement lifecycle test against PostgreSQL host %q", postgres.Host)
+		return ""
+	}
+}
+
+func newRetirementLocalStackConfig(ctx context.Context, endpoint string) aws.Config {
+	cfg, err := awsconfig.LoadDefaultConfig(
+		ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+		awsconfig.WithEndpointResolverWithOptions(
+			aws.EndpointResolverWithOptionsFunc(func(string, string, ...interface{}) (aws.Endpoint, error) {
+				return aws.Endpoint{URL: endpoint, HostnameImmutable: true}, nil
+			}),
+		),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("failed to configure LocalStack: %v", err))
+	}
+	return cfg
 }
 
 func retentionSafeBucketPolicy(bucket string) string {

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ const (
 	retirementClaimLease              = 15 * time.Minute
 	retirementSafetyQuiescencePeriod  = 15 * time.Minute
 	s3MutableNullVersionID            = "null"
+	versionedDeleteMode               = "exact_pinned_versions_and_delete_markers"
 )
 
 var unverifiedRetentionSafetySHA256 = keySHA256("unverified-retention-safety-configuration")
@@ -156,7 +158,12 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 			manifest.State != RetirementStateEligible &&
 				manifest.State != RetirementStateDeleting &&
 				manifest.State != RetirementStateDeletedPendingVerification ||
-			!isSHA256Hex(manifest.SingleBlockObjectKeySHA256) || !isSHA256Hex(manifest.PayloadSHA256) {
+			!isSHA256Hex(manifest.SingleBlockObjectKeySHA256) || !isSHA256Hex(manifest.PayloadSHA256) ||
+			!validPinnedVersionIDs(
+				firstString(manifest.SingleBlockObjectVersionIDs),
+				manifest.SingleBlockObjectVersionIDs,
+				manifest.SingleBlockDeleteMarkerVersionIDs,
+			) {
 			markCandidateBlocked(&item, SkipMetadataChanged)
 			report.Items = append(report.Items, item)
 			continue
@@ -256,6 +263,10 @@ func (p *Planner) planRow(
 			}
 			item.Key = ""
 			item.VersionID = firstString(row.Retirement.SingleBlockObjectVersionIDs)
+			item.VersionIDs = append([]string(nil), row.Retirement.SingleBlockObjectVersionIDs...)
+			item.DeleteMarkerVersionIDs = append([]string(nil), row.Retirement.SingleBlockDeleteMarkerVersionIDs...)
+			item.SingleBlockVersions = len(item.VersionIDs)
+			item.DeleteMarkers = len(item.DeleteMarkerVersionIDs)
 			item.SingleBlockETag = row.Retirement.SingleBlockObjectETag
 			item.SingleBlockBytes = row.Retirement.SingleBlockObjectBytes
 			item.ConsolidatedKey = row.Retirement.ConsolidatedObjectKey
@@ -275,6 +286,10 @@ func (p *Planner) planRow(
 			}
 			item.Key = ""
 			item.VersionID = firstString(row.Retirement.SingleBlockObjectVersionIDs)
+			item.VersionIDs = append([]string(nil), row.Retirement.SingleBlockObjectVersionIDs...)
+			item.DeleteMarkerVersionIDs = append([]string(nil), row.Retirement.SingleBlockDeleteMarkerVersionIDs...)
+			item.SingleBlockVersions = len(item.VersionIDs)
+			item.DeleteMarkers = len(item.DeleteMarkerVersionIDs)
 			item.SingleBlockBytes = row.Retirement.SingleBlockObjectBytes
 			item.ConsolidatedKey = row.Retirement.ConsolidatedObjectKey
 			item.CSCBVersionID = row.Retirement.ConsolidatedObjectVersionID
@@ -359,18 +374,16 @@ func (p *Planner) planRow(
 		item.SkipReason = SkipSingleBlockObjectMissing
 		return item
 	}
-	if len(topology.Versions) != 1 || len(topology.DeleteMarkers) != 0 || !topology.Versions[0].IsLatest {
-		item.SkipReason = SkipUnsafeSingleBlockVersionTopology
+	version, versionIDs, deleteMarkerVersionIDs, reason := pinSingleBlockTopology(topology)
+	if reason != "" {
+		item.SkipReason = reason
 		return item
 	}
-	version := topology.Versions[0]
 	item.VersionID = version.VersionID
+	item.VersionIDs = versionIDs
+	item.DeleteMarkerVersionIDs = deleteMarkerVersionIDs
 	item.SingleBlockETag = version.ETag
 	item.SingleBlockBytes = version.Bytes
-	if !isImmutableVersionID(item.VersionID) || item.SingleBlockETag == "" {
-		item.SkipReason = SkipSingleBlockVersionIDUnavailable
-		return item
-	}
 
 	head, ok := cscbHeads[shadow.ConsolidatedObjectKey]
 	if !ok {
@@ -455,8 +468,8 @@ func (p *Planner) applyCandidate(ctx context.Context, req PlanRequest, item *Can
 		if reason, err := p.verifyCSCBRetentionSafety(ctx, item); err != nil {
 			return reason, err
 		}
-		if err := p.store.DeleteObjectVersion(ctx, item.Bucket, item.Key, item.VersionID); err != nil {
-			return SkipVersionedDeleteFailed, err
+		if reason, err := p.deletePinnedSingleBlockTopology(ctx, item, claimToken); err != nil {
+			return reason, err
 		}
 		return p.completeObjectDeletion(ctx, req, item, claimToken, item.PayloadSHA256)
 	})
@@ -490,6 +503,9 @@ func (p *Planner) reconcileManifest(
 		if len(topology.Versions) == 0 && len(topology.DeleteMarkers) == 0 {
 			return SkipMetadataChanged, xerrors.Errorf("single-block object is absent before any delete attempt: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
+		if !topologyMatchesManifest(topology, manifest) {
+			return SkipUnsafeSingleBlockVersionTopology, xerrors.Errorf("eligible retirement topology changed: block_metadata_id=%d", manifest.BlockMetadataID)
+		}
 	}
 	return p.withRetirementClaim(ctx, item, func(claimToken string) (string, error) {
 		topology, err := p.store.ListObjectVersions(ctx, manifest.Bucket, manifest.SingleBlockObjectKey)
@@ -505,18 +521,23 @@ func (p *Planner) reconcileManifest(
 			}
 			return p.completeObjectDeletion(ctx, req, item, claimToken, manifest.PayloadSHA256)
 		}
-		if !topologyMatchesManifest(topology, manifest) {
+		if manifest.State == RetirementStateEligible && !topologyMatchesManifest(topology, manifest) ||
+			manifest.State == RetirementStateDeleting && !topologyIsPinnedSubset(topology, manifest) {
 			return SkipUnsafeSingleBlockVersionTopology, xerrors.Errorf("pending retirement topology changed: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
 		verifier := p.verifierFactory()
-		payloadSHA256, reason, err := p.revalidateCandidate(ctx, req, *item, verifier)
+		verify := p.revalidateCandidate
+		if manifest.State == RetirementStateDeleting {
+			verify = p.revalidateConsolidatedCandidate
+		}
+		payloadSHA256, reason, err := verify(ctx, req, *item, verifier)
 		if err != nil {
 			return reason, err
 		}
 		if payloadSHA256 != manifest.PayloadSHA256 {
 			return SkipSingleBlockPayloadMismatch, xerrors.Errorf("pending retirement payload digest changed: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
-		preDeleteSHA256, reason, err := p.revalidateCandidate(ctx, req, *item, verifier)
+		preDeleteSHA256, reason, err := verify(ctx, req, *item, verifier)
 		if err != nil {
 			return reason, err
 		}
@@ -529,8 +550,8 @@ func (p *Planner) reconcileManifest(
 		if reason, err := p.verifyCSCBRetentionSafety(ctx, item); err != nil {
 			return reason, err
 		}
-		if err := p.store.DeleteObjectVersion(ctx, item.Bucket, item.Key, item.VersionID); err != nil {
-			return SkipVersionedDeleteFailed, err
+		if reason, err := p.deletePinnedSingleBlockTopology(ctx, item, claimToken); err != nil {
+			return reason, err
 		}
 		return p.completeObjectDeletion(ctx, req, item, claimToken, manifest.PayloadSHA256)
 	})
@@ -658,6 +679,66 @@ func (p *Planner) withRetirementClaim(
 func (p *Planner) renewRetirementClaim(ctx context.Context, blockMetadataID int64, claimToken string) error {
 	renewedAt := time.Now().UTC()
 	return p.repo.RenewRetirementClaim(ctx, blockMetadataID, claimToken, renewedAt, renewedAt.Add(retirementClaimLease))
+}
+
+func (p *Planner) deletePinnedSingleBlockTopology(
+	ctx context.Context,
+	item *Candidate,
+	claimToken string,
+) (string, error) {
+	topology, err := p.store.ListObjectVersions(ctx, item.Bucket, item.Key)
+	if err != nil {
+		return SkipObjectInspectionFailed, err
+	}
+	if !topologyIsPinnedCandidateSubset(topology, *item) {
+		return SkipUnsafeSingleBlockVersionTopology, xerrors.Errorf(
+			"single-block object version topology changed before exact deletion: block_metadata_id=%d",
+			item.BlockMetadataID,
+		)
+	}
+
+	remainingVersions := make(map[string]struct{}, len(topology.Versions))
+	for _, version := range topology.Versions {
+		remainingVersions[version.VersionID] = struct{}{}
+	}
+	remainingMarkers := make(map[string]struct{}, len(topology.DeleteMarkers))
+	for _, marker := range topology.DeleteMarkers {
+		remainingMarkers[marker.VersionID] = struct{}{}
+	}
+	deleteVersion := func(versionID string) (string, error) {
+		if err := p.renewRetirementClaim(ctx, item.BlockMetadataID, claimToken); err != nil {
+			return SkipRetirementClaimActive, err
+		}
+		if err := p.store.DeleteObjectVersion(ctx, item.Bucket, item.Key, versionID); err != nil {
+			return SkipVersionedDeleteFailed, err
+		}
+		return "", nil
+	}
+
+	// Keep the payload-validation version available until every older data
+	// version is gone, then remove delete markers only after all data versions.
+	for _, versionID := range item.VersionIDs[1:] {
+		if _, ok := remainingVersions[versionID]; !ok {
+			continue
+		}
+		if reason, err := deleteVersion(versionID); err != nil {
+			return reason, err
+		}
+	}
+	if _, ok := remainingVersions[item.VersionID]; ok {
+		if reason, err := deleteVersion(item.VersionID); err != nil {
+			return reason, err
+		}
+	}
+	for _, versionID := range item.DeleteMarkerVersionIDs {
+		if _, ok := remainingMarkers[versionID]; !ok {
+			continue
+		}
+		if reason, err := deleteVersion(versionID); err != nil {
+			return reason, err
+		}
+	}
+	return "", nil
 }
 
 func (p *Planner) completeObjectDeletion(
@@ -872,8 +953,9 @@ func pendingRetirementMatchesCandidate(row MetadataRow, candidate Candidate) boo
 		manifest.Bucket == candidate.Bucket &&
 		manifest.SingleBlockObjectKey == candidate.Key &&
 		manifest.SingleBlockObjectKeySHA256 == candidate.SingleBlockKeySHA256 &&
-		len(manifest.SingleBlockObjectVersionIDs) == 1 &&
-		manifest.SingleBlockObjectVersionIDs[0] == candidate.VersionID &&
+		sameStrings(manifest.SingleBlockObjectVersionIDs, candidate.VersionIDs) &&
+		sameStrings(manifest.SingleBlockDeleteMarkerVersionIDs, candidate.DeleteMarkerVersionIDs) &&
+		firstString(manifest.SingleBlockObjectVersionIDs) == candidate.VersionID &&
 		manifest.SingleBlockObjectETag == candidate.SingleBlockETag &&
 		manifest.SingleBlockObjectBytes == candidate.SingleBlockBytes &&
 		manifest.ConsolidatedObjectKey == candidate.ConsolidatedKey &&
@@ -957,7 +1039,7 @@ func validateApplyReport(req PlanRequest, report *Report) error {
 		report.SafetyGates.SingleBlockWritersGuarded != req.SingleBlockWritersGuarded ||
 		report.SafetyGates.FallbackReadErrors != req.FallbackErrorCount ||
 		report.SafetyGates.ProductionDeleteEnabled != req.ProductionDeleteEnabled ||
-		report.SafetyGates.VersionedDeleteMode != "exact_single_object_version_only" ||
+		report.SafetyGates.VersionedDeleteMode != versionedDeleteMode ||
 		report.SafetyGates.CSCBWriteOncePolicyMode != cscbWriteOncePolicyMode ||
 		!report.SafetyGates.CSCBWriteOncePolicyVerified {
 		return xerrors.New("retirement report does not match the execution request")
@@ -970,8 +1052,9 @@ func validateApplyReport(req PlanRequest, report *Report) error {
 			continue
 		}
 		if !requestAllowsCandidate(req, item) || item.BlockMetadataID <= 0 || item.Key == "" ||
-			item.SingleBlockKeySHA256 != keySHA256(item.Key) || !isImmutableVersionID(item.VersionID) || item.SingleBlockETag == "" ||
-			item.SingleBlockBytes == 0 || item.SingleBlockVersions != 1 || item.DeleteMarkers != 0 ||
+			item.SingleBlockKeySHA256 != keySHA256(item.Key) ||
+			!validPinnedVersionIDs(item.VersionID, item.VersionIDs, item.DeleteMarkerVersionIDs) || item.SingleBlockETag == "" ||
+			item.SingleBlockBytes == 0 || item.SingleBlockVersions != len(item.VersionIDs) || item.DeleteMarkers != len(item.DeleteMarkerVersionIDs) ||
 			item.ConsolidatedKey == "" || !isImmutableVersionID(item.CSCBVersionID) || item.CSCBETag == "" ||
 			!item.CSCBWriteOncePolicy ||
 			item.ByteLength == 0 || item.UncompressedLength == 0 || !isSHA256Hex(item.PayloadSHA256) {
@@ -982,24 +1065,146 @@ func validateApplyReport(req PlanRequest, report *Report) error {
 }
 
 func topologyMatchesCandidate(topology ObjectVersionTopology, candidate Candidate) bool {
-	return len(topology.Versions) == 1 &&
-		len(topology.DeleteMarkers) == 0 &&
-		topology.Versions[0].IsLatest &&
-		isImmutableVersionID(topology.Versions[0].VersionID) &&
-		topology.Versions[0].VersionID == candidate.VersionID &&
-		topology.Versions[0].ETag == candidate.SingleBlockETag &&
-		topology.Versions[0].Bytes == candidate.SingleBlockBytes
+	version, versionIDs, markerIDs, reason := pinSingleBlockTopology(topology)
+	return reason == "" &&
+		version.VersionID == candidate.VersionID &&
+		version.ETag == candidate.SingleBlockETag &&
+		version.Bytes == candidate.SingleBlockBytes &&
+		sameStrings(versionIDs, candidate.VersionIDs) &&
+		sameStrings(markerIDs, candidate.DeleteMarkerVersionIDs)
 }
 
 func topologyMatchesManifest(topology ObjectVersionTopology, manifest RetirementManifest) bool {
-	return len(manifest.SingleBlockObjectVersionIDs) == 1 &&
-		isImmutableVersionID(manifest.SingleBlockObjectVersionIDs[0]) &&
-		len(topology.Versions) == 1 &&
-		len(topology.DeleteMarkers) == 0 &&
-		topology.Versions[0].IsLatest &&
-		topology.Versions[0].VersionID == manifest.SingleBlockObjectVersionIDs[0] &&
-		topology.Versions[0].ETag == manifest.SingleBlockObjectETag &&
-		topology.Versions[0].Bytes == manifest.SingleBlockObjectBytes
+	return topologyMatchesCandidate(topology, candidateFromManifest(manifest))
+}
+
+func topologyIsPinnedSubset(topology ObjectVersionTopology, manifest RetirementManifest) bool {
+	return topologyIsPinnedCandidateSubset(topology, candidateFromManifest(manifest))
+}
+
+func topologyIsPinnedCandidateSubset(topology ObjectVersionTopology, candidate Candidate) bool {
+	if !validPinnedVersionIDs(candidate.VersionID, candidate.VersionIDs, candidate.DeleteMarkerVersionIDs) {
+		return false
+	}
+	versionIDs := make(map[string]struct{}, len(candidate.VersionIDs))
+	for _, versionID := range candidate.VersionIDs {
+		versionIDs[versionID] = struct{}{}
+	}
+	markerIDs := make(map[string]struct{}, len(candidate.DeleteMarkerVersionIDs))
+	for _, versionID := range candidate.DeleteMarkerVersionIDs {
+		markerIDs[versionID] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(topology.Versions)+len(topology.DeleteMarkers))
+	for _, version := range topology.Versions {
+		if !isImmutableVersionID(version.VersionID) {
+			return false
+		}
+		if _, ok := versionIDs[version.VersionID]; !ok {
+			return false
+		}
+		if _, duplicate := seen[version.VersionID]; duplicate {
+			return false
+		}
+		seen[version.VersionID] = struct{}{}
+		if version.VersionID == candidate.VersionID &&
+			(version.ETag != candidate.SingleBlockETag || version.Bytes != candidate.SingleBlockBytes) {
+			return false
+		}
+	}
+	for _, marker := range topology.DeleteMarkers {
+		if !isImmutableVersionID(marker.VersionID) {
+			return false
+		}
+		if _, ok := markerIDs[marker.VersionID]; !ok {
+			return false
+		}
+		if _, duplicate := seen[marker.VersionID]; duplicate {
+			return false
+		}
+		seen[marker.VersionID] = struct{}{}
+	}
+	return true
+}
+
+func pinSingleBlockTopology(topology ObjectVersionTopology) (ObjectVersion, []string, []string, string) {
+	if len(topology.Versions) == 0 {
+		return ObjectVersion{}, nil, nil, SkipUnsafeSingleBlockVersionTopology
+	}
+	seen := make(map[string]struct{}, len(topology.Versions)+len(topology.DeleteMarkers))
+	latestVersion := -1
+	latestEntries := 0
+	for i, version := range topology.Versions {
+		if !isImmutableVersionID(version.VersionID) {
+			return ObjectVersion{}, nil, nil, SkipSingleBlockVersionIDUnavailable
+		}
+		if _, duplicate := seen[version.VersionID]; duplicate {
+			return ObjectVersion{}, nil, nil, SkipUnsafeSingleBlockVersionTopology
+		}
+		seen[version.VersionID] = struct{}{}
+		if version.IsLatest {
+			latestEntries++
+			latestVersion = i
+		}
+	}
+	for _, marker := range topology.DeleteMarkers {
+		if !isImmutableVersionID(marker.VersionID) {
+			return ObjectVersion{}, nil, nil, SkipSingleBlockVersionIDUnavailable
+		}
+		if _, duplicate := seen[marker.VersionID]; duplicate {
+			return ObjectVersion{}, nil, nil, SkipUnsafeSingleBlockVersionTopology
+		}
+		seen[marker.VersionID] = struct{}{}
+		if marker.IsLatest {
+			latestEntries++
+		}
+	}
+	if latestEntries != 1 {
+		return ObjectVersion{}, nil, nil, SkipUnsafeSingleBlockVersionTopology
+	}
+	if latestVersion < 0 {
+		// ListObjectVersions returns data versions newest first. When a delete
+		// marker is current, the first data version is the last readable payload.
+		latestVersion = 0
+	}
+	selected := topology.Versions[latestVersion]
+	if selected.ETag == "" || selected.Bytes == 0 {
+		return ObjectVersion{}, nil, nil, SkipSingleBlockVersionIDUnavailable
+	}
+
+	versionIDs := make([]string, 0, len(topology.Versions))
+	versionIDs = append(versionIDs, selected.VersionID)
+	remainder := make([]string, 0, len(topology.Versions)-1)
+	for i, version := range topology.Versions {
+		if i != latestVersion {
+			remainder = append(remainder, version.VersionID)
+		}
+	}
+	sort.Strings(remainder)
+	versionIDs = append(versionIDs, remainder...)
+	markerIDs := make([]string, 0, len(topology.DeleteMarkers))
+	for _, marker := range topology.DeleteMarkers {
+		markerIDs = append(markerIDs, marker.VersionID)
+	}
+	sort.Strings(markerIDs)
+	return selected, versionIDs, markerIDs, ""
+}
+
+func validPinnedVersionIDs(validationVersionID string, versionIDs []string, markerIDs []string) bool {
+	if len(versionIDs) == 0 || versionIDs[0] != validationVersionID || !isImmutableVersionID(validationVersionID) ||
+		!sort.StringsAreSorted(versionIDs[1:]) || !sort.StringsAreSorted(markerIDs) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(versionIDs)+len(markerIDs))
+	for _, versionID := range append(append([]string(nil), versionIDs...), markerIDs...) {
+		if !isImmutableVersionID(versionID) {
+			return false
+		}
+		if _, duplicate := seen[versionID]; duplicate {
+			return false
+		}
+		seen[versionID] = struct{}{}
+	}
+	return true
 }
 
 func isImmutableVersionID(versionID string) bool {
@@ -1008,54 +1213,58 @@ func isImmutableVersionID(versionID string) bool {
 
 func manifestFromCandidate(candidate Candidate, preparedAt time.Time) RetirementManifest {
 	return RetirementManifest{
-		BlockMetadataID:                candidate.BlockMetadataID,
-		Tag:                            candidate.Tag,
-		Height:                         candidate.Height,
-		Hash:                           candidate.Hash,
-		State:                          RetirementStateEligible,
-		Bucket:                         candidate.Bucket,
-		SingleBlockObjectKey:           candidate.Key,
-		SingleBlockObjectKeySHA256:     keySHA256(candidate.Key),
-		SingleBlockObjectVersionIDs:    []string{candidate.VersionID},
-		SingleBlockObjectETag:          candidate.SingleBlockETag,
-		SingleBlockObjectBytes:         candidate.SingleBlockBytes,
-		ConsolidatedObjectKey:          candidate.ConsolidatedKey,
-		ConsolidatedObjectVersionID:    candidate.CSCBVersionID,
-		ConsolidatedObjectETag:         candidate.CSCBETag,
-		ConsolidatedByteOffset:         candidate.ByteOffset,
-		ConsolidatedByteLength:         candidate.ByteLength,
-		ConsolidatedUncompressedLength: candidate.UncompressedLength,
-		PayloadSHA256:                  candidate.PayloadSHA256,
-		PreparedAt:                     preparedAt,
+		BlockMetadataID:                   candidate.BlockMetadataID,
+		Tag:                               candidate.Tag,
+		Height:                            candidate.Height,
+		Hash:                              candidate.Hash,
+		State:                             RetirementStateEligible,
+		Bucket:                            candidate.Bucket,
+		SingleBlockObjectKey:              candidate.Key,
+		SingleBlockObjectKeySHA256:        keySHA256(candidate.Key),
+		SingleBlockObjectVersionIDs:       append([]string(nil), candidate.VersionIDs...),
+		SingleBlockDeleteMarkerVersionIDs: append([]string(nil), candidate.DeleteMarkerVersionIDs...),
+		SingleBlockObjectETag:             candidate.SingleBlockETag,
+		SingleBlockObjectBytes:            candidate.SingleBlockBytes,
+		ConsolidatedObjectKey:             candidate.ConsolidatedKey,
+		ConsolidatedObjectVersionID:       candidate.CSCBVersionID,
+		ConsolidatedObjectETag:            candidate.CSCBETag,
+		ConsolidatedByteOffset:            candidate.ByteOffset,
+		ConsolidatedByteLength:            candidate.ByteLength,
+		ConsolidatedUncompressedLength:    candidate.UncompressedLength,
+		PayloadSHA256:                     candidate.PayloadSHA256,
+		PreparedAt:                        preparedAt,
 	}
 }
 
 func candidateFromManifest(manifest RetirementManifest) Candidate {
 	candidate := Candidate{
-		Bucket:               manifest.Bucket,
-		Key:                  manifest.SingleBlockObjectKey,
-		VersionID:            firstString(manifest.SingleBlockObjectVersionIDs),
-		BlockMetadataID:      manifest.BlockMetadataID,
-		Tag:                  manifest.Tag,
-		Height:               manifest.Height,
-		Hash:                 manifest.Hash,
-		SingleBlockBytes:     manifest.SingleBlockObjectBytes,
-		SingleBlockETag:      manifest.SingleBlockObjectETag,
-		SingleBlockKeySHA256: manifest.SingleBlockObjectKeySHA256,
-		SingleBlockVersions:  len(manifest.SingleBlockObjectVersionIDs),
-		ConsolidatedKey:      manifest.ConsolidatedObjectKey,
-		CSCBVersionID:        manifest.ConsolidatedObjectVersionID,
-		CSCBETag:             manifest.ConsolidatedObjectETag,
-		ByteOffset:           manifest.ConsolidatedByteOffset,
-		ByteLength:           manifest.ConsolidatedByteLength,
-		UncompressedLength:   manifest.ConsolidatedUncompressedLength,
-		PayloadSHA256:        manifest.PayloadSHA256,
-		RetirementState:      manifest.State,
-		RetirementAttempts:   manifest.AttemptCount,
-		RetirementOutcome:    manifest.Outcome,
-		SingleBlockDeletedAt: manifest.DeletedAt,
-		RetirementVerifiedAt: manifest.VerifiedAt,
-		Action:               ActionDeleteObjectVersion,
+		Bucket:                 manifest.Bucket,
+		Key:                    manifest.SingleBlockObjectKey,
+		VersionID:              firstString(manifest.SingleBlockObjectVersionIDs),
+		VersionIDs:             append([]string(nil), manifest.SingleBlockObjectVersionIDs...),
+		DeleteMarkerVersionIDs: append([]string(nil), manifest.SingleBlockDeleteMarkerVersionIDs...),
+		BlockMetadataID:        manifest.BlockMetadataID,
+		Tag:                    manifest.Tag,
+		Height:                 manifest.Height,
+		Hash:                   manifest.Hash,
+		SingleBlockBytes:       manifest.SingleBlockObjectBytes,
+		SingleBlockETag:        manifest.SingleBlockObjectETag,
+		SingleBlockKeySHA256:   manifest.SingleBlockObjectKeySHA256,
+		SingleBlockVersions:    len(manifest.SingleBlockObjectVersionIDs),
+		DeleteMarkers:          len(manifest.SingleBlockDeleteMarkerVersionIDs),
+		ConsolidatedKey:        manifest.ConsolidatedObjectKey,
+		CSCBVersionID:          manifest.ConsolidatedObjectVersionID,
+		CSCBETag:               manifest.ConsolidatedObjectETag,
+		ByteOffset:             manifest.ConsolidatedByteOffset,
+		ByteLength:             manifest.ConsolidatedByteLength,
+		UncompressedLength:     manifest.ConsolidatedUncompressedLength,
+		PayloadSHA256:          manifest.PayloadSHA256,
+		RetirementState:        manifest.State,
+		RetirementAttempts:     manifest.AttemptCount,
+		RetirementOutcome:      manifest.Outcome,
+		SingleBlockDeletedAt:   manifest.DeletedAt,
+		RetirementVerifiedAt:   manifest.VerifiedAt,
+		Action:                 ActionDeleteObjectVersion,
 	}
 	if manifest.State == RetirementStateDeletedPendingVerification {
 		candidate.Action = ActionDeletedObjectVersion
@@ -1117,7 +1326,7 @@ func newReport(req PlanRequest) *Report {
 			ClientMigrationApproved:   req.ClientMigrationApproved,
 			SingleBlockWritersGuarded: req.SingleBlockWritersGuarded,
 			FallbackReadErrors:        req.FallbackErrorCount,
-			VersionedDeleteMode:       "exact_single_object_version_only",
+			VersionedDeleteMode:       versionedDeleteMode,
 			CSCBWriteOncePolicyMode:   cscbWriteOncePolicyMode,
 			ProductionDeleteEnabled:   req.ProductionDeleteEnabled,
 		},

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -1195,7 +1195,7 @@ func validPinnedVersionIDs(validationVersionID string, versionIDs []string, mark
 		return false
 	}
 	seen := make(map[string]struct{}, len(versionIDs)+len(markerIDs))
-	for _, versionID := range append(append([]string(nil), versionIDs...), markerIDs...) {
+	for _, versionID := range versionIDs {
 		if !isImmutableVersionID(versionID) {
 			return false
 		}
@@ -1203,6 +1203,15 @@ func validPinnedVersionIDs(validationVersionID string, versionIDs []string, mark
 			return false
 		}
 		seen[versionID] = struct{}{}
+	}
+	for _, markerID := range markerIDs {
+		if !isImmutableVersionID(markerID) {
+			return false
+		}
+		if _, duplicate := seen[markerID]; duplicate {
+			return false
+		}
+		seen[markerID] = struct{}{}
 	}
 	return true
 }

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -279,6 +279,7 @@ type fakeStore struct {
 	policyHook    func(key string, call int) (RetentionSafetySnapshot, error)
 	deleted       []Candidate
 	deleteMutates bool
+	deleteErrors  map[string]error
 	listHook      func(key string, call int) ObjectVersionTopology
 	headHook      func(key string, call int) ObjectHead
 }
@@ -294,6 +295,7 @@ func newFakeStore() *fakeStore {
 		policyCalls:  make(map[string]int),
 		policyErrors: make(map[string]error),
 		policyHashes: make(map[string]string),
+		deleteErrors: make(map[string]error),
 	}
 }
 
@@ -346,14 +348,36 @@ func (s *fakeStore) ReadObjectVersionRange(ctx context.Context, bucket string, k
 }
 
 func (s *fakeStore) DeleteObjectVersion(ctx context.Context, bucket string, key string, versionID string) error {
+	if err := s.deleteErrors[versionID]; err != nil {
+		return err
+	}
 	s.deleted = append(s.deleted, Candidate{
 		Bucket:    bucket,
 		Key:       key,
 		VersionID: versionID,
 	})
 	if s.deleteMutates {
-		delete(s.topologies, key)
-		delete(s.heads, key)
+		topology := s.topologies[key]
+		versions := topology.Versions[:0]
+		for _, version := range topology.Versions {
+			if version.VersionID != versionID {
+				versions = append(versions, version)
+			}
+		}
+		topology.Versions = versions
+		markers := topology.DeleteMarkers[:0]
+		for _, marker := range topology.DeleteMarkers {
+			if marker.VersionID != versionID {
+				markers = append(markers, marker)
+			}
+		}
+		topology.DeleteMarkers = markers
+		if len(topology.Versions) == 0 && len(topology.DeleteMarkers) == 0 {
+			delete(s.topologies, key)
+			delete(s.heads, key)
+		} else {
+			s.topologies[key] = topology
+		}
 	}
 	return nil
 }
@@ -645,7 +669,7 @@ func TestPlannerPlan_PromotedRowUsesShadowSingleBlockKeyAndRetireAfter(t *testin
 	require.Empty(report.Items[0].SkipReason)
 }
 
-func TestPlannerPlan_VersionedDeleteMarkerBehavior(t *testing.T) {
+func TestPlannerPlan_RejectsMarkerOnlyTopology(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	validatedAt := now.Add(-8 * 24 * time.Hour)
@@ -664,39 +688,69 @@ func TestPlannerPlan_VersionedDeleteMarkerBehavior(t *testing.T) {
 	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
 }
 
-func TestPlannerPlan_RejectsNonSingletonSingleBlockTopology(t *testing.T) {
+func TestPlannerPlan_AcceptsImmutableMultiVersionTopology(t *testing.T) {
+	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	validatedAt := now.Add(-8 * 24 * time.Hour)
-	for _, test := range []struct {
-		name     string
-		topology ObjectVersionTopology
-	}{
-		{
-			name: "older version exists",
-			topology: ObjectVersionTopology{Versions: []ObjectVersion{
-				{VersionID: "single-block-v2", ETag: "etag-v2", Bytes: 42, IsLatest: true},
-				{VersionID: "single-block-v1", ETag: "etag-v1", Bytes: 41, IsLatest: false},
-			}},
+	row := testRow(100, "hash-100", "single-block/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
+	store := newFakeStore()
+	store.topologies[row.SingleBlockObjectKey] = ObjectVersionTopology{
+		Versions: []ObjectVersion{
+			{VersionID: "single-block-v2", ETag: "etag-v2", Bytes: 42, IsLatest: true},
+			{VersionID: "single-block-v1", ETag: "etag-v1", Bytes: 41},
 		},
-		{
-			name: "single version is not latest",
-			topology: ObjectVersionTopology{Versions: []ObjectVersion{
-				{VersionID: "single-block-v1", ETag: "etag-v1", Bytes: 42, IsLatest: false},
-			}},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			require := require.New(t)
-			row := testRow(100, "hash-100", "single-block/100.zstd", "consolidated/canary.cscb.zstd", validatedAt)
-			store := newFakeStore()
-			store.topologies[row.SingleBlockObjectKey] = test.topology
-			report, err := testPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
-			require.NoError(err)
-			require.Equal(ActionSkip, report.Items[0].Action)
-			require.Equal(SkipUnsafeSingleBlockVersionTopology, report.Items[0].SkipReason)
-			require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
-		})
+		DeleteMarkers: []ObjectDeleteMarker{{VersionID: "delete-marker-v1"}},
 	}
+	store.heads[row.PrimaryObjectKey] = cscbObjectHead(1024, 1024)
+
+	report, err := testPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Equal(ActionReportOnly, report.Items[0].Action)
+	require.Empty(report.Items[0].SkipReason)
+	require.Equal("single-block-v2", report.Items[0].VersionID)
+	require.Equal(2, report.Items[0].SingleBlockVersions)
+	require.Equal(1, report.Items[0].DeleteMarkers)
+}
+
+func TestPlannerPlan_AcceptsCurrentDeleteMarkerWithHistoricalDataVersions(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	row := testRow(100, "hash-100", "single-block/100.zstd", "consolidated/canary.cscb.zstd", now.Add(-8*24*time.Hour))
+	store := newFakeStore()
+	store.topologies[row.SingleBlockObjectKey] = ObjectVersionTopology{
+		Versions: []ObjectVersion{
+			{VersionID: "single-block-v2", ETag: "etag-v2", Bytes: 42},
+			{VersionID: "single-block-v1", ETag: "etag-v1", Bytes: 41},
+		},
+		DeleteMarkers: []ObjectDeleteMarker{{VersionID: "delete-marker-v3", IsLatest: true}},
+	}
+	store.heads[row.PrimaryObjectKey] = cscbObjectHead(1024, 1024)
+
+	report, err := testPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Equal(ActionReportOnly, report.Items[0].Action)
+	require.Empty(report.Items[0].SkipReason)
+	require.Equal("single-block-v2", report.Items[0].VersionID)
+	require.Equal([]string{"single-block-v2", "single-block-v1"}, report.Items[0].VersionIDs)
+	require.Equal([]string{"delete-marker-v3"}, report.Items[0].DeleteMarkerVersionIDs)
+}
+
+func TestPlannerPlan_RejectsTopologyWithoutLatestEntry(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	row := testRow(100, "hash-100", "single-block/100.zstd", "consolidated/canary.cscb.zstd", now.Add(-8*24*time.Hour))
+	store := newFakeStore()
+	store.topologies[row.SingleBlockObjectKey] = ObjectVersionTopology{Versions: []ObjectVersion{{
+		VersionID: "single-block-v1",
+		ETag:      "etag-v1",
+		Bytes:     42,
+	}}}
+
+	report, err := testPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Equal(ActionSkip, report.Items[0].Action)
+	require.Equal(SkipUnsafeSingleBlockVersionTopology, report.Items[0].SkipReason)
+	require.Zero(store.headCalls[row.Shadow.ConsolidatedObjectKey])
 }
 
 func TestPlannerPlan_RejectsMutableNullVersionIDs(t *testing.T) {
@@ -718,6 +772,15 @@ func TestPlannerPlan_RejectsMutableNullVersionIDs(t *testing.T) {
 	report, err = testPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
 	require.NoError(err)
 	require.Equal(SkipMissingCSCBObject, report.Items[0].SkipReason)
+
+	store.topologies[row.SingleBlockObjectKey] = ObjectVersionTopology{
+		Versions:      []ObjectVersion{{VersionID: "single-block-v1", ETag: "single-block-etag", Bytes: 42, IsLatest: true}},
+		DeleteMarkers: []ObjectDeleteMarker{{VersionID: "null"}},
+	}
+	store.heads[row.PrimaryObjectKey] = cscbObjectHead(1024, 1024)
+	report, err = testPlanner(&fakeRepo{rows: []MetadataRow{row}}, store).Plan(context.Background(), testRequest(now, false))
+	require.NoError(err)
+	require.Equal(SkipSingleBlockVersionIDUnavailable, report.Items[0].SkipReason)
 }
 
 func TestPlannerPlan_RequiresIndependentPayloadComparison(t *testing.T) {
@@ -990,6 +1053,90 @@ func TestPlannerApply_RequiresProductionGateAndFinalizesMetadata(t *testing.T) {
 	require.NotNil(finalReport.Items[0].RetirementVerifiedAt)
 	require.Empty(finalReport.Items[0].Key)
 	require.Equal(keySHA256(row.SingleBlockObjectKey), manifest.SingleBlockObjectKeySHA256)
+}
+
+func TestPlannerApply_DeletesEveryPinnedVersionAndDeleteMarker(t *testing.T) {
+	require := require.New(t)
+	row, repo, store, planner, _, req, report := newMultiVersionExecutableTestFixture(t)
+
+	err := planner.Apply(context.Background(), req, report)
+	require.NoError(err)
+	require.Equal(ActionDeletedVerified, report.Items[0].Action)
+	require.Len(store.deleted, 3)
+	require.Equal([]string{"single-block-v1", "single-block-v2", "delete-marker-v1"}, []string{
+		store.deleted[0].VersionID,
+		store.deleted[1].VersionID,
+		store.deleted[2].VersionID,
+	})
+	require.Empty(store.topologies[row.SingleBlockObjectKey].Versions)
+	require.Empty(store.topologies[row.SingleBlockObjectKey].DeleteMarkers)
+	require.Empty(repo.rows[0].SingleBlockObjectKey)
+	require.Empty(repo.rows[0].Shadow.SingleBlockObjectKey)
+	manifest := repo.manifests[row.BlockMetadataID]
+	require.Equal(RetirementStateDeletedVerified, manifest.State)
+	require.Equal([]string{"single-block-v2", "single-block-v1"}, manifest.SingleBlockObjectVersionIDs)
+	require.Equal([]string{"delete-marker-v1"}, manifest.SingleBlockDeleteMarkerVersionIDs)
+}
+
+func TestPlannerReconcile_ResumesPartiallyDeletedPinnedTopology(t *testing.T) {
+	require := require.New(t)
+	row, repo, store, planner, _, req, report := newMultiVersionExecutableTestFixture(t)
+	store.deleteErrors["single-block-v2"] = errors.New("temporary S3 failure")
+
+	err := planner.Apply(context.Background(), req, report)
+	require.Error(err)
+	require.Equal([]string{"single-block-v1"}, []string{store.deleted[0].VersionID})
+	require.Equal(RetirementStateDeleting, repo.manifests[row.BlockMetadataID].State)
+	require.Len(store.topologies[row.SingleBlockObjectKey].Versions, 1)
+	require.Len(store.topologies[row.SingleBlockObjectKey].DeleteMarkers, 1)
+	require.Equal(row.SingleBlockObjectKey, repo.rows[0].SingleBlockObjectKey)
+
+	delete(store.deleteErrors, "single-block-v2")
+	manifest := repo.manifests[row.BlockMetadataID]
+	expiredAt := time.Now().UTC().Add(-time.Second)
+	manifest.ClaimExpiresAt = &expiredAt
+	repo.manifests[row.BlockMetadataID] = manifest
+	repo.updateManifestRow(manifest)
+
+	reconcileReport, err := planner.Reconcile(context.Background(), req)
+	require.NoError(err)
+	require.Equal(ActionDeletedVerified, reconcileReport.Items[0].Action)
+	require.Equal([]string{"single-block-v1", "single-block-v2", "delete-marker-v1"}, []string{
+		store.deleted[0].VersionID,
+		store.deleted[1].VersionID,
+		store.deleted[2].VersionID,
+	})
+	require.Empty(repo.rows[0].SingleBlockObjectKey)
+	require.Empty(repo.rows[0].Shadow.SingleBlockObjectKey)
+	require.Equal(RetirementStateDeletedVerified, repo.manifests[row.BlockMetadataID].State)
+}
+
+func TestPlannerReconcile_RejectsUnpinnedVersionAfterPartialDeletion(t *testing.T) {
+	require := require.New(t)
+	row, repo, store, planner, _, req, report := newMultiVersionExecutableTestFixture(t)
+	store.deleteErrors["single-block-v2"] = errors.New("temporary S3 failure")
+	require.Error(planner.Apply(context.Background(), req, report))
+
+	delete(store.deleteErrors, "single-block-v2")
+	topology := store.topologies[row.SingleBlockObjectKey]
+	topology.Versions = append(topology.Versions, ObjectVersion{
+		VersionID: "unpinned-v3",
+		ETag:      "unpinned-etag",
+		Bytes:     40,
+	})
+	store.topologies[row.SingleBlockObjectKey] = topology
+	manifest := repo.manifests[row.BlockMetadataID]
+	expiredAt := time.Now().UTC().Add(-time.Second)
+	manifest.ClaimExpiresAt = &expiredAt
+	repo.manifests[row.BlockMetadataID] = manifest
+	repo.updateManifestRow(manifest)
+
+	reconcileReport, err := planner.Reconcile(context.Background(), req)
+	require.Error(err)
+	require.Equal(ActionSkip, reconcileReport.Items[0].Action)
+	require.Equal(SkipUnsafeSingleBlockVersionTopology, reconcileReport.Items[0].SkipReason)
+	require.Len(store.deleted, 1)
+	require.Equal(row.SingleBlockObjectKey, repo.rows[0].SingleBlockObjectKey)
 }
 
 func TestPlannerApply_RejectsTamperedReportBeforeManifestWrite(t *testing.T) {
@@ -1472,6 +1619,48 @@ func newExecutableTestFixture(t *testing.T) (
 	store := newFakeStore()
 	store.deleteMutates = true
 	store.topologies[row.SingleBlockObjectKey] = safeTopology("single-block-v1", "single-block-etag", 42)
+	cscbHead := cscbObjectHead(1024, 1024)
+	store.heads[row.PrimaryObjectKey] = cscbHead
+	store.versionHeads[versionObjectKey(row.PrimaryObjectKey, cscbHead.VersionID)] = cscbHead
+	planner, verifier := newTestPlanner(repo, store)
+	req := testRequest(now, true)
+	req.ProductionDeleteEnabled = true
+	report, err := planner.Plan(context.Background(), req)
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(ActionDeleteObjectVersion, report.Items[0].Action)
+	return row, repo, store, planner, verifier, req, report
+}
+
+func newMultiVersionExecutableTestFixture(t *testing.T) (
+	MetadataRow,
+	*fakeRepo,
+	*fakeStore,
+	*Planner,
+	*fakePayloadVerifier,
+	PlanRequest,
+	*Report,
+) {
+	t.Helper()
+	require := require.New(t)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	row := testRow(
+		428058000,
+		"hash-428058000",
+		"single-block/428058000.zstd",
+		"consolidated/canary.cscb.zstd",
+		now.Add(-8*24*time.Hour),
+	)
+	repo := &fakeRepo{rows: []MetadataRow{row}}
+	store := newFakeStore()
+	store.deleteMutates = true
+	store.topologies[row.SingleBlockObjectKey] = ObjectVersionTopology{
+		Versions: []ObjectVersion{
+			{VersionID: "single-block-v2", ETag: "etag-v2", Bytes: 42, IsLatest: true},
+			{VersionID: "single-block-v1", ETag: "etag-v1", Bytes: 41},
+		},
+		DeleteMarkers: []ObjectDeleteMarker{{VersionID: "delete-marker-v1"}},
+	}
 	cscbHead := cscbObjectHead(1024, 1024)
 	store.heads[row.PrimaryObjectKey] = cscbHead
 	store.versionHeads[versionObjectKey(row.PrimaryObjectKey, cscbHead.VersionID)] = cscbHead

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -47,6 +47,7 @@ const metadataRowColumns = `
 	retirement.single_block_object_key_main,
 	retirement.single_block_object_key_sha256,
 	retirement.single_block_object_version_ids,
+	retirement.single_block_delete_marker_version_ids,
 	retirement.single_block_object_etag,
 	retirement.single_block_object_bytes,
 	retirement.consolidated_object_key_main,
@@ -228,13 +229,14 @@ func (r *PostgresRepository) PrepareRetirement(ctx context.Context, manifest Ret
 		INSERT INTO block_single_block_retention (
 			block_metadata_id, tag, height, hash, state, bucket,
 			single_block_object_key_main, single_block_object_key_sha256, single_block_object_version_ids,
+			single_block_delete_marker_version_ids,
 			single_block_object_etag, single_block_object_bytes,
 			consolidated_object_key_main, consolidated_object_version_id, consolidated_object_etag,
 			consolidated_byte_offset, consolidated_byte_length, consolidated_uncompressed_length,
 			payload_sha256, outcome, prepared_at, updated_at
 		)
 		VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, $9, $10, $11,
-			$12, $13, $14, $15, $16, $17, $18, $19, $20, $20)
+			$12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $21)
 		ON CONFLICT (block_metadata_id) DO NOTHING`
 	if _, err := tx.ExecContext(ctx, insert,
 		manifest.BlockMetadataID,
@@ -246,6 +248,7 @@ func (r *PostgresRepository) PrepareRetirement(ctx context.Context, manifest Ret
 		manifest.SingleBlockObjectKey,
 		manifest.SingleBlockObjectKeySHA256,
 		pq.Array(manifest.SingleBlockObjectVersionIDs),
+		pq.Array(manifest.SingleBlockDeleteMarkerVersionIDs),
 		manifest.SingleBlockObjectETag,
 		manifest.SingleBlockObjectBytes,
 		manifest.ConsolidatedObjectKey,
@@ -842,6 +845,7 @@ func (r *PostgresRepository) ListPendingRetirements(ctx context.Context, tag uin
 		SELECT
 			block_metadata_id, tag, height, COALESCE(hash, ''), state, bucket,
 			single_block_object_key_main, single_block_object_key_sha256, single_block_object_version_ids,
+			single_block_delete_marker_version_ids,
 			single_block_object_etag, single_block_object_bytes,
 			consolidated_object_key_main, consolidated_object_version_id, consolidated_object_etag,
 			consolidated_byte_offset, consolidated_byte_length, consolidated_uncompressed_length,
@@ -915,6 +919,7 @@ func scanMetadataRow(source scanner) (MetadataRow, error) {
 	var retirementSingleBlockKey sql.NullString
 	var retirementSingleBlockKeySHA256 sql.NullString
 	var retirementVersionIDs pq.StringArray
+	var retirementDeleteMarkerVersionIDs pq.StringArray
 	var retirementSingleBlockETag sql.NullString
 	var retirementSingleBlockBytes sql.NullInt64
 	var retirementConsolidatedKey sql.NullString
@@ -967,6 +972,7 @@ func scanMetadataRow(source scanner) (MetadataRow, error) {
 		&retirementSingleBlockKey,
 		&retirementSingleBlockKeySHA256,
 		&retirementVersionIDs,
+		&retirementDeleteMarkerVersionIDs,
 		&retirementSingleBlockETag,
 		&retirementSingleBlockBytes,
 		&retirementConsolidatedKey,
@@ -1014,33 +1020,34 @@ func scanMetadataRow(source scanner) (MetadataRow, error) {
 	}
 	if retirementBlockMetadataID.Valid {
 		row.Retirement = &RetirementManifest{
-			BlockMetadataID:                retirementBlockMetadataID.Int64,
-			Tag:                            row.Tag,
-			Height:                         row.Height,
-			Hash:                           row.Hash,
-			State:                          retirementState.String,
-			Bucket:                         retirementBucket.String,
-			SingleBlockObjectKey:           retirementSingleBlockKey.String,
-			SingleBlockObjectKeySHA256:     retirementSingleBlockKeySHA256.String,
-			SingleBlockObjectVersionIDs:    append([]string(nil), retirementVersionIDs...),
-			SingleBlockObjectETag:          retirementSingleBlockETag.String,
-			SingleBlockObjectBytes:         nullableUint64(retirementSingleBlockBytes),
-			ConsolidatedObjectKey:          retirementConsolidatedKey.String,
-			ConsolidatedObjectVersionID:    retirementConsolidatedVersionID.String,
-			ConsolidatedObjectETag:         retirementConsolidatedETag.String,
-			ConsolidatedByteOffset:         nullableUint64(retirementByteOffset),
-			ConsolidatedByteLength:         nullableUint64(retirementByteLength),
-			ConsolidatedUncompressedLength: nullableUint64(retirementUncompressedLength),
-			PayloadSHA256:                  retirementPayloadSHA256.String,
-			Outcome:                        retirementOutcome.String,
-			AttemptCount:                   int(retirementAttemptCount.Int64),
-			ClaimToken:                     retirementClaimToken.String,
-			ClaimExpiresAt:                 nullableTime(retirementClaimExpiresAt),
-			PreparedAt:                     retirementPreparedAt.Time,
-			DeleteStartedAt:                nullableTime(retirementDeleteStartedAt),
-			LastAttemptAt:                  nullableTime(retirementLastAttemptAt),
-			DeletedAt:                      nullableTime(retirementDeletedAt),
-			VerifiedAt:                     nullableTime(retirementVerifiedAt),
+			BlockMetadataID:                   retirementBlockMetadataID.Int64,
+			Tag:                               row.Tag,
+			Height:                            row.Height,
+			Hash:                              row.Hash,
+			State:                             retirementState.String,
+			Bucket:                            retirementBucket.String,
+			SingleBlockObjectKey:              retirementSingleBlockKey.String,
+			SingleBlockObjectKeySHA256:        retirementSingleBlockKeySHA256.String,
+			SingleBlockObjectVersionIDs:       append([]string(nil), retirementVersionIDs...),
+			SingleBlockDeleteMarkerVersionIDs: append([]string(nil), retirementDeleteMarkerVersionIDs...),
+			SingleBlockObjectETag:             retirementSingleBlockETag.String,
+			SingleBlockObjectBytes:            nullableUint64(retirementSingleBlockBytes),
+			ConsolidatedObjectKey:             retirementConsolidatedKey.String,
+			ConsolidatedObjectVersionID:       retirementConsolidatedVersionID.String,
+			ConsolidatedObjectETag:            retirementConsolidatedETag.String,
+			ConsolidatedByteOffset:            nullableUint64(retirementByteOffset),
+			ConsolidatedByteLength:            nullableUint64(retirementByteLength),
+			ConsolidatedUncompressedLength:    nullableUint64(retirementUncompressedLength),
+			PayloadSHA256:                     retirementPayloadSHA256.String,
+			Outcome:                           retirementOutcome.String,
+			AttemptCount:                      int(retirementAttemptCount.Int64),
+			ClaimToken:                        retirementClaimToken.String,
+			ClaimExpiresAt:                    nullableTime(retirementClaimExpiresAt),
+			PreparedAt:                        retirementPreparedAt.Time,
+			DeleteStartedAt:                   nullableTime(retirementDeleteStartedAt),
+			LastAttemptAt:                     nullableTime(retirementLastAttemptAt),
+			DeletedAt:                         nullableTime(retirementDeletedAt),
+			VerifiedAt:                        nullableTime(retirementVerifiedAt),
 		}
 	}
 	return row, nil
@@ -1051,6 +1058,7 @@ func getManifestForUpdate(ctx context.Context, tx *sql.Tx, blockMetadataID int64
 		SELECT
 			block_metadata_id, tag, height, COALESCE(hash, ''), state, bucket,
 			single_block_object_key_main, single_block_object_key_sha256, single_block_object_version_ids,
+			single_block_delete_marker_version_ids,
 			single_block_object_etag, single_block_object_bytes,
 			consolidated_object_key_main, consolidated_object_version_id, consolidated_object_etag,
 			consolidated_byte_offset, consolidated_byte_length, consolidated_uncompressed_length,
@@ -1071,6 +1079,7 @@ func scanManifest(source scanner) (RetirementManifest, error) {
 	var hash sql.NullString
 	var singleBlockKey sql.NullString
 	var versionIDs pq.StringArray
+	var deleteMarkerVersionIDs pq.StringArray
 	var singleBlockBytes int64
 	var byteOffset int64
 	var byteLength int64
@@ -1092,6 +1101,7 @@ func scanManifest(source scanner) (RetirementManifest, error) {
 		&singleBlockKey,
 		&manifest.SingleBlockObjectKeySHA256,
 		&versionIDs,
+		&deleteMarkerVersionIDs,
 		&manifest.SingleBlockObjectETag,
 		&singleBlockBytes,
 		&manifest.ConsolidatedObjectKey,
@@ -1119,6 +1129,7 @@ func scanManifest(source scanner) (RetirementManifest, error) {
 	manifest.Hash = hash.String
 	manifest.SingleBlockObjectKey = singleBlockKey.String
 	manifest.SingleBlockObjectVersionIDs = append([]string(nil), versionIDs...)
+	manifest.SingleBlockDeleteMarkerVersionIDs = append([]string(nil), deleteMarkerVersionIDs...)
 	manifest.SingleBlockObjectBytes = uint64(singleBlockBytes)
 	manifest.ConsolidatedByteOffset = uint64(byteOffset)
 	manifest.ConsolidatedByteLength = uint64(byteLength)
@@ -1157,7 +1168,11 @@ func validateManifestMetadata(row MetadataRow, manifest RetirementManifest) erro
 func validatePreparedManifest(manifest RetirementManifest) error {
 	if manifest.BlockMetadataID <= 0 || manifest.Bucket == "" || manifest.SingleBlockObjectKey == "" ||
 		manifest.SingleBlockObjectKeySHA256 != keySHA256(manifest.SingleBlockObjectKey) ||
-		len(manifest.SingleBlockObjectVersionIDs) != 1 || !isImmutableVersionID(manifest.SingleBlockObjectVersionIDs[0]) ||
+		!validPinnedVersionIDs(
+			firstString(manifest.SingleBlockObjectVersionIDs),
+			manifest.SingleBlockObjectVersionIDs,
+			manifest.SingleBlockDeleteMarkerVersionIDs,
+		) ||
 		manifest.SingleBlockObjectETag == "" || manifest.SingleBlockObjectBytes == 0 ||
 		manifest.ConsolidatedObjectKey == "" || !isImmutableVersionID(manifest.ConsolidatedObjectVersionID) || manifest.ConsolidatedObjectETag == "" ||
 		manifest.ConsolidatedByteLength == 0 || manifest.ConsolidatedUncompressedLength == 0 ||
@@ -1179,6 +1194,7 @@ func samePreparedManifest(existing RetirementManifest, expected RetirementManife
 		existing.SingleBlockObjectKey == expected.SingleBlockObjectKey &&
 		existing.SingleBlockObjectKeySHA256 == expected.SingleBlockObjectKeySHA256 &&
 		sameStrings(existing.SingleBlockObjectVersionIDs, expected.SingleBlockObjectVersionIDs) &&
+		sameStrings(existing.SingleBlockDeleteMarkerVersionIDs, expected.SingleBlockDeleteMarkerVersionIDs) &&
 		existing.SingleBlockObjectETag == expected.SingleBlockObjectETag &&
 		existing.SingleBlockObjectBytes == expected.SingleBlockObjectBytes &&
 		existing.ConsolidatedObjectKey == expected.ConsolidatedObjectKey &&

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -238,6 +238,10 @@ func (r *PostgresRepository) PrepareRetirement(ctx context.Context, manifest Ret
 		VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, $9, $10, $11,
 			$12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $21)
 		ON CONFLICT (block_metadata_id) DO NOTHING`
+	deleteMarkerVersionIDs := manifest.SingleBlockDeleteMarkerVersionIDs
+	if deleteMarkerVersionIDs == nil {
+		deleteMarkerVersionIDs = []string{}
+	}
 	if _, err := tx.ExecContext(ctx, insert,
 		manifest.BlockMetadataID,
 		manifest.Tag,
@@ -248,7 +252,7 @@ func (r *PostgresRepository) PrepareRetirement(ctx context.Context, manifest Ret
 		manifest.SingleBlockObjectKey,
 		manifest.SingleBlockObjectKeySHA256,
 		pq.Array(manifest.SingleBlockObjectVersionIDs),
-		pq.Array(manifest.SingleBlockDeleteMarkerVersionIDs),
+		pq.Array(deleteMarkerVersionIDs),
 		manifest.SingleBlockObjectETag,
 		manifest.SingleBlockObjectBytes,
 		manifest.ConsolidatedObjectKey,

--- a/internal/storage/retirement/repository_postgres_integration_test.go
+++ b/internal/storage/retirement/repository_postgres_integration_test.go
@@ -104,25 +104,26 @@ func TestIntegrationPostgresRepositoryRetirementStateMachine(t *testing.T) {
 	repo := NewPostgresRepository(db)
 	preparedAt := time.Now().UTC().Add(7 * 24 * time.Hour)
 	manifest := RetirementManifest{
-		BlockMetadataID:                blockMetadataID,
-		Tag:                            tag,
-		Height:                         height,
-		Hash:                           hash,
-		State:                          RetirementStateEligible,
-		Bucket:                         "integration-bucket",
-		SingleBlockObjectKey:           singleBlockKey,
-		SingleBlockObjectKeySHA256:     keySHA256(singleBlockKey),
-		SingleBlockObjectVersionIDs:    []string{"single-block-v1"},
-		SingleBlockObjectETag:          "single-block-etag",
-		SingleBlockObjectBytes:         256,
-		ConsolidatedObjectKey:          cscbKey,
-		ConsolidatedObjectVersionID:    "cscb-v1",
-		ConsolidatedObjectETag:         "cscb-etag",
-		ConsolidatedByteOffset:         0,
-		ConsolidatedByteLength:         128,
-		ConsolidatedUncompressedLength: 128,
-		PayloadSHA256:                  keySHA256("payload"),
-		PreparedAt:                     preparedAt,
+		BlockMetadataID:                   blockMetadataID,
+		Tag:                               tag,
+		Height:                            height,
+		Hash:                              hash,
+		State:                             RetirementStateEligible,
+		Bucket:                            "integration-bucket",
+		SingleBlockObjectKey:              singleBlockKey,
+		SingleBlockObjectKeySHA256:        keySHA256(singleBlockKey),
+		SingleBlockObjectVersionIDs:       []string{"single-block-v2", "single-block-v1"},
+		SingleBlockDeleteMarkerVersionIDs: []string{"delete-marker-v1"},
+		SingleBlockObjectETag:             "single-block-etag",
+		SingleBlockObjectBytes:            256,
+		ConsolidatedObjectKey:             cscbKey,
+		ConsolidatedObjectVersionID:       "cscb-v1",
+		ConsolidatedObjectETag:            "cscb-etag",
+		ConsolidatedByteOffset:            0,
+		ConsolidatedByteLength:            128,
+		ConsolidatedUncompressedLength:    128,
+		PayloadSHA256:                     keySHA256("payload"),
+		PreparedAt:                        preparedAt,
 	}
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO block_single_block_retention (
@@ -206,6 +207,9 @@ func TestIntegrationPostgresRepositoryRetirementStateMachine(t *testing.T) {
 	_, err = db.ExecContext(ctx, `UPDATE block_single_block_retention SET consolidated_object_etag = 'mutated' WHERE block_metadata_id = $1`, blockMetadataID)
 	require.Error(err)
 	require.Contains(err.Error(), "cannot change pinned retirement manifest fields")
+	_, err = db.ExecContext(ctx, `UPDATE block_single_block_retention SET single_block_delete_marker_version_ids = ARRAY['mutated-marker'] WHERE block_metadata_id = $1`, blockMetadataID)
+	require.Error(err)
+	require.Contains(err.Error(), "cannot change pinned retirement delete-marker versions")
 
 	startedAt := preparedAt.Add(24 * time.Hour)
 	claimToken := "integration-claim"
@@ -297,7 +301,8 @@ func TestIntegrationPostgresRepositoryRetirementStateMachine(t *testing.T) {
 	require.Equal(RetirementStateDeletedVerified, row.Retirement.State)
 	require.Empty(row.Retirement.SingleBlockObjectKey)
 	require.Equal(keySHA256(singleBlockKey), row.Retirement.SingleBlockObjectKeySHA256)
-	require.Equal([]string{"single-block-v1"}, row.Retirement.SingleBlockObjectVersionIDs)
+	require.Equal([]string{"single-block-v2", "single-block-v1"}, row.Retirement.SingleBlockObjectVersionIDs)
+	require.Equal([]string{"delete-marker-v1"}, row.Retirement.SingleBlockDeleteMarkerVersionIDs)
 	require.Empty(row.Retirement.SingleBlockObjectETag)
 	require.Empty(row.Retirement.ClaimToken)
 	require.Nil(row.Retirement.ClaimExpiresAt)

--- a/internal/storage/retirement/types.go
+++ b/internal/storage/retirement/types.go
@@ -101,33 +101,34 @@ type (
 	}
 
 	RetirementManifest struct {
-		BlockMetadataID                int64
-		Tag                            uint32
-		Height                         uint64
-		Hash                           string
-		State                          string
-		Bucket                         string
-		SingleBlockObjectKey           string
-		SingleBlockObjectKeySHA256     string
-		SingleBlockObjectVersionIDs    []string
-		SingleBlockObjectETag          string
-		SingleBlockObjectBytes         uint64
-		ConsolidatedObjectKey          string
-		ConsolidatedObjectVersionID    string
-		ConsolidatedObjectETag         string
-		ConsolidatedByteOffset         uint64
-		ConsolidatedByteLength         uint64
-		ConsolidatedUncompressedLength uint64
-		PayloadSHA256                  string
-		Outcome                        string
-		AttemptCount                   int
-		ClaimToken                     string
-		ClaimExpiresAt                 *time.Time
-		PreparedAt                     time.Time
-		DeleteStartedAt                *time.Time
-		LastAttemptAt                  *time.Time
-		DeletedAt                      *time.Time
-		VerifiedAt                     *time.Time
+		BlockMetadataID                   int64
+		Tag                               uint32
+		Height                            uint64
+		Hash                              string
+		State                             string
+		Bucket                            string
+		SingleBlockObjectKey              string
+		SingleBlockObjectKeySHA256        string
+		SingleBlockObjectVersionIDs       []string
+		SingleBlockDeleteMarkerVersionIDs []string
+		SingleBlockObjectETag             string
+		SingleBlockObjectBytes            uint64
+		ConsolidatedObjectKey             string
+		ConsolidatedObjectVersionID       string
+		ConsolidatedObjectETag            string
+		ConsolidatedByteOffset            uint64
+		ConsolidatedByteLength            uint64
+		ConsolidatedUncompressedLength    uint64
+		PayloadSHA256                     string
+		Outcome                           string
+		AttemptCount                      int
+		ClaimToken                        string
+		ClaimExpiresAt                    *time.Time
+		PreparedAt                        time.Time
+		DeleteStartedAt                   *time.Time
+		LastAttemptAt                     *time.Time
+		DeletedAt                         *time.Time
+		VerifiedAt                        *time.Time
 	}
 
 	PlanRequest struct {
@@ -193,36 +194,38 @@ type (
 	}
 
 	Candidate struct {
-		Bucket               string     `json:"bucket"`
-		Key                  string     `json:"key"`
-		VersionID            string     `json:"version_id,omitempty"`
-		Height               uint64     `json:"height"`
-		Hash                 string     `json:"hash"`
-		SingleBlockBytes     uint64     `json:"single_block_bytes"`
-		ConsolidatedKey      string     `json:"consolidated_key"`
-		BlockMetadataID      int64      `json:"block_metadata_id"`
-		Tag                  uint32     `json:"tag"`
-		SingleBlockETag      string     `json:"single_block_etag,omitempty"`
-		SingleBlockKeySHA256 string     `json:"single_block_key_sha256,omitempty"`
-		SingleBlockVersions  int        `json:"single_block_version_count"`
-		DeleteMarkers        int        `json:"delete_marker_count"`
-		CSCBVersionID        string     `json:"cscb_version_id,omitempty"`
-		CSCBETag             string     `json:"cscb_etag,omitempty"`
-		CSCBWriteOncePolicy  bool       `json:"cscb_write_once_policy_verified"`
-		PayloadSHA256        string     `json:"payload_sha256,omitempty"`
-		ByteOffset           uint64     `json:"byte_offset,omitempty"`
-		ByteLength           uint64     `json:"byte_length,omitempty"`
-		UncompressedLength   uint64     `json:"uncompressed_length,omitempty"`
-		RetirementState      string     `json:"retirement_state,omitempty"`
-		RetirementAttempts   int        `json:"retirement_attempts,omitempty"`
-		RetirementOutcome    string     `json:"retirement_outcome,omitempty"`
-		ValidatedAt          *time.Time `json:"validated_at"`
-		RetiredAt            *time.Time `json:"retired_at"`
-		EligibleAt           *time.Time `json:"eligible_at"`
-		SingleBlockDeletedAt *time.Time `json:"single_block_deleted_at,omitempty"`
-		RetirementVerifiedAt *time.Time `json:"retirement_verified_at,omitempty"`
-		Action               string     `json:"action"`
-		SkipReason           string     `json:"skip_reason"`
+		Bucket                 string     `json:"bucket"`
+		Key                    string     `json:"key"`
+		VersionID              string     `json:"version_id,omitempty"`
+		VersionIDs             []string   `json:"single_block_version_ids,omitempty"`
+		DeleteMarkerVersionIDs []string   `json:"single_block_delete_marker_version_ids,omitempty"`
+		Height                 uint64     `json:"height"`
+		Hash                   string     `json:"hash"`
+		SingleBlockBytes       uint64     `json:"single_block_bytes"`
+		ConsolidatedKey        string     `json:"consolidated_key"`
+		BlockMetadataID        int64      `json:"block_metadata_id"`
+		Tag                    uint32     `json:"tag"`
+		SingleBlockETag        string     `json:"single_block_etag,omitempty"`
+		SingleBlockKeySHA256   string     `json:"single_block_key_sha256,omitempty"`
+		SingleBlockVersions    int        `json:"single_block_version_count"`
+		DeleteMarkers          int        `json:"delete_marker_count"`
+		CSCBVersionID          string     `json:"cscb_version_id,omitempty"`
+		CSCBETag               string     `json:"cscb_etag,omitempty"`
+		CSCBWriteOncePolicy    bool       `json:"cscb_write_once_policy_verified"`
+		PayloadSHA256          string     `json:"payload_sha256,omitempty"`
+		ByteOffset             uint64     `json:"byte_offset,omitempty"`
+		ByteLength             uint64     `json:"byte_length,omitempty"`
+		UncompressedLength     uint64     `json:"uncompressed_length,omitempty"`
+		RetirementState        string     `json:"retirement_state,omitempty"`
+		RetirementAttempts     int        `json:"retirement_attempts,omitempty"`
+		RetirementOutcome      string     `json:"retirement_outcome,omitempty"`
+		ValidatedAt            *time.Time `json:"validated_at"`
+		RetiredAt              *time.Time `json:"retired_at"`
+		EligibleAt             *time.Time `json:"eligible_at"`
+		SingleBlockDeletedAt   *time.Time `json:"single_block_deleted_at,omitempty"`
+		RetirementVerifiedAt   *time.Time `json:"retirement_verified_at,omitempty"`
+		Action                 string     `json:"action"`
+		SkipReason             string     `json:"skip_reason"`
 	}
 )
 


### PR DESCRIPTION
## Summary

- pin every immutable S3 data-version ID and delete-marker ID for a single-block key
- validate the selected single-block payload against the exact CSCB version, then delete every pinned ID
- make partial deletion crash-safe by persisting the complete topology and accepting only a shrinking pinned subset on reconciliation
- clear PostgreSQL single-block paths only after the S3 key has no versions, no markers, and no resolvable HEAD
- decode the exact CSCB again after deletion before finalizing retirement

## Deployment order

1. Apply PostgreSQL migration `20260721000001_support_multi_version_retirement.sql`.
2. Deploy the image built from this change.
3. Update the monorepo retention canary to that immutable image digest.

The migration is backward-compatible with the current singleton manifests, but the new binary requires the migration before startup.

## Verification

- `goimports` on changed Go files
- `go vet -printfuncs=wrapf,statusf,warnf,infof,debugf,failf,equalf,containsf,fprintf,sprintf ./...`
- `errcheck -ignoretests -ignoregenerated ./...`
- `ineffassign ./...`
- `TEST_TYPE=unit go test ./...`
- uncached Docker-backed PostgreSQL + LocalStack retirement integration tests
- Goose migration validation and local Down/Up `redo`

Linear: [INF-1126](https://linear.app/cipherowl/issue/INF-1126)
