### PR TITLE
fix(INF-1126): order bounded retention selection by height

### DIFF
--- a/internal/storage/retirement/repository_postgres_integration_test.go
+++ b/internal/storage/retirement/repository_postgres_integration_test.go
@@ -469,6 +469,148 @@ func TestIntegrationPostgresRepositorySelectsDueRetentionCohorts(t *testing.T) {
 	require.Empty(cohorts, "an object with an active CSCB repair must not be selected for retention")
 }
 
+// TestIntegrationPostgresRepositoryOrdersBoundedSelectionByHeight seeds three
+// cohorts whose due-time order is the exact reverse of their height order, so
+// the two orderings cannot be confused for one another.
+//
+// A bounded selection must walk the supplied range by height, and when the limit
+// truncates it must keep the *lowest* cohorts, so that repeated runs advance
+// monotonically and an approved range maps to a predictable set of cohorts. An
+// unbounded selection must still drain the most-overdue work first.
+func TestIntegrationPostgresRepositoryOrdersBoundedSelectionByHeight(t *testing.T) {
+	require := require.New(t)
+	cfg, err := config.New()
+	require.NoError(err)
+	if cfg.AWS.Postgres == nil {
+		t.Skip("Postgres is not configured")
+	}
+	if cfg.Env() == config.EnvProduction {
+		t.Skip("retention integration tests never write to production")
+	}
+
+	ctx := context.Background()
+	db, err := openRetirementIntegrationDB(ctx, cfg.AWS.Postgres)
+	if err != nil {
+		t.Skipf("Postgres integration database is unavailable: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	goose.SetBaseFS(metapostgres.GetEmbeddedMigrations())
+	require.NoError(goose.SetDialect("postgres"))
+	require.NoError(goose.UpContext(ctx, db, "db/migrations"))
+
+	const cohortCount = 3
+	unique := time.Now().UTC().UnixNano()
+	tag := uint32(1_100_000_000 + unique%100_000_000)
+	startHeight := uint64(8_100_000_000 + unique%100_000_000)
+	blockMetadataIDs := make([]int64, 0, cohortCount)
+	cohortKeys := make([]string, 0, cohortCount)
+	defer func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM block_consolidation_shadow WHERE tag = $1`, tag)
+		_, _ = db.ExecContext(ctx, `DELETE FROM canonical_blocks WHERE tag = $1`, tag)
+		for _, blockMetadataID := range blockMetadataIDs {
+			_, _ = db.ExecContext(ctx, `DELETE FROM block_metadata WHERE id = $1`, blockMetadataID)
+		}
+	}()
+
+	now := time.Now().UTC()
+	for index := 0; index < cohortCount; index++ {
+		height := startHeight + uint64(index)
+		consolidatedKey := fmt.Sprintf("consolidated/ordering-%d-%d.cscb.gzip", unique, index)
+		cohortKeys = append(cohortKeys, consolidatedKey)
+		// Later heights are more overdue, so due-time order reverses height order.
+		deleteAfter := now.Add(-time.Duration(index+1) * time.Hour)
+
+		var blockMetadataID int64
+		err = db.QueryRowContext(ctx, `
+			INSERT INTO block_metadata (
+				height, tag, hash, parent_height, object_key_main, timestamp, skipped,
+				object_format, byte_offset, byte_length, uncompressed_length
+			) VALUES ($1, $2, NULL, $3, $4, $5, FALSE, $6, $7, $8, $9)
+			RETURNING id`,
+			height,
+			tag,
+			height-1,
+			consolidatedKey,
+			now.Unix(),
+			api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			0,
+			128,
+			128,
+		).Scan(&blockMetadataID)
+		require.NoError(err)
+		blockMetadataIDs = append(blockMetadataIDs, blockMetadataID)
+
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO canonical_blocks (height, block_metadata_id, tag)
+			VALUES ($1, $2, $3)`,
+			height,
+			blockMetadataID,
+			tag,
+		)
+		require.NoError(err)
+
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO block_consolidation_shadow (
+				block_metadata_id, tag, height, hash, single_block_object_key_main,
+				consolidated_object_key_main, object_format, byte_offset, byte_length,
+				uncompressed_length, validated_at, single_block_retention_started_at,
+				single_block_delete_after
+			) VALUES ($1, $2, $3, NULL, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+			blockMetadataID,
+			tag,
+			height,
+			fmt.Sprintf("single-block/%d.gzip", height),
+			consolidatedKey,
+			api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
+			0,
+			128,
+			128,
+			now.Add(-96*time.Hour),
+			now.Add(-96*time.Hour),
+			deleteAfter,
+		)
+		require.NoError(err)
+	}
+
+	endHeight := startHeight + cohortCount
+
+	repo := NewPostgresRepository(db)
+	bounded, err := repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, 10)
+	require.NoError(err)
+	require.Len(bounded, cohortCount)
+	boundedHeights := make([]uint64, 0, len(bounded))
+	for _, cohort := range bounded {
+		boundedHeights = append(boundedHeights, cohort.StartHeight)
+	}
+	require.Equal(
+		[]uint64{startHeight, startHeight + 1, startHeight + 2},
+		boundedHeights,
+		"a bounded selection must be ordered by height, not by due time",
+	)
+
+	truncated, err := repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, 2)
+	require.NoError(err)
+	require.Len(truncated, 2)
+	require.Equal(
+		[]string{cohortKeys[0], cohortKeys[1]},
+		[]string{truncated[0].ConsolidatedObjectKey, truncated[1].ConsolidatedObjectKey},
+		"a truncated bounded selection must keep the lowest cohorts so repeated runs advance monotonically",
+	)
+
+	unbounded, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, 10)
+	require.NoError(err)
+	require.Len(unbounded, cohortCount)
+	unboundedHeights := make([]uint64, 0, len(unbounded))
+	for _, cohort := range unbounded {
+		unboundedHeights = append(unboundedHeights, cohort.StartHeight)
+	}
+	require.Equal(
+		[]uint64{startHeight + 2, startHeight + 1, startHeight},
+		unboundedHeights,
+		"an unbounded selection must still drain the most overdue cohorts first",
+	)
+}
+
 func openRetirementIntegrationDB(ctx context.Context, cfg *config.PostgresConfig) (*sql.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
 		cfg.Host, cfg.Port, cfg.Database, cfg.User, cfg.Password, cfg.SSLMode)

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -3,6 +3,7 @@ package retirement
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -59,6 +60,37 @@ func (r *PostgresRepository) ListPendingRetentionCohorts(
 	return scanRetentionCohorts(rows, true)
 }
 
+const (
+	// dueRetentionCohortOrderingByDueTime retires whatever has been due longest
+	// first. It is the right policy for an unbounded selection, where the caller
+	// is asking "find the most overdue work anywhere".
+	dueRetentionCohortOrderingByDueTime = "due.eligible_at, MIN(shadow.height), due.consolidated_object_key_main"
+	// dueRetentionCohortOrderingByHeight walks a caller-supplied range in height
+	// order so the selection is deterministic and prefix-shaped.
+	dueRetentionCohortOrderingByHeight = "MIN(shadow.height), due.consolidated_object_key_main"
+)
+
+// dueRetentionCohortOrdering picks the cohort ordering for a selection. Both
+// return values are compile-time constants and never caller input.
+//
+// When an explicit height range is supplied, selection must be deterministic:
+// a run takes the lowest eligible cohorts in the range and repeated runs walk it
+// monotonically until MoreEligibleRanges reports false. Ordering by eligible_at
+// there would instead return a due-time-ordered *subset* of the range, which
+// breaks both retention gates that operators rely on. First, an operator
+// approving [start, end) cannot predict which cohorts a run will touch, which
+// reintroduces the "approval does not match the selected work" problem. Second,
+// eligible_at advances as retention clocks tick and as repairs re-stamp
+// single_block_delete_after, so the same approved range can resolve to a
+// different subset later — meaning a clean dry run would no longer predict what
+// an execute run over that range deletes.
+func dueRetentionCohortOrdering(endHeight uint64) string {
+	if endHeight > 0 {
+		return dueRetentionCohortOrderingByHeight
+	}
+	return dueRetentionCohortOrderingByDueTime
+}
+
 func (r *PostgresRepository) ListDueRetentionCohorts(
 	ctx context.Context,
 	tag uint32,
@@ -72,7 +104,7 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 	if limit <= 0 {
 		return nil, nil
 	}
-	const query = `
+	const queryTemplate = `
 		WITH due_keys AS (
 			SELECT
 				shadow.consolidated_object_key_main,
@@ -129,8 +161,9 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 			)
 		GROUP BY due.consolidated_object_key_main, due.eligible_at
 		HAVING MAX(shadow.single_block_delete_after) <= CURRENT_TIMESTAMP
-		ORDER BY due.eligible_at, MIN(shadow.height), due.consolidated_object_key_main
+		ORDER BY %s
 		LIMIT $5`
+	query := fmt.Sprintf(queryTemplate, dueRetentionCohortOrdering(endHeight))
 	rows, err := r.db.QueryContext(
 		ctx,
 		query,

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -149,3 +149,8 @@ func TestSelectorReportsRemainingBacklog(t *testing.T) {
 	require.Len(t, cohorts, 1)
 	require.Equal(t, "consolidated/a.cscb.zstd", cohorts[0].ConsolidatedObjectKey)
 }
+
+func TestDueRetentionCohortOrdering(t *testing.T) {
+	require.Equal(t, dueRetentionCohortOrderingByHeight, dueRetentionCohortOrdering(100))
+	require.Equal(t, dueRetentionCohortOrderingByDueTime, dueRetentionCohortOrdering(0))
+}


### PR DESCRIPTION
## Problem

`ListDueRetentionCohorts` orders by `eligible_at` even when the caller supplies an explicit height range. With `LIMIT` in play, a bounded run returns a **due-time-ordered subset** of the range:

- **Approval semantics are unpredictable.** In an execute run the operator approves an exact range, but which cohorts inside it get selected is decided by a due-time ordering the operator cannot see — "approve `[A,B)`" means "retire up to N cohorts *somewhere* in `[A,B)`".
- **A dry run stops predicting the execute run.** `eligible_at` shifts as retention clocks tick and as repairs re-stamp `single_block_delete_after`, so the same approved range can resolve to a different subset on a later day.

Observed in prod dry run `019f974e` (Step A of the INF-1126 rollout): requesting `[431260000, 431300000)` with `MaxObjectRanges=5` selected the non-contiguous, non-lowest cohorts 431291000, 431290000, 431289000, 431299000, 431288000.

## Fix

When an explicit range is supplied (`endHeight > 0`), order by `MIN(shadow.height)` so selection is deterministic and prefix-shaped: each run takes the lowest eligible cohorts in the range and repeated runs walk it monotonically until `MoreEligibleRanges` reports false. The unbounded path keeps due-time ordering ("most overdue first" remains the right policy there). The `ORDER BY` clause is chosen between two compile-time constants — no caller input is interpolated.

## Testing

- `TestDueRetentionCohortOrdering` — unit, ordering choice contract.
- `TestIntegrationPostgresRepositoryOrdersBoundedSelectionByHeight` — new integration test seeding three cohorts whose due-time order is the *reverse* of their height order: bounded selection returns height order, a truncated (`limit=2`) bounded selection keeps the lowest cohorts, unbounded selection still returns due-time order.
- Full `internal/storage/retirement` integration suite green locally against Postgres + localstack (`TEST_TYPE=integration`, `p=1`).

## Notes

- Does not change the pre-existing unbounded-selection timeout issue (statement-timeout on a large backlog); this ordering change composes with the future index-ordered-early-cutoff rewrite.
- No workflow/activity signature changes; no config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
