### PR TITLE
feat(INF-1126): sweep retention range to completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,10 +725,12 @@ go run ./cmd/admin workflow start --workflow single_block_retention --input '{"T
 The workflow is manual-only while production retention is being verified; no
 recurring cron or Temporal Schedule starts it. `MaxObjectRanges` bounds each
 Temporal run. A read-only run remains bounded and reports the current backlog
-through `MoreEligibleRanges`. An execute run continues as new with the same
-selection and approval envelope until no currently due or pending cohorts
-remain; it never bypasses each cohort's retention clock. Execution requires
-Postgres metadata plus versioned S3 storage, an explicit
+through `MoreEligibleRanges` and returns its frozen `EligibilityCutoff`. A new
+execute sweep must supply that exact dry-run cutoff. It continues as new with
+the same cutoff, selection, and approval envelope until a final empty selection
+confirms that no cohort from the frozen set remains; it never admits cohorts
+that become eligible later or bypasses each cohort's retention clock. Execution
+requires Postgres metadata plus versioned S3 storage, an explicit
 `FallbackReadsValidated` assertion with zero `FallbackErrorCount`, and a
 separate operator approval (`ApprovedChain`, `ApprovedStartHeight`,
 `ApprovedEndHeight`) that must exactly match the selection range. Every selected

--- a/README.md
+++ b/README.md
@@ -723,21 +723,24 @@ go run ./cmd/admin workflow start --workflow single_block_retention --input '{"T
 ```
 
 The workflow is manual-only while production retention is being verified; no
-recurring cron or Temporal Schedule starts it. Each explicit run is bounded by
-`MaxObjectRanges`, and `MoreEligibleRanges` reports whether the selected range
-still has a backlog. Omitting `Execute` keeps the run read-only. Execution
-requires Postgres metadata plus versioned S3 storage, an explicit
+recurring cron or Temporal Schedule starts it. `MaxObjectRanges` bounds each
+Temporal run. A read-only run remains bounded and reports the current backlog
+through `MoreEligibleRanges`. An execute run continues as new with the same
+selection and approval envelope until no currently due or pending cohorts
+remain; it never bypasses each cohort's retention clock. Execution requires
+Postgres metadata plus versioned S3 storage, an explicit
 `FallbackReadsValidated` assertion with zero `FallbackErrorCount`, and a
 separate operator approval (`ApprovedChain`, `ApprovedStartHeight`,
-`ApprovedEndHeight`) that must exactly match both the selection range and the
-selected cohort; the approval is passed through unchanged and is never derived
-from whatever cohort the selector discovers, so unbounded execution requests
-are rejected. API and SDK clients continue to use the same Chainstorage
-interface; the `DirectStorageClientsGuarded` execution gate applies only to
-consumers that bypass Chainstorage and access object storage directly. The
-process activity heartbeats from the row and per-version delete loops under a
-bounded heartbeat timeout, so stopping the workflow cancels destructive work
-between steps instead of letting it run to completion.
+`ApprovedEndHeight`) that must exactly match the selection range. Every selected
+cohort must be fully contained by that immutable envelope across continuations;
+the approval is passed through unchanged and is never derived from selector
+output, so unbounded execution requests are rejected. API and SDK clients
+continue to use the same Chainstorage interface; the
+`DirectStorageClientsGuarded` execution gate applies only to consumers that
+bypass Chainstorage and access object storage directly. The process activity
+heartbeats from the row and per-version delete loops under a bounded heartbeat
+timeout, so stopping the workflow cancels destructive work between steps
+instead of letting it run to completion.
 
 Stop the monitor workflow:
 ```shell

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -174,7 +174,14 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 	if req.Execute && !req.SingleBlockWritersGuarded {
 		return nil, xerrors.New("retirement reconciliation requires all single-block writers to honor the retirement fence")
 	}
-	manifests, err := p.repo.ListPendingRetirements(ctx, req.Tag, req.StartHeight, req.EndHeight, req.Limit)
+	manifests, err := p.repo.ListPendingRetirements(
+		ctx,
+		req.Tag,
+		req.StartHeight,
+		req.EndHeight,
+		req.EligibilityCutoff,
+		req.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +388,7 @@ func (p *Planner) planRow(
 		item.SkipReason = SkipMissingRetirementMarker
 		return item
 	}
-	if item.EligibleAt != nil && req.Now.Before(*item.EligibleAt) {
+	if item.EligibleAt != nil && req.EligibilityCutoff.Before(*item.EligibleAt) {
 		item.SkipReason = SkipRetentionPeriodActive
 		return item
 	}
@@ -938,7 +945,7 @@ func candidateMatchesRow(req PlanRequest, candidate Candidate, row MetadataRow, 
 	}
 	if row.Shadow == nil || row.Shadow.ValidatedAt == nil || row.Shadow.SingleBlockRetentionStartedAt == nil ||
 		row.Shadow.SingleBlockDeleteAfter == nil || row.Shadow.SingleBlockObjectDeletedAt != nil ||
-		req.Now.Before(*row.Shadow.SingleBlockDeleteAfter) {
+		req.EligibilityCutoff.Before(*row.Shadow.SingleBlockDeleteAfter) {
 		return false
 	}
 	retirementMatches := row.Retirement == nil || pendingRetirementMatchesCandidate(row, candidate)
@@ -1426,6 +1433,9 @@ func normalizeRequest(req *PlanRequest) error {
 	if req.Now.IsZero() {
 		req.Now = time.Now().UTC()
 	}
+	if req.EligibilityCutoff.IsZero() {
+		req.EligibilityCutoff = req.Now
+	}
 	return nil
 }
 
@@ -1498,14 +1508,21 @@ func isPrimaryConsolidated(row MetadataRow) bool {
 }
 
 func approvalMatches(req PlanRequest) bool {
-	return normalizeApprovalChain(req.Approval.Chain) == normalizeApprovalChain(actualChain(req)) &&
-		req.Approval.StartHeight <= req.StartHeight &&
-		req.Approval.EndHeight >= req.EndHeight
+	if normalizeApprovalChain(req.Approval.Chain) != normalizeApprovalChain(actualChain(req)) {
+		return false
+	}
+	if req.Approval.AllowContainingRange {
+		return req.Approval.StartHeight <= req.StartHeight &&
+			req.Approval.EndHeight >= req.EndHeight
+	}
+	return req.Approval.StartHeight == req.StartHeight &&
+		req.Approval.EndHeight == req.EndHeight
 }
 
 // approvalGateBlocked reports whether the operator approval blocks this
-// request. Execution always requires an explicit chain/envelope approval that
-// fully contains the cohort under deletion. A
+// request. Direct planner callers require an exact chain/range approval. The
+// retention workflow may explicitly opt into a containing envelope after it
+// independently validates the selected cohort against that operator input. A
 // read-only run may omit the approval entirely so it can still reach the S3
 // safety inspection, but a supplied approval is validated even on dry runs so
 // the report predicts the execute-time gate.

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -1499,12 +1499,13 @@ func isPrimaryConsolidated(row MetadataRow) bool {
 
 func approvalMatches(req PlanRequest) bool {
 	return normalizeApprovalChain(req.Approval.Chain) == normalizeApprovalChain(actualChain(req)) &&
-		req.Approval.StartHeight == req.StartHeight &&
-		req.Approval.EndHeight == req.EndHeight
+		req.Approval.StartHeight <= req.StartHeight &&
+		req.Approval.EndHeight >= req.EndHeight
 }
 
 // approvalGateBlocked reports whether the operator approval blocks this
-// request. Execution always requires an exact chain/range approval. A
+// request. Execution always requires an explicit chain/envelope approval that
+// fully contains the cohort under deletion. A
 // read-only run may omit the approval entirely so it can still reach the S3
 // safety inspection, but a supplied approval is validated even on dry runs so
 // the report predicts the execute-time gate.

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -599,6 +599,21 @@ func TestPlannerPlan_ValidationAndApprovalGates(t *testing.T) {
 	})
 }
 
+func TestApprovalMatchesContainingEnvelope(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	req := testRequest(now, true)
+	req.Approval.StartHeight = req.StartHeight - 1000
+	req.Approval.EndHeight = req.EndHeight + 1000
+	require.True(t, approvalMatches(req))
+
+	req.Approval.StartHeight = req.StartHeight + 1
+	require.False(t, approvalMatches(req))
+
+	req = testRequest(now, true)
+	req.Approval.EndHeight = req.EndHeight - 1
+	require.False(t, approvalMatches(req))
+}
+
 func TestPlannerPlan_FallbackAndDirectStorageClientGates(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -250,12 +250,20 @@ func (r *fakeRepo) updateManifestRow(manifest RetirementManifest) {
 	}
 }
 
-func (r *fakeRepo) ListPendingRetirements(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]RetirementManifest, error) {
+func (r *fakeRepo) ListPendingRetirements(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	eligibilityCutoff time.Time,
+	limit uint64,
+) ([]RetirementManifest, error) {
 	var manifests []RetirementManifest
 	for _, manifest := range r.manifests {
 		if manifest.Tag == tag && manifest.Height >= startHeight && manifest.Height < endHeight &&
 			(manifest.State == RetirementStateEligible || manifest.State == RetirementStateDeleting ||
-				manifest.State == RetirementStateDeletedPendingVerification) {
+				manifest.State == RetirementStateDeletedPendingVerification) &&
+			r.retirementEligibleAt(manifest.BlockMetadataID, eligibilityCutoff) {
 			manifests = append(manifests, manifest)
 		}
 	}
@@ -264,6 +272,18 @@ func (r *fakeRepo) ListPendingRetirements(ctx context.Context, tag uint32, start
 		manifests = manifests[:limit]
 	}
 	return manifests, nil
+}
+
+func (r *fakeRepo) retirementEligibleAt(blockMetadataID int64, eligibilityCutoff time.Time) bool {
+	for _, row := range r.rows {
+		if row.BlockMetadataID != blockMetadataID {
+			continue
+		}
+		return row.Shadow != nil &&
+			row.Shadow.SingleBlockDeleteAfter != nil &&
+			!row.Shadow.SingleBlockDeleteAfter.After(eligibilityCutoff)
+	}
+	return false
 }
 
 type fakeStore struct {
@@ -448,6 +468,28 @@ func TestPlannerPlan_NotEligibleRetentionPeriod(t *testing.T) {
 	require.Zero(store.versionCalls[row.SingleBlockObjectKey])
 }
 
+func TestPlannerPlan_UsesFrozenEligibilityCutoff(t *testing.T) {
+	require := require.New(t)
+	cutoff := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	now := cutoff.Add(2 * time.Hour)
+	row := testRow(
+		100,
+		"hash-100",
+		"single-block/100.zstd",
+		"consolidated/canary.cscb.zstd",
+		cutoff.Add(-8*24*time.Hour),
+	)
+	deleteAfter := cutoff.Add(time.Hour)
+	row.Shadow.SingleBlockDeleteAfter = &deleteAfter
+	req := testRequest(now, false)
+	req.EligibilityCutoff = cutoff
+
+	report, err := testPlanner(&fakeRepo{rows: []MetadataRow{row}}, newFakeStore()).Plan(context.Background(), req)
+	require.NoError(err)
+	require.Len(report.Items, 1)
+	require.Equal(SkipRetentionPeriodActive, report.Items[0].SkipReason)
+}
+
 func TestPlannerPlan_MissingRetirementMarkerIsNeverEligible(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
@@ -599,11 +641,14 @@ func TestPlannerPlan_ValidationAndApprovalGates(t *testing.T) {
 	})
 }
 
-func TestApprovalMatchesContainingEnvelope(t *testing.T) {
+func TestApprovalMatchesExactRangeUnlessContainmentIsExplicit(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	req := testRequest(now, true)
 	req.Approval.StartHeight = req.StartHeight - 1000
 	req.Approval.EndHeight = req.EndHeight + 1000
+	require.False(t, approvalMatches(req))
+
+	req.Approval.AllowContainingRange = true
 	require.True(t, approvalMatches(req))
 
 	req.Approval.StartHeight = req.StartHeight + 1
@@ -1261,6 +1306,21 @@ func TestPlannerReconcile_ResumesPartiallyDeletedPinnedTopology(t *testing.T) {
 	require.Empty(repo.rows[0].SingleBlockObjectKey)
 	require.Empty(repo.rows[0].Shadow.SingleBlockObjectKey)
 	require.Equal(RetirementStateDeletedVerified, repo.manifests[row.BlockMetadataID].State)
+}
+
+func TestPlannerReconcile_ExcludesManifestBeyondFrozenEligibilityCutoff(t *testing.T) {
+	require := require.New(t)
+	_, repo, store, planner, _, req, _ := newMultiVersionExecutableTestFixture(t)
+	cutoff := req.Now
+	deleteAfter := cutoff.Add(time.Hour)
+	repo.rows[0].Shadow.SingleBlockDeleteAfter = &deleteAfter
+	req.Now = cutoff.Add(2 * time.Hour)
+	req.EligibilityCutoff = cutoff
+
+	report, err := planner.Reconcile(context.Background(), req)
+	require.NoError(err)
+	require.Empty(report.Items)
+	require.Empty(store.deleted)
 }
 
 func TestPlannerReconcile_RejectsUnpinnedVersionAfterPartialDeletion(t *testing.T) {

--- a/internal/storage/retirement/postgres_repository.go
+++ b/internal/storage/retirement/postgres_repository.go
@@ -835,7 +835,14 @@ func nullableHashMatches(value sql.NullString, expected string) bool {
 	return value.String == expected
 }
 
-func (r *PostgresRepository) ListPendingRetirements(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]RetirementManifest, error) {
+func (r *PostgresRepository) ListPendingRetirements(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	eligibilityCutoff time.Time,
+	limit uint64,
+) ([]RetirementManifest, error) {
 	if r.db == nil {
 		return nil, xerrors.New("postgres db is required")
 	}
@@ -847,21 +854,31 @@ func (r *PostgresRepository) ListPendingRetirements(ctx context.Context, tag uin
 	}
 	const query = `
 		SELECT
-			block_metadata_id, tag, height, COALESCE(hash, ''), state, bucket,
-			single_block_object_key_main, single_block_object_key_sha256, single_block_object_version_ids,
-			single_block_delete_marker_version_ids,
-			single_block_object_etag, single_block_object_bytes,
-			consolidated_object_key_main, consolidated_object_version_id, consolidated_object_etag,
-			consolidated_byte_offset, consolidated_byte_length, consolidated_uncompressed_length,
-			payload_sha256, outcome, attempt_count, claim_token, claim_expires_at,
-			prepared_at, delete_started_at, last_attempt_at, deleted_at, verified_at
-		FROM block_single_block_retention
-		WHERE tag = $1
-			AND height >= $2
-			AND height < $3
-			AND state IN ($4, $5, $6)
-		ORDER BY height ASC
-		LIMIT $7`
+			retention.block_metadata_id, retention.tag, retention.height, COALESCE(retention.hash, ''),
+			retention.state, retention.bucket,
+			retention.single_block_object_key_main, retention.single_block_object_key_sha256,
+			retention.single_block_object_version_ids, retention.single_block_delete_marker_version_ids,
+			retention.single_block_object_etag, retention.single_block_object_bytes,
+			retention.consolidated_object_key_main, retention.consolidated_object_version_id,
+			retention.consolidated_object_etag, retention.consolidated_byte_offset,
+			retention.consolidated_byte_length, retention.consolidated_uncompressed_length,
+			retention.payload_sha256, retention.outcome, retention.attempt_count,
+			retention.claim_token, retention.claim_expires_at, retention.prepared_at,
+			retention.delete_started_at, retention.last_attempt_at, retention.deleted_at,
+			retention.verified_at
+		FROM block_single_block_retention retention
+		JOIN block_consolidation_shadow shadow
+			ON shadow.block_metadata_id = retention.block_metadata_id
+			AND shadow.tag = retention.tag
+			AND shadow.height = retention.height
+		WHERE retention.tag = $1
+			AND retention.height >= $2
+			AND retention.height < $3
+			AND retention.state IN ($4, $5, $6)
+			AND shadow.single_block_delete_after IS NOT NULL
+			AND shadow.single_block_delete_after <= $7
+		ORDER BY retention.height ASC
+		LIMIT $8`
 	rows, err := r.db.QueryContext(
 		ctx,
 		query,
@@ -871,6 +888,7 @@ func (r *PostgresRepository) ListPendingRetirements(ctx context.Context, tag uin
 		RetirementStateEligible,
 		RetirementStateDeleting,
 		RetirementStateDeletedPendingVerification,
+		eligibilityCutoff,
 		limit,
 	)
 	if err != nil {

--- a/internal/storage/retirement/repository_postgres_integration_test.go
+++ b/internal/storage/retirement/repository_postgres_integration_test.go
@@ -319,7 +319,7 @@ func TestIntegrationPostgresRepositoryRetirementStateMachine(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "cannot change a verified single-block retirement")
 
-	pending, err := repo.ListPendingRetirements(ctx, tag, height, height+1, 0)
+	pending, err := repo.ListPendingRetirements(ctx, tag, height, height+1, time.Now().UTC(), 0)
 	require.NoError(err)
 	require.Empty(pending)
 }
@@ -464,12 +464,28 @@ func TestIntegrationPostgresRepositorySelectsDueRetentionCohorts(t *testing.T) {
 	require.Len(pending, 1)
 	require.Equal(uint64(1), pending[0].RowCount)
 
+	futureAtCutoff, err := repo.ListPendingRetirements(
+		ctx,
+		tag,
+		startHeight,
+		startHeight+1,
+		now.Add(-2*time.Hour),
+		10,
+	)
+	require.NoError(err)
+	require.Empty(futureAtCutoff)
+
 	due, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, now, 10)
 	require.NoError(err)
 	require.Len(due, 1)
 	require.Equal(startHeight+1, due[0].StartHeight)
 	require.Equal(startHeight+2, due[0].EndHeight)
 	require.Equal(uint64(1), due[0].RowCount)
+
+	snapshotPending, snapshotDue, err := repo.ListRetentionCohorts(ctx, tag, 0, 0, now, 10)
+	require.NoError(err)
+	require.Equal(pending, snapshotPending)
+	require.Equal(due, snapshotDue)
 
 	merged, hasMore, err := NewSelector(repo).Select(ctx, tag, 0, 0, now, 10)
 	require.NoError(err)

--- a/internal/storage/retirement/repository_postgres_integration_test.go
+++ b/internal/storage/retirement/repository_postgres_integration_test.go
@@ -425,7 +425,7 @@ func TestIntegrationPostgresRepositorySelectsDueRetentionCohorts(t *testing.T) {
 	}
 
 	repo := NewPostgresRepository(db)
-	cohorts, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, 10)
+	cohorts, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, now, 10)
 	require.NoError(err)
 	require.Len(cohorts, 1)
 	require.Equal([]RetentionCohort{{
@@ -437,11 +437,58 @@ func TestIntegrationPostgresRepositorySelectsDueRetentionCohorts(t *testing.T) {
 	}}, cohorts)
 	require.WithinDuration(now.Add(-time.Hour), cohorts[0].EligibleAt, time.Second)
 
+	pendingManifest := RetirementManifest{
+		BlockMetadataID:                blockMetadataIDs[0],
+		Tag:                            tag,
+		Height:                         startHeight,
+		State:                          RetirementStateEligible,
+		Bucket:                         "integration-bucket",
+		SingleBlockObjectKey:           fmt.Sprintf("single-block/%d.gzip", startHeight),
+		SingleBlockObjectKeySHA256:     keySHA256(fmt.Sprintf("single-block/%d.gzip", startHeight)),
+		SingleBlockObjectVersionIDs:    []string{"single-block-v1"},
+		SingleBlockObjectETag:          "single-block-etag",
+		SingleBlockObjectBytes:         128,
+		ConsolidatedObjectKey:          dueKey,
+		ConsolidatedObjectVersionID:    "cscb-v1",
+		ConsolidatedObjectETag:         "cscb-etag",
+		ConsolidatedByteOffset:         0,
+		ConsolidatedByteLength:         128,
+		ConsolidatedUncompressedLength: 128,
+		PayloadSHA256:                  keySHA256("payload"),
+		PreparedAt:                     now.Add(-30 * time.Minute),
+	}
+	require.NoError(repo.PrepareRetirement(ctx, pendingManifest))
+
+	pending, err := repo.ListPendingRetentionCohorts(ctx, tag, 0, 0, now, 10)
+	require.NoError(err)
+	require.Len(pending, 1)
+	require.Equal(uint64(1), pending[0].RowCount)
+
+	due, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, now, 10)
+	require.NoError(err)
+	require.Len(due, 1)
+	require.Equal(startHeight+1, due[0].StartHeight)
+	require.Equal(startHeight+2, due[0].EndHeight)
+	require.Equal(uint64(1), due[0].RowCount)
+
+	merged, hasMore, err := NewSelector(repo).Select(ctx, tag, 0, 0, now, 10)
+	require.NoError(err)
+	require.False(hasMore)
+	require.Equal([]RetentionCohort{{
+		ConsolidatedObjectKey: dueKey,
+		StartHeight:           startHeight,
+		EndHeight:             startHeight + 2,
+		RowCount:              2,
+		EligibleAt:            merged[0].EligibleAt,
+		Pending:               true,
+	}}, merged)
+
 	bounded, err := repo.ListDueRetentionCohorts(
 		ctx,
 		tag,
 		startHeight+1,
 		startHeight+2,
+		now,
 		10,
 	)
 	require.NoError(err)
@@ -464,7 +511,7 @@ func TestIntegrationPostgresRepositorySelectsDueRetentionCohorts(t *testing.T) {
 		strings.Repeat("a", 64),
 	)
 	require.NoError(err)
-	cohorts, err = repo.ListDueRetentionCohorts(ctx, tag, 0, 0, 10)
+	cohorts, err = repo.ListDueRetentionCohorts(ctx, tag, 0, 0, now, 10)
 	require.NoError(err)
 	require.Empty(cohorts, "an object with an active CSCB repair must not be selected for retention")
 }
@@ -575,7 +622,7 @@ func TestIntegrationPostgresRepositoryOrdersBoundedSelectionByHeight(t *testing.
 	endHeight := startHeight + cohortCount
 
 	repo := NewPostgresRepository(db)
-	bounded, err := repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, 10)
+	bounded, err := repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, now, 10)
 	require.NoError(err)
 	require.Len(bounded, cohortCount)
 	boundedHeights := make([]uint64, 0, len(bounded))
@@ -588,7 +635,7 @@ func TestIntegrationPostgresRepositoryOrdersBoundedSelectionByHeight(t *testing.
 		"a bounded selection must be ordered by height, not by due time",
 	)
 
-	truncated, err := repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, 2)
+	truncated, err := repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, now, 2)
 	require.NoError(err)
 	require.Len(truncated, 2)
 	require.Equal(
@@ -597,7 +644,7 @@ func TestIntegrationPostgresRepositoryOrdersBoundedSelectionByHeight(t *testing.
 		"a truncated bounded selection must keep the lowest cohorts so repeated runs advance monotonically",
 	)
 
-	unbounded, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, 10)
+	unbounded, err := repo.ListDueRetentionCohorts(ctx, tag, 0, 0, now, 10)
 	require.NoError(err)
 	require.Len(unbounded, cohortCount)
 	unboundedHeights := make([]uint64, 0, len(unbounded))

--- a/internal/storage/retirement/selector.go
+++ b/internal/storage/retirement/selector.go
@@ -21,25 +21,17 @@ type (
 	}
 
 	// CohortRepository must return row-disjoint pending and due aggregates.
-	// Selector merges aggregates for the same consolidated object by summing
-	// their row counts.
+	// Both slices must come from one database snapshot. Selector merges
+	// aggregates for the same consolidated object by summing their row counts.
 	CohortRepository interface {
-		ListPendingRetentionCohorts(
+		ListRetentionCohorts(
 			ctx context.Context,
 			tag uint32,
 			startHeight uint64,
 			endHeight uint64,
 			eligibilityCutoff time.Time,
 			limit int,
-		) ([]RetentionCohort, error)
-		ListDueRetentionCohorts(
-			ctx context.Context,
-			tag uint32,
-			startHeight uint64,
-			endHeight uint64,
-			eligibilityCutoff time.Time,
-			limit int,
-		) ([]RetentionCohort, error)
+		) ([]RetentionCohort, []RetentionCohort, error)
 	}
 
 	Selector struct {
@@ -80,7 +72,7 @@ func (s *Selector) Select(
 	}
 
 	queryLimit := limit + 1
-	pending, err := s.repo.ListPendingRetentionCohorts(
+	pending, due, err := s.repo.ListRetentionCohorts(
 		ctx,
 		tag,
 		startHeight,
@@ -89,18 +81,7 @@ func (s *Selector) Select(
 		queryLimit,
 	)
 	if err != nil {
-		return nil, false, xerrors.Errorf("failed to list pending retention cohorts: %w", err)
-	}
-	due, err := s.repo.ListDueRetentionCohorts(
-		ctx,
-		tag,
-		startHeight,
-		endHeight,
-		eligibilityCutoff,
-		queryLimit,
-	)
-	if err != nil {
-		return nil, false, xerrors.Errorf("failed to list due retention cohorts: %w", err)
+		return nil, false, xerrors.Errorf("failed to list retention cohorts: %w", err)
 	}
 
 	result := make([]RetentionCohort, 0, queryLimit)

--- a/internal/storage/retirement/selector.go
+++ b/internal/storage/retirement/selector.go
@@ -2,6 +2,7 @@ package retirement
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -19,12 +20,16 @@ type (
 		Pending               bool      `json:"pending"`
 	}
 
+	// CohortRepository must return row-disjoint pending and due aggregates.
+	// Selector merges aggregates for the same consolidated object by summing
+	// their row counts.
 	CohortRepository interface {
 		ListPendingRetentionCohorts(
 			ctx context.Context,
 			tag uint32,
 			startHeight uint64,
 			endHeight uint64,
+			eligibilityCutoff time.Time,
 			limit int,
 		) ([]RetentionCohort, error)
 		ListDueRetentionCohorts(
@@ -32,6 +37,7 @@ type (
 			tag uint32,
 			startHeight uint64,
 			endHeight uint64,
+			eligibilityCutoff time.Time,
 			limit int,
 		) ([]RetentionCohort, error)
 	}
@@ -50,6 +56,7 @@ func (s *Selector) Select(
 	tag uint32,
 	startHeight uint64,
 	endHeight uint64,
+	eligibilityCutoff time.Time,
 	limit int,
 ) ([]RetentionCohort, bool, error) {
 	if s == nil || s.repo == nil {
@@ -68,13 +75,30 @@ func (s *Selector) Select(
 	if endHeight != 0 && endHeight <= startHeight {
 		return nil, false, xerrors.Errorf("invalid retention selection range [%d, %d)", startHeight, endHeight)
 	}
+	if eligibilityCutoff.IsZero() {
+		return nil, false, xerrors.New("retention selection eligibility cutoff is required")
+	}
 
 	queryLimit := limit + 1
-	pending, err := s.repo.ListPendingRetentionCohorts(ctx, tag, startHeight, endHeight, queryLimit)
+	pending, err := s.repo.ListPendingRetentionCohorts(
+		ctx,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		queryLimit,
+	)
 	if err != nil {
 		return nil, false, xerrors.Errorf("failed to list pending retention cohorts: %w", err)
 	}
-	due, err := s.repo.ListDueRetentionCohorts(ctx, tag, startHeight, endHeight, queryLimit)
+	due, err := s.repo.ListDueRetentionCohorts(
+		ctx,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		queryLimit,
+	)
 	if err != nil {
 		return nil, false, xerrors.Errorf("failed to list due retention cohorts: %w", err)
 	}
@@ -93,9 +117,13 @@ func (s *Selector) Select(
 			if cohort.EndHeight > existing.EndHeight {
 				existing.EndHeight = cohort.EndHeight
 			}
-			if cohort.RowCount > existing.RowCount {
-				existing.RowCount = cohort.RowCount
+			if cohort.RowCount > math.MaxUint64-existing.RowCount {
+				return xerrors.Errorf(
+					"retention cohort row count overflow for object %q",
+					cohort.ConsolidatedObjectKey,
+				)
 			}
+			existing.RowCount += cohort.RowCount
 			if cohort.EligibleAt.After(existing.EligibleAt) {
 				existing.EligibleAt = cohort.EligibleAt
 			}

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -11,6 +11,66 @@ import (
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
+type retentionCohortQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// ListRetentionCohorts reads pending and newly due work from one repeatable-read
+// snapshot. Without the shared snapshot, a manifest inserted between the two
+// reads can disappear from both result sets and falsely signal sweep completion.
+func (r *PostgresRepository) ListRetentionCohorts(
+	ctx context.Context,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	eligibilityCutoff time.Time,
+	limit int,
+) ([]RetentionCohort, []RetentionCohort, error) {
+	if r == nil || r.db == nil {
+		return nil, nil, xerrors.New("postgres db is required")
+	}
+	if limit <= 0 {
+		return nil, nil, nil
+	}
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	})
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to begin retention cohort snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	pending, err := listPendingRetentionCohorts(
+		ctx,
+		tx,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		limit,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	due, err := listDueRetentionCohorts(
+		ctx,
+		tx,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		limit,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, xerrors.Errorf("failed to commit retention cohort snapshot: %w", err)
+	}
+	return pending, due, nil
+}
+
 func (r *PostgresRepository) ListPendingRetentionCohorts(
 	ctx context.Context,
 	tag uint32,
@@ -22,6 +82,26 @@ func (r *PostgresRepository) ListPendingRetentionCohorts(
 	if r == nil || r.db == nil {
 		return nil, xerrors.New("postgres db is required")
 	}
+	return listPendingRetentionCohorts(
+		ctx,
+		r.db,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		limit,
+	)
+}
+
+func listPendingRetentionCohorts(
+	ctx context.Context,
+	db retentionCohortQuerier,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	eligibilityCutoff time.Time,
+	limit int,
+) ([]RetentionCohort, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
@@ -44,7 +124,7 @@ func (r *PostgresRepository) ListPendingRetentionCohorts(
 		GROUP BY retention.consolidated_object_key_main
 		ORDER BY MIN(retention.prepared_at), MIN(retention.height), retention.consolidated_object_key_main
 		LIMIT $8`
-	rows, err := r.db.QueryContext(
+	rows, err := db.QueryContext(
 		ctx,
 		query,
 		tag,
@@ -105,6 +185,26 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 	if r == nil || r.db == nil {
 		return nil, xerrors.New("postgres db is required")
 	}
+	return listDueRetentionCohorts(
+		ctx,
+		r.db,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		limit,
+	)
+}
+
+func listDueRetentionCohorts(
+	ctx context.Context,
+	db retentionCohortQuerier,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	eligibilityCutoff time.Time,
+	limit int,
+) ([]RetentionCohort, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
@@ -182,7 +282,7 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 		ORDER BY %s
 		LIMIT $5`
 	query := fmt.Sprintf(queryTemplate, dueRetentionCohortOrdering(endHeight))
-	rows, err := r.db.QueryContext(
+	rows, err := db.QueryContext(
 		ctx,
 		query,
 		tag,

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -16,6 +16,7 @@ func (r *PostgresRepository) ListPendingRetentionCohorts(
 	tag uint32,
 	startHeight uint64,
 	endHeight uint64,
+	eligibilityCutoff time.Time,
 	limit int,
 ) ([]RetentionCohort, error) {
 	if r == nil || r.db == nil {
@@ -39,9 +40,10 @@ func (r *PostgresRepository) ListPendingRetentionCohorts(
 		WHERE retention.tag = $1
 			AND retention.state IN ($2, $3, $4)
 			AND ($6::BIGINT = 0 OR (retention.height >= $5 AND retention.height < $6))
+			AND shadow.single_block_delete_after <= $7
 		GROUP BY retention.consolidated_object_key_main
 		ORDER BY MIN(retention.prepared_at), MIN(retention.height), retention.consolidated_object_key_main
-		LIMIT $7`
+		LIMIT $8`
 	rows, err := r.db.QueryContext(
 		ctx,
 		query,
@@ -51,6 +53,7 @@ func (r *PostgresRepository) ListPendingRetentionCohorts(
 		RetirementStateDeletedPendingVerification,
 		startHeight,
 		endHeight,
+		eligibilityCutoff,
 		limit,
 	)
 	if err != nil {
@@ -96,6 +99,7 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 	tag uint32,
 	startHeight uint64,
 	endHeight uint64,
+	eligibilityCutoff time.Time,
 	limit int,
 ) ([]RetentionCohort, error) {
 	if r == nil || r.db == nil {
@@ -113,13 +117,20 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 			WHERE shadow.tag = $1
 				AND shadow.validated_at IS NOT NULL
 				AND shadow.single_block_delete_after IS NOT NULL
-				AND shadow.single_block_delete_after <= CURRENT_TIMESTAMP
+				AND shadow.single_block_delete_after <= $6
 				AND shadow.single_block_object_deleted_at IS NULL
 				AND shadow.single_block_object_key_main IS NOT NULL
 				AND shadow.single_block_object_key_main <> ''
 				AND shadow.consolidated_object_key_main IS NOT NULL
 				AND shadow.consolidated_object_key_main <> ''
 				AND ($3::BIGINT = 0 OR (shadow.height >= $2 AND shadow.height < $3))
+				AND NOT EXISTS (
+					SELECT 1
+					FROM block_single_block_retention retention
+					WHERE retention.block_metadata_id = shadow.block_metadata_id
+						AND retention.tag = shadow.tag
+						AND retention.state IN ($7, $8, $9)
+				)
 			GROUP BY shadow.consolidated_object_key_main
 		)
 		SELECT
@@ -151,6 +162,13 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 			AND metadata.object_key_main = shadow.consolidated_object_key_main
 			AND NOT EXISTS (
 				SELECT 1
+				FROM block_single_block_retention retention
+				WHERE retention.block_metadata_id = shadow.block_metadata_id
+					AND retention.tag = shadow.tag
+					AND retention.state IN ($7, $8, $9)
+			)
+			AND NOT EXISTS (
+				SELECT 1
 				FROM cscb_repair_manifest repair
 				WHERE repair.tag = shadow.tag
 					AND repair.state <> 'completed'
@@ -160,7 +178,7 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 					)
 			)
 		GROUP BY due.consolidated_object_key_main, due.eligible_at
-		HAVING MAX(shadow.single_block_delete_after) <= CURRENT_TIMESTAMP
+		HAVING MAX(shadow.single_block_delete_after) <= $6
 		ORDER BY %s
 		LIMIT $5`
 	query := fmt.Sprintf(queryTemplate, dueRetentionCohortOrdering(endHeight))
@@ -172,6 +190,10 @@ func (r *PostgresRepository) ListDueRetentionCohorts(
 		endHeight,
 		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
 		limit,
+		eligibilityCutoff,
+		RetirementStateEligible,
+		RetirementStateDeleting,
+		RetirementStateDeletedPendingVerification,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query due retention cohorts: %w", err)

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -10,29 +10,35 @@ import (
 )
 
 type fakeCohortRepository struct {
-	pending    []RetentionCohort
-	due        []RetentionCohort
-	pendingErr error
-	dueErr     error
+	pending       []RetentionCohort
+	due           []RetentionCohort
+	pendingErr    error
+	dueErr        error
+	pendingCutoff time.Time
+	dueCutoff     time.Time
 }
 
 func (r *fakeCohortRepository) ListPendingRetentionCohorts(
-	context.Context,
-	uint32,
-	uint64,
-	uint64,
-	int,
+	_ context.Context,
+	_ uint32,
+	_ uint64,
+	_ uint64,
+	eligibilityCutoff time.Time,
+	_ int,
 ) ([]RetentionCohort, error) {
+	r.pendingCutoff = eligibilityCutoff
 	return r.pending, r.pendingErr
 }
 
 func (r *fakeCohortRepository) ListDueRetentionCohorts(
-	context.Context,
-	uint32,
-	uint64,
-	uint64,
-	int,
+	_ context.Context,
+	_ uint32,
+	_ uint64,
+	_ uint64,
+	eligibilityCutoff time.Time,
+	_ int,
 ) ([]RetentionCohort, error) {
+	r.dueCutoff = eligibilityCutoff
 	return r.due, r.dueErr
 }
 
@@ -51,7 +57,7 @@ func TestSelectorPrioritizesPendingAndMergesDueRange(t *testing.T) {
 				ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
 				StartHeight:           100,
 				EndHeight:             110,
-				RowCount:              9,
+				RowCount:              8,
 				EligibleAt:            now.Add(-2 * time.Hour),
 			},
 			{
@@ -64,15 +70,17 @@ func TestSelectorPrioritizesPendingAndMergesDueRange(t *testing.T) {
 		},
 	}
 
-	cohorts, hasMore, err := NewSelector(repo).Select(context.Background(), 2, 0, 0, 2)
+	cohorts, hasMore, err := NewSelector(repo).Select(context.Background(), 2, 0, 0, now, 2)
 	require.NoError(t, err)
 	require.False(t, hasMore)
+	require.Equal(t, now, repo.pendingCutoff)
+	require.Equal(t, now, repo.dueCutoff)
 	require.Equal(t, []RetentionCohort{
 		{
 			ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
 			StartHeight:           100,
 			EndHeight:             110,
-			RowCount:              9,
+			RowCount:              10,
 			EligibleAt:            now.Add(-time.Hour),
 			Pending:               true,
 		},
@@ -87,7 +95,8 @@ func TestSelectorPrioritizesPendingAndMergesDueRange(t *testing.T) {
 }
 
 func TestSelectorRejectsInvalidLimitAndCohort(t *testing.T) {
-	_, _, err := NewSelector(&fakeCohortRepository{}).Select(context.Background(), 2, 0, 0, 0)
+	now := time.Now().UTC()
+	_, _, err := NewSelector(&fakeCohortRepository{}).Select(context.Background(), 2, 0, 0, now, 0)
 	require.ErrorContains(t, err, "between 1 and")
 
 	repo := &fakeCohortRepository{
@@ -99,27 +108,31 @@ func TestSelectorRejectsInvalidLimitAndCohort(t *testing.T) {
 			EligibleAt:            time.Now(),
 		}},
 	}
-	_, _, err = NewSelector(repo).Select(context.Background(), 2, 0, 0, 1)
+	_, _, err = NewSelector(repo).Select(context.Background(), 2, 0, 0, now, 1)
 	require.ErrorContains(t, err, "invalid retention cohort")
 }
 
 func TestSelectorPropagatesRepositoryErrors(t *testing.T) {
 	repo := &fakeCohortRepository{pendingErr: errors.New("database unavailable")}
-	_, _, err := NewSelector(repo).Select(context.Background(), 2, 0, 0, 1)
+	_, _, err := NewSelector(repo).Select(context.Background(), 2, 0, 0, time.Now().UTC(), 1)
 	require.ErrorContains(t, err, "database unavailable")
 }
 
 func TestSelectorValidatesOptionalHeightRange(t *testing.T) {
 	selector := NewSelector(&fakeCohortRepository{})
+	now := time.Now().UTC()
 
-	_, _, err := selector.Select(context.Background(), 2, 100, 0, 1)
+	_, _, err := selector.Select(context.Background(), 2, 100, 0, now, 1)
 	require.ErrorContains(t, err, "end height is required")
 
-	_, _, err = selector.Select(context.Background(), 2, 100, 100, 1)
+	_, _, err = selector.Select(context.Background(), 2, 100, 100, now, 1)
 	require.ErrorContains(t, err, "invalid retention selection range")
 
-	_, _, err = selector.Select(context.Background(), 2, 100, 200, 1)
+	_, _, err = selector.Select(context.Background(), 2, 100, 200, now, 1)
 	require.NoError(t, err)
+
+	_, _, err = selector.Select(context.Background(), 2, 100, 200, time.Time{}, 1)
+	require.ErrorContains(t, err, "eligibility cutoff is required")
 }
 
 func TestSelectorReportsRemainingBacklog(t *testing.T) {
@@ -143,7 +156,7 @@ func TestSelectorReportsRemainingBacklog(t *testing.T) {
 		},
 	}
 
-	cohorts, hasMore, err := NewSelector(repo).Select(context.Background(), 2, 0, 0, 1)
+	cohorts, hasMore, err := NewSelector(repo).Select(context.Background(), 2, 0, 0, now, 1)
 	require.NoError(t, err)
 	require.True(t, hasMore)
 	require.Len(t, cohorts, 1)

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -18,28 +18,23 @@ type fakeCohortRepository struct {
 	dueCutoff     time.Time
 }
 
-func (r *fakeCohortRepository) ListPendingRetentionCohorts(
+func (r *fakeCohortRepository) ListRetentionCohorts(
 	_ context.Context,
 	_ uint32,
 	_ uint64,
 	_ uint64,
 	eligibilityCutoff time.Time,
 	_ int,
-) ([]RetentionCohort, error) {
+) ([]RetentionCohort, []RetentionCohort, error) {
 	r.pendingCutoff = eligibilityCutoff
-	return r.pending, r.pendingErr
-}
-
-func (r *fakeCohortRepository) ListDueRetentionCohorts(
-	_ context.Context,
-	_ uint32,
-	_ uint64,
-	_ uint64,
-	eligibilityCutoff time.Time,
-	_ int,
-) ([]RetentionCohort, error) {
 	r.dueCutoff = eligibilityCutoff
-	return r.due, r.dueErr
+	if r.pendingErr != nil {
+		return nil, nil, r.pendingErr
+	}
+	if r.dueErr != nil {
+		return nil, nil, r.dueErr
+	}
+	return r.pending, r.due, nil
 }
 
 func TestSelectorPrioritizesPendingAndMergesDueRange(t *testing.T) {

--- a/internal/storage/retirement/types.go
+++ b/internal/storage/retirement/types.go
@@ -19,7 +19,14 @@ type (
 		RecordRetirementOutcome(ctx context.Context, blockMetadataID int64, claimToken string, outcome string, attemptedAt time.Time) error
 		RecordRetirementObjectDeleted(ctx context.Context, blockMetadataID int64, claimToken string, outcome string) (time.Time, error)
 		FinalizeRetirement(ctx context.Context, blockMetadataID int64, claimToken string, outcome string) (time.Time, error)
-		ListPendingRetirements(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]RetirementManifest, error)
+		ListPendingRetirements(
+			ctx context.Context,
+			tag uint32,
+			startHeight uint64,
+			endHeight uint64,
+			eligibilityCutoff time.Time,
+			limit uint64,
+		) ([]RetirementManifest, error)
 	}
 
 	ObjectStore interface {
@@ -142,6 +149,7 @@ type (
 		EndHeight                   uint64
 		Limit                       uint64
 		Now                         time.Time
+		EligibilityCutoff           time.Time
 		Execute                     bool
 		ProductionDeleteEnabled     bool
 		DirectStorageClientsGuarded bool
@@ -151,9 +159,10 @@ type (
 	}
 
 	Approval struct {
-		Chain       string `json:"chain"`
-		StartHeight uint64 `json:"start_height"`
-		EndHeight   uint64 `json:"end_height"`
+		Chain                string `json:"chain"`
+		StartHeight          uint64 `json:"start_height"`
+		EndHeight            uint64 `json:"end_height"`
+		AllowContainingRange bool   `json:"allow_containing_range,omitempty"`
 	}
 
 	Report struct {

--- a/internal/workflow/activity/single_block_retention.go
+++ b/internal/workflow/activity/single_block_retention.go
@@ -330,8 +330,8 @@ func (a *SingleBlockRetention) planRequest(request *SingleBlockRetentionProcessR
 		SingleBlockWritersGuarded:   request.SingleBlockWritersGuarded,
 		FallbackErrorCount:          request.FallbackErrorCount,
 		// The approval is the operator's assertion passed through unchanged.
-		// The planner independently re-verifies it against the actual chain
-		// and the exact range under deletion.
+		// The planner independently re-verifies the actual chain and requires
+		// the cohort under deletion to be contained by this exact envelope.
 		Approval: retirement.Approval{
 			Chain:       request.ApprovedChain,
 			StartHeight: request.ApprovedStartHeight,
@@ -402,14 +402,14 @@ func validateSingleBlockRetentionProcessRequest(
 			)
 		}
 	}
-	if request.ApprovedStartHeight != cohort.StartHeight || request.ApprovedEndHeight != cohort.EndHeight {
+	if request.ApprovedStartHeight > cohort.StartHeight || request.ApprovedEndHeight < cohort.EndHeight {
 		return xerrors.Errorf(
-			"retention execution approval range [%d, %d) does not exactly match cohort %q [%d, %d)",
-			request.ApprovedStartHeight,
-			request.ApprovedEndHeight,
+			"retention execution cohort %q [%d, %d) is outside approval envelope [%d, %d)",
 			cohort.ConsolidatedObjectKey,
 			cohort.StartHeight,
 			cohort.EndHeight,
+			request.ApprovedStartHeight,
+			request.ApprovedEndHeight,
 		)
 	}
 	if cfg != nil && isProductionRetentionEnvironment(cfg.Env()) && !request.ProductionDeleteEnabled {

--- a/internal/workflow/activity/single_block_retention.go
+++ b/internal/workflow/activity/single_block_retention.go
@@ -41,11 +41,13 @@ type (
 	}
 
 	SingleBlockRetentionSelectRequest struct {
-		Tag               uint32
-		StartHeight       uint64
-		EndHeight         uint64
-		EligibilityCutoff time.Time `validate:"required"`
-		Limit             int       `validate:"required,gt=0,lte=250"`
+		Tag         uint32
+		StartHeight uint64
+		EndHeight   uint64
+		// A zero cutoff is accepted only for activity payloads scheduled by the
+		// pre-sweep workflow and is resolved to activity start time.
+		EligibilityCutoff time.Time
+		Limit             int `validate:"required,gt=0,lte=250"`
 	}
 
 	SingleBlockRetentionSelectResponse struct {
@@ -54,18 +56,20 @@ type (
 	}
 
 	SingleBlockRetentionProcessRequest struct {
-		Tag                         uint32
-		Cohort                      retirement.RetentionCohort
+		Tag    uint32
+		Cohort retirement.RetentionCohort
+		// A zero cutoff preserves compatibility with activity payloads
+		// scheduled before range sweeps froze their destructive set.
+		EligibilityCutoff           time.Time
 		Execute                     bool
 		ProductionDeleteEnabled     bool
 		DirectStorageClientsGuarded bool
 		SingleBlockWritersGuarded   bool
 		FallbackReadsValidated      bool
 		FallbackErrorCount          uint64
-		// Approved* carry the operator's explicit exact-range deletion
-		// approval verbatim. They are never derived from the selected cohort;
-		// execution fails closed unless they name this chain and exactly the
-		// cohort range being processed.
+		// Approved* carry the operator's explicit deletion envelope verbatim.
+		// They are never derived from the selected cohort; execution fails
+		// closed unless they name this chain and contain the cohort.
 		ApprovedChain       string
 		ApprovedStartHeight uint64
 		ApprovedEndHeight   uint64
@@ -140,13 +144,17 @@ func (a *SingleBlockRetention) executeSelect(
 		return nil, err
 	}
 	tag := a.config.GetEffectiveBlockTag(request.Tag)
+	eligibilityCutoff := resolveSingleBlockRetentionEligibilityCutoff(
+		request.EligibilityCutoff,
+		time.Now(),
+	)
 	sdkactivity.RecordHeartbeat(ctx, "single_block_retention.select.started", tag, request.Limit)
 	cohorts, hasMore, err := selector.Select(
 		ctx,
 		tag,
 		request.StartHeight,
 		request.EndHeight,
-		request.EligibilityCutoff,
+		eligibilityCutoff,
 		request.Limit,
 	)
 	if err != nil {
@@ -157,7 +165,7 @@ func (a *SingleBlockRetention) executeSelect(
 		zap.Uint32("tag", tag),
 		zap.Uint64("start_height", request.StartHeight),
 		zap.Uint64("end_height", request.EndHeight),
-		zap.Time("eligibility_cutoff", request.EligibilityCutoff),
+		zap.Time("eligibility_cutoff", eligibilityCutoff),
 		zap.Int("cohorts", len(cohorts)),
 		zap.Bool("has_more", hasMore),
 		zap.Int("limit", request.Limit),
@@ -317,6 +325,16 @@ func (a *SingleBlockRetention) getComponents(
 func (a *SingleBlockRetention) planRequest(request *SingleBlockRetentionProcessRequest) retirement.PlanRequest {
 	blockchain, network, sidechain := singleBlockRetentionChainNames(a.config)
 	tag := a.config.GetEffectiveBlockTag(request.Tag)
+	now := time.Now().UTC()
+	eligibilityCutoff := resolveSingleBlockRetentionEligibilityCutoff(request.EligibilityCutoff, now)
+	approval := retirement.Approval{
+		Chain:       request.ApprovedChain,
+		StartHeight: request.ApprovedStartHeight,
+		EndHeight:   request.ApprovedEndHeight,
+	}
+	if request.ApprovedChain != "" {
+		approval.AllowContainingRange = true
+	}
 	return retirement.PlanRequest{
 		Environment:                 string(a.config.Env()),
 		Blockchain:                  blockchain,
@@ -326,7 +344,8 @@ func (a *SingleBlockRetention) planRequest(request *SingleBlockRetentionProcessR
 		Tag:                         tag,
 		StartHeight:                 request.Cohort.StartHeight,
 		EndHeight:                   request.Cohort.EndHeight,
-		Now:                         time.Now().UTC(),
+		Now:                         now,
+		EligibilityCutoff:           eligibilityCutoff,
 		Execute:                     request.Execute,
 		ProductionDeleteEnabled:     request.ProductionDeleteEnabled,
 		DirectStorageClientsGuarded: request.DirectStorageClientsGuarded,
@@ -334,13 +353,16 @@ func (a *SingleBlockRetention) planRequest(request *SingleBlockRetentionProcessR
 		FallbackErrorCount:          request.FallbackErrorCount,
 		// The approval is the operator's assertion passed through unchanged.
 		// The planner independently re-verifies the actual chain and requires
-		// the cohort under deletion to be contained by this exact envelope.
-		Approval: retirement.Approval{
-			Chain:       request.ApprovedChain,
-			StartHeight: request.ApprovedStartHeight,
-			EndHeight:   request.ApprovedEndHeight,
-		},
+		// the cohort under deletion to be contained by this immutable envelope.
+		Approval: approval,
 	}
+}
+
+func resolveSingleBlockRetentionEligibilityCutoff(cutoff time.Time, now time.Time) time.Time {
+	if cutoff.IsZero() {
+		return now.UTC()
+	}
+	return cutoff.UTC()
 }
 
 func singleBlockRetentionExpectedChain(cfg *config.Config) string {

--- a/internal/workflow/activity/single_block_retention.go
+++ b/internal/workflow/activity/single_block_retention.go
@@ -41,10 +41,11 @@ type (
 	}
 
 	SingleBlockRetentionSelectRequest struct {
-		Tag         uint32
-		StartHeight uint64
-		EndHeight   uint64
-		Limit       int `validate:"required,gt=0,lte=250"`
+		Tag               uint32
+		StartHeight       uint64
+		EndHeight         uint64
+		EligibilityCutoff time.Time `validate:"required"`
+		Limit             int       `validate:"required,gt=0,lte=250"`
 	}
 
 	SingleBlockRetentionSelectResponse struct {
@@ -145,6 +146,7 @@ func (a *SingleBlockRetention) executeSelect(
 		tag,
 		request.StartHeight,
 		request.EndHeight,
+		request.EligibilityCutoff,
 		request.Limit,
 	)
 	if err != nil {
@@ -155,6 +157,7 @@ func (a *SingleBlockRetention) executeSelect(
 		zap.Uint32("tag", tag),
 		zap.Uint64("start_height", request.StartHeight),
 		zap.Uint64("end_height", request.EndHeight),
+		zap.Time("eligibility_cutoff", request.EligibilityCutoff),
 		zap.Int("cohorts", len(cohorts)),
 		zap.Bool("has_more", hasMore),
 		zap.Int("limit", request.Limit),

--- a/internal/workflow/activity/single_block_retention_test.go
+++ b/internal/workflow/activity/single_block_retention_test.go
@@ -245,11 +245,12 @@ func TestValidateSingleBlockRetentionProcessRequestRequiresExecutionGates(t *tes
 	require.ErrorContains(t, err, "approval names chain")
 
 	base.ApprovedChain = singleBlockRetentionExpectedChain(cfg)
-	base.ApprovedEndHeight = 102
+	base.ApprovedStartHeight = 101
 	err = validateSingleBlockRetentionProcessRequest(cfg, base)
-	require.ErrorContains(t, err, "does not exactly match cohort")
+	require.ErrorContains(t, err, "outside approval envelope")
 
-	base.ApprovedEndHeight = 101
+	base.ApprovedStartHeight = 99
+	base.ApprovedEndHeight = 102
 	err = validateSingleBlockRetentionProcessRequest(cfg, base)
 	require.ErrorContains(t, err, "production-delete")
 
@@ -276,13 +277,13 @@ func TestSingleBlockRetentionPlanRequestUsesOperatorApprovalVerbatim(t *testing.
 		Cohort:              cohort,
 		Execute:             true,
 		ApprovedChain:       "solana-mainnet",
-		ApprovedStartHeight: 100,
-		ApprovedEndHeight:   110,
+		ApprovedStartHeight: 90,
+		ApprovedEndHeight:   120,
 	})
 	require.Equal(t, retirement.Approval{
 		Chain:       "solana-mainnet",
-		StartHeight: 100,
-		EndHeight:   110,
+		StartHeight: 90,
+		EndHeight:   120,
 	}, executeReq.Approval)
 
 	// An omitted operator approval stays omitted; it is never synthesized

--- a/internal/workflow/activity/single_block_retention_test.go
+++ b/internal/workflow/activity/single_block_retention_test.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -285,6 +286,12 @@ func TestSingleBlockRetentionPlanRequestUsesOperatorApprovalVerbatim(t *testing.
 		StartHeight: 90,
 		EndHeight:   120,
 	}, executeReq.Approval)
+
+	tagZeroReq := a.planRequest(&SingleBlockRetentionProcessRequest{
+		Tag:    math.MaxUint32,
+		Cohort: cohort,
+	})
+	require.Equal(t, uint32(0), tagZeroReq.Tag)
 
 	// An omitted operator approval stays omitted; it is never synthesized
 	// from the selected cohort.

--- a/internal/workflow/activity/single_block_retention_test.go
+++ b/internal/workflow/activity/single_block_retention_test.go
@@ -276,16 +276,19 @@ func TestSingleBlockRetentionPlanRequestUsesOperatorApprovalVerbatim(t *testing.
 
 	executeReq := a.planRequest(&SingleBlockRetentionProcessRequest{
 		Cohort:              cohort,
+		EligibilityCutoff:   cohort.EligibleAt,
 		Execute:             true,
 		ApprovedChain:       "solana-mainnet",
 		ApprovedStartHeight: 90,
 		ApprovedEndHeight:   120,
 	})
 	require.Equal(t, retirement.Approval{
-		Chain:       "solana-mainnet",
-		StartHeight: 90,
-		EndHeight:   120,
+		Chain:                "solana-mainnet",
+		StartHeight:          90,
+		EndHeight:            120,
+		AllowContainingRange: true,
 	}, executeReq.Approval)
+	require.Equal(t, cohort.EligibleAt.UTC(), executeReq.EligibilityCutoff)
 
 	tagZeroReq := a.planRequest(&SingleBlockRetentionProcessRequest{
 		Tag:    math.MaxUint32,
@@ -297,6 +300,16 @@ func TestSingleBlockRetentionPlanRequestUsesOperatorApprovalVerbatim(t *testing.
 	// from the selected cohort.
 	dryRunReq := a.planRequest(&SingleBlockRetentionProcessRequest{Cohort: cohort})
 	require.Equal(t, retirement.Approval{}, dryRunReq.Approval)
+	require.False(t, dryRunReq.EligibilityCutoff.IsZero())
+	require.Equal(t, dryRunReq.Now, dryRunReq.EligibilityCutoff)
+}
+
+func TestResolveSingleBlockRetentionEligibilityCutoffSupportsLegacyPayload(t *testing.T) {
+	now := time.Date(2026, 7, 31, 4, 0, 0, 0, time.FixedZone("test", 8*60*60))
+	require.Equal(t, now.UTC(), resolveSingleBlockRetentionEligibilityCutoff(time.Time{}, now))
+
+	cutoff := now.Add(-time.Hour)
+	require.Equal(t, cutoff.UTC(), resolveSingleBlockRetentionEligibilityCutoff(cutoff, now.Add(time.Hour)))
 }
 
 func TestSingleBlockRetentionChainNamesUseOperatorCompatibleComponents(t *testing.T) {

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"time"
 
@@ -384,6 +385,7 @@ func (w *SingleBlockRetention) execute(
 		}
 		if request.Execute && rangeSweepEnabled && result.MoreEligibleRanges {
 			nextRequest := *request
+			nextRequest.Tag = encodeSingleBlockRetentionEffectiveTag(tag)
 			nextRequest.Checkpoint = result.checkpoint()
 			nextRequest.Checkpoint.ContinueAsNewCount++
 			logger.Info(
@@ -416,6 +418,13 @@ func (w *SingleBlockRetention) execute(
 		result.FailureMessage = err.Error()
 	}
 	return result, err
+}
+
+func encodeSingleBlockRetentionEffectiveTag(tag uint32) uint32 {
+	if tag == 0 {
+		return math.MaxUint32
+	}
+	return tag
 }
 
 func newSingleBlockRetentionResult(

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -32,9 +32,11 @@ type (
 	}
 
 	SingleBlockRetentionRequest struct {
-		Tag                         uint32
-		StartHeight                 uint64
-		EndHeight                   uint64
+		Tag         uint32
+		StartHeight uint64
+		EndHeight   uint64
+		// MaxObjectRanges bounds each workflow run. Execute runs continue as new
+		// with the same approved envelope while more eligible cohorts remain.
 		MaxObjectRanges             int `validate:"omitempty,gt=0,lte=250"`
 		Execute                     bool
 		ProductionDeleteEnabled     bool
@@ -42,14 +44,39 @@ type (
 		SingleBlockWritersGuarded   bool
 		FallbackReadsValidated      bool
 		FallbackErrorCount          uint64
-		// Approved* are the operator's separate exact-range deletion approval.
+		// Approved* are the operator's separate exact-envelope deletion approval.
 		// Execution requires them, requires the selection range to equal the
-		// approved range, and passes them through unchanged; approval is never
-		// derived from whatever cohort the selector discovers. Read-only runs
-		// may omit them.
+		// approved envelope, and passes them through unchanged across every
+		// continuation. Selected cohorts must be contained by this envelope;
+		// approval is never derived from selector output. Read-only runs may
+		// omit them.
 		ApprovedChain       string
 		ApprovedStartHeight uint64
 		ApprovedEndHeight   uint64
+
+		// Checkpoint is internal continue-as-new state. Initial workflow
+		// executions reject caller-supplied checkpoints.
+		Checkpoint *SingleBlockRetentionCheckpoint
+	}
+
+	SingleBlockRetentionCheckpoint struct {
+		StartedAt                 time.Time
+		EffectiveTag              uint32
+		ContinueAsNewCount        uint64
+		SelectedObjectRanges      uint64
+		ProcessedObjectRanges     uint64
+		CompletedObjectRangeCount uint64
+		ScannedRows               uint64
+		PlannedRows               uint64
+		DeletedVerifiedRows       uint64
+		AlreadyRetiredRows        uint64
+		SkippedSlots              uint64
+		DeferredRows              uint64
+		FailedRows                uint64
+		DeletedVersions           uint64
+		DeletedMarkers            uint64
+		RetiredBytes              uint64
+		LastCompletedObjectRange  *SingleBlockRetentionCompletedRange
 	}
 
 	SingleBlockRetentionCompletedRange struct {
@@ -60,39 +87,51 @@ type (
 	}
 
 	SingleBlockRetentionResult struct {
-		StartedAt              time.Time                                   `json:"started_at"`
-		CompletedAt            time.Time                                   `json:"completed_at"`
-		Tag                    uint32                                      `json:"tag"`
-		SelectionStartHeight   uint64                                      `json:"selection_start_height"`
-		SelectionEndHeight     uint64                                      `json:"selection_end_height"`
-		Execute                bool                                        `json:"execute"`
-		ApprovedChain          string                                      `json:"approved_chain,omitempty"`
-		ApprovedStartHeight    uint64                                      `json:"approved_start_height,omitempty"`
-		ApprovedEndHeight      uint64                                      `json:"approved_end_height,omitempty"`
-		FallbackReadsValidated bool                                        `json:"fallback_reads_validated"`
-		FallbackErrorCount     uint64                                      `json:"fallback_error_count"`
-		SelectedObjectRanges   uint64                                      `json:"selected_object_ranges"`
-		MoreEligibleRanges     bool                                        `json:"more_eligible_ranges"`
-		ProcessedObjectRanges  uint64                                      `json:"processed_object_ranges"`
-		CompletedObjectRanges  []SingleBlockRetentionCompletedRange        `json:"completed_object_ranges,omitempty"`
-		RangeResults           []*activity.SingleBlockRetentionRangeResult `json:"range_results,omitempty"`
-		ScannedRows            uint64                                      `json:"scanned_rows"`
-		PlannedRows            uint64                                      `json:"planned_rows"`
-		DeletedVerifiedRows    uint64                                      `json:"deleted_verified_rows"`
-		AlreadyRetiredRows     uint64                                      `json:"already_retired_rows"`
-		SkippedSlots           uint64                                      `json:"skipped_slots"`
-		DeferredRows           uint64                                      `json:"deferred_rows"`
-		FailedRows             uint64                                      `json:"failed_rows"`
-		DeletedVersions        uint64                                      `json:"deleted_versions"`
-		DeletedMarkers         uint64                                      `json:"deleted_markers"`
-		RetiredBytes           uint64                                      `json:"retired_bytes"`
-		FailureMessage         string                                      `json:"failure_message,omitempty"`
+		StartedAt                 time.Time                           `json:"started_at"`
+		CompletedAt               time.Time                           `json:"completed_at"`
+		Tag                       uint32                              `json:"tag"`
+		SelectionStartHeight      uint64                              `json:"selection_start_height"`
+		SelectionEndHeight        uint64                              `json:"selection_end_height"`
+		Execute                   bool                                `json:"execute"`
+		ApprovedChain             string                              `json:"approved_chain,omitempty"`
+		ApprovedStartHeight       uint64                              `json:"approved_start_height,omitempty"`
+		ApprovedEndHeight         uint64                              `json:"approved_end_height,omitempty"`
+		FallbackReadsValidated    bool                                `json:"fallback_reads_validated"`
+		FallbackErrorCount        uint64                              `json:"fallback_error_count"`
+		ContinueAsNewCount        uint64                              `json:"continue_as_new_count"`
+		SweepCompleted            bool                                `json:"sweep_completed"`
+		SelectedObjectRanges      uint64                              `json:"selected_object_ranges"`
+		MoreEligibleRanges        bool                                `json:"more_eligible_ranges"`
+		ProcessedObjectRanges     uint64                              `json:"processed_object_ranges"`
+		CompletedObjectRangeCount uint64                              `json:"completed_object_range_count"`
+		LastCompletedObjectRange  *SingleBlockRetentionCompletedRange `json:"last_completed_object_range,omitempty"`
+		// CompletedObjectRanges and RangeResults contain only the current
+		// Temporal run. The scalar counters above are cumulative across the
+		// full continue-as-new chain.
+		CompletedObjectRanges []SingleBlockRetentionCompletedRange        `json:"completed_object_ranges,omitempty"`
+		RangeResults          []*activity.SingleBlockRetentionRangeResult `json:"range_results,omitempty"`
+		ScannedRows           uint64                                      `json:"scanned_rows"`
+		PlannedRows           uint64                                      `json:"planned_rows"`
+		DeletedVerifiedRows   uint64                                      `json:"deleted_verified_rows"`
+		AlreadyRetiredRows    uint64                                      `json:"already_retired_rows"`
+		SkippedSlots          uint64                                      `json:"skipped_slots"`
+		DeferredRows          uint64                                      `json:"deferred_rows"`
+		FailedRows            uint64                                      `json:"failed_rows"`
+		DeletedVersions       uint64                                      `json:"deleted_versions"`
+		DeletedMarkers        uint64                                      `json:"deleted_markers"`
+		RetiredBytes          uint64                                      `json:"retired_bytes"`
+		FailureMessage        string                                      `json:"failure_message,omitempty"`
 	}
 )
 
 var _ InstrumentedRequest = (*SingleBlockRetentionRequest)(nil)
 
-const maxSingleBlockRetentionRetryDelay = 30 * time.Minute
+const (
+	maxSingleBlockRetentionRetryDelay = 30 * time.Minute
+
+	singleBlockRetentionRangeSweepChangeID = "single_block_retention.range_sweep"
+	singleBlockRetentionRangeSweepVersion  = 1
+)
 
 func NewSingleBlockRetention(params SingleBlockRetentionParams) *SingleBlockRetention {
 	w := &SingleBlockRetention{
@@ -128,15 +167,7 @@ func (w *SingleBlockRetention) execute(
 	ctx workflow.Context,
 	request *SingleBlockRetentionRequest,
 ) (*SingleBlockRetentionResult, error) {
-	result := &SingleBlockRetentionResult{StartedAt: workflow.Now(ctx).UTC()}
-	if request != nil {
-		result.Execute = request.Execute
-		result.ApprovedChain = request.ApprovedChain
-		result.ApprovedStartHeight = request.ApprovedStartHeight
-		result.ApprovedEndHeight = request.ApprovedEndHeight
-		result.FallbackReadsValidated = request.FallbackReadsValidated
-		result.FallbackErrorCount = request.FallbackErrorCount
-	}
+	result := newSingleBlockRetentionResult(request, workflow.Now(ctx).UTC())
 	err := w.executeWorkflow(ctx, request, func() error {
 		var cfg config.SingleBlockRetentionWorkflowConfig
 		if err := w.readConfig(ctx, &cfg); err != nil {
@@ -145,6 +176,13 @@ func (w *SingleBlockRetention) execute(
 		if err := validateSingleBlockRetentionExecutionRequest(request); err != nil {
 			return err
 		}
+		rangeSweepEnabled := workflow.GetVersion(
+			ctx,
+			singleBlockRetentionRangeSweepChangeID,
+			workflow.DefaultVersion,
+			singleBlockRetentionRangeSweepVersion,
+		) != workflow.DefaultVersion
+		isContinuation := workflow.GetInfo(ctx).ContinuedExecutionRunID != ""
 
 		maxObjectRanges := cfg.MaxObjectRanges
 		if request.MaxObjectRanges > 0 {
@@ -161,6 +199,14 @@ func (w *SingleBlockRetention) execute(
 		result.Tag = tag
 		result.SelectionStartHeight = request.StartHeight
 		result.SelectionEndHeight = request.EndHeight
+		if err := validateSingleBlockRetentionCheckpoint(
+			request,
+			isContinuation,
+			rangeSweepEnabled,
+			tag,
+		); err != nil {
+			return err
+		}
 
 		logger := w.getLogger(ctx).With(
 			zap.Uint32("effective_tag", tag),
@@ -190,7 +236,7 @@ func (w *SingleBlockRetention) execute(
 		if selected.HasMore && len(selected.Cohorts) == 0 {
 			return xerrors.New("single-block retention selector reported a backlog without returning a cohort")
 		}
-		result.SelectedObjectRanges = uint64(len(selected.Cohorts))
+		result.SelectedObjectRanges += uint64(len(selected.Cohorts))
 		result.MoreEligibleRanges = selected.HasMore
 
 		for _, cohort := range selected.Cohorts {
@@ -202,7 +248,11 @@ func (w *SingleBlockRetention) execute(
 				return err
 			}
 			if request.Execute {
-				if err := validateApprovedSingleBlockRetentionCohort(cohort, request); err != nil {
+				if err := validateApprovedSingleBlockRetentionCohort(
+					cohort,
+					request,
+					rangeSweepEnabled,
+				); err != nil {
 					return err
 				}
 			}
@@ -287,12 +337,30 @@ func (w *SingleBlockRetention) execute(
 				}
 			}
 		}
+		if request.Execute && rangeSweepEnabled && selected.HasMore {
+			nextRequest := *request
+			nextRequest.Checkpoint = result.checkpoint()
+			nextRequest.Checkpoint.ContinueAsNewCount++
+			logger.Info(
+				"single-block retention workflow continuing as new",
+				zap.Uint64("continue_as_new_count", nextRequest.Checkpoint.ContinueAsNewCount),
+				zap.Uint64("selected_object_ranges", result.SelectedObjectRanges),
+				zap.Uint64("processed_object_ranges", result.ProcessedObjectRanges),
+				zap.Uint64("completed_object_range_count", result.CompletedObjectRangeCount),
+				zap.Uint64("deleted_verified_rows", result.DeletedVerifiedRows),
+				zap.Uint64("retired_bytes", result.RetiredBytes),
+			)
+			return w.continueAsNew(ctx, &nextRequest)
+		}
+		result.SweepCompleted = request.Execute && !selected.HasMore
 		logger.Info(
 			"single-block retention workflow completed",
+			zap.Bool("sweep_completed", result.SweepCompleted),
+			zap.Uint64("continue_as_new_count", result.ContinueAsNewCount),
 			zap.Uint64("selected_object_ranges", result.SelectedObjectRanges),
 			zap.Bool("more_eligible_ranges", result.MoreEligibleRanges),
 			zap.Uint64("processed_object_ranges", result.ProcessedObjectRanges),
-			zap.Int("completed_object_ranges", len(result.CompletedObjectRanges)),
+			zap.Uint64("completed_object_range_count", result.CompletedObjectRangeCount),
 			zap.Uint64("deleted_verified_rows", result.DeletedVerifiedRows),
 			zap.Uint64("retired_bytes", result.RetiredBytes),
 		)
@@ -303,6 +371,81 @@ func (w *SingleBlockRetention) execute(
 		result.FailureMessage = err.Error()
 	}
 	return result, err
+}
+
+func newSingleBlockRetentionResult(
+	request *SingleBlockRetentionRequest,
+	now time.Time,
+) *SingleBlockRetentionResult {
+	result := &SingleBlockRetentionResult{StartedAt: now}
+	if request == nil {
+		return result
+	}
+
+	result.Execute = request.Execute
+	result.ApprovedChain = request.ApprovedChain
+	result.ApprovedStartHeight = request.ApprovedStartHeight
+	result.ApprovedEndHeight = request.ApprovedEndHeight
+	result.FallbackReadsValidated = request.FallbackReadsValidated
+	result.FallbackErrorCount = request.FallbackErrorCount
+
+	checkpoint := request.Checkpoint
+	if checkpoint == nil {
+		return result
+	}
+	result.StartedAt = checkpoint.StartedAt
+	result.ContinueAsNewCount = checkpoint.ContinueAsNewCount
+	result.SelectedObjectRanges = checkpoint.SelectedObjectRanges
+	result.ProcessedObjectRanges = checkpoint.ProcessedObjectRanges
+	result.CompletedObjectRangeCount = checkpoint.CompletedObjectRangeCount
+	result.ScannedRows = checkpoint.ScannedRows
+	result.PlannedRows = checkpoint.PlannedRows
+	result.DeletedVerifiedRows = checkpoint.DeletedVerifiedRows
+	result.AlreadyRetiredRows = checkpoint.AlreadyRetiredRows
+	result.SkippedSlots = checkpoint.SkippedSlots
+	result.DeferredRows = checkpoint.DeferredRows
+	result.FailedRows = checkpoint.FailedRows
+	result.DeletedVersions = checkpoint.DeletedVersions
+	result.DeletedMarkers = checkpoint.DeletedMarkers
+	result.RetiredBytes = checkpoint.RetiredBytes
+	result.LastCompletedObjectRange = cloneSingleBlockRetentionCompletedRange(
+		checkpoint.LastCompletedObjectRange,
+	)
+	return result
+}
+
+func (r *SingleBlockRetentionResult) checkpoint() *SingleBlockRetentionCheckpoint {
+	return &SingleBlockRetentionCheckpoint{
+		StartedAt:                 r.StartedAt,
+		EffectiveTag:              r.Tag,
+		ContinueAsNewCount:        r.ContinueAsNewCount,
+		SelectedObjectRanges:      r.SelectedObjectRanges,
+		ProcessedObjectRanges:     r.ProcessedObjectRanges,
+		CompletedObjectRangeCount: r.CompletedObjectRangeCount,
+		ScannedRows:               r.ScannedRows,
+		PlannedRows:               r.PlannedRows,
+		DeletedVerifiedRows:       r.DeletedVerifiedRows,
+		AlreadyRetiredRows:        r.AlreadyRetiredRows,
+		SkippedSlots:              r.SkippedSlots,
+		DeferredRows:              r.DeferredRows,
+		FailedRows:                r.FailedRows,
+		DeletedVersions:           r.DeletedVersions,
+		DeletedMarkers:            r.DeletedMarkers,
+		RetiredBytes:              r.RetiredBytes,
+		LastCompletedObjectRange: cloneSingleBlockRetentionCompletedRange(
+			r.LastCompletedObjectRange,
+		),
+	}
+}
+
+func cloneSingleBlockRetentionCompletedRange(
+	completedRange *SingleBlockRetentionCompletedRange,
+) *SingleBlockRetentionCompletedRange {
+	if completedRange == nil {
+		return nil
+	}
+	cloned := *completedRange
+	return &cloned
 }
 
 func (r *SingleBlockRetentionResult) addRangeResult(result *activity.SingleBlockRetentionRangeResult) {
@@ -322,13 +465,63 @@ func (r *SingleBlockRetentionResult) addRangeResult(result *activity.SingleBlock
 	r.DeletedMarkers += result.DeletedMarkers
 	r.RetiredBytes += result.RetiredBytes
 	if result.Terminal {
-		r.CompletedObjectRanges = append(r.CompletedObjectRanges, SingleBlockRetentionCompletedRange{
+		completedRange := SingleBlockRetentionCompletedRange{
 			ConsolidatedObjectKey: result.Cohort.ConsolidatedObjectKey,
 			StartHeight:           result.Cohort.StartHeight,
 			EndHeight:             result.Cohort.EndHeight,
 			EligibleRows:          result.Cohort.RowCount,
-		})
+		}
+		r.CompletedObjectRanges = append(r.CompletedObjectRanges, completedRange)
+		r.CompletedObjectRangeCount++
+		r.LastCompletedObjectRange = &completedRange
 	}
+}
+
+func validateSingleBlockRetentionCheckpoint(
+	request *SingleBlockRetentionRequest,
+	isContinuation bool,
+	rangeSweepEnabled bool,
+	effectiveTag uint32,
+) error {
+	if request == nil || !rangeSweepEnabled {
+		return nil
+	}
+	checkpoint := request.Checkpoint
+	if !isContinuation {
+		if checkpoint != nil {
+			return xerrors.New("single-block retention checkpoint is internal and cannot be supplied on an initial execution")
+		}
+		return nil
+	}
+	if !request.Execute {
+		return xerrors.New("single-block retention continuation requires execution mode")
+	}
+	if checkpoint == nil {
+		return xerrors.New("single-block retention continuation is missing its checkpoint")
+	}
+	if checkpoint.StartedAt.IsZero() || checkpoint.ContinueAsNewCount == 0 {
+		return xerrors.New("single-block retention continuation checkpoint is invalid")
+	}
+	if checkpoint.EffectiveTag != effectiveTag {
+		return xerrors.Errorf(
+			"single-block retention effective tag changed across continuation: checkpoint=%d current=%d",
+			checkpoint.EffectiveTag,
+			effectiveTag,
+		)
+	}
+	if checkpoint.ProcessedObjectRanges > checkpoint.SelectedObjectRanges ||
+		checkpoint.CompletedObjectRangeCount > checkpoint.ProcessedObjectRanges {
+		return xerrors.Errorf(
+			"single-block retention continuation checkpoint counters are invalid: selected=%d processed=%d completed=%d",
+			checkpoint.SelectedObjectRanges,
+			checkpoint.ProcessedObjectRanges,
+			checkpoint.CompletedObjectRangeCount,
+		)
+	}
+	if checkpoint.CompletedObjectRangeCount > 0 && checkpoint.LastCompletedObjectRange == nil {
+		return xerrors.New("single-block retention continuation checkpoint is missing its last completed range")
+	}
+	return nil
 }
 
 func validateSingleBlockRetentionExecutionRequest(
@@ -390,17 +583,32 @@ func validateSingleBlockRetentionSelectionRange(startHeight uint64, endHeight ui
 	return nil
 }
 
-// validateApprovedSingleBlockRetentionCohort fails an execution run closed
-// when the selector discovers a cohort other than the exact object range the
-// operator approved, instead of letting the discovered work redefine the
-// approval.
+// validateApprovedSingleBlockRetentionCohort preserves the exact-cohort check
+// for workflows started before range sweeps were introduced. New workflows
+// allow each selected cohort only when it is fully contained by the immutable
+// operator-approved envelope.
 func validateApprovedSingleBlockRetentionCohort(
 	cohort retirement.RetentionCohort,
 	request *SingleBlockRetentionRequest,
+	rangeSweepEnabled bool,
 ) error {
-	if cohort.StartHeight != request.ApprovedStartHeight || cohort.EndHeight != request.ApprovedEndHeight {
+	if !rangeSweepEnabled {
+		if cohort.StartHeight == request.ApprovedStartHeight &&
+			cohort.EndHeight == request.ApprovedEndHeight {
+			return nil
+		}
 		return xerrors.Errorf(
 			"selected retention cohort %q [%d, %d) does not exactly match the approved range [%d, %d); approve the exact cohort range before execution",
+			cohort.ConsolidatedObjectKey,
+			cohort.StartHeight,
+			cohort.EndHeight,
+			request.ApprovedStartHeight,
+			request.ApprovedEndHeight,
+		)
+	}
+	if cohort.StartHeight < request.ApprovedStartHeight || cohort.EndHeight > request.ApprovedEndHeight {
+		return xerrors.Errorf(
+			"selected retention cohort %q [%d, %d) is outside the approved envelope [%d, %d)",
 			cohort.ConsolidatedObjectKey,
 			cohort.StartHeight,
 			cohort.EndHeight,

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -212,6 +212,16 @@ func (w *SingleBlockRetention) execute(
 			)
 		}
 		tag := cfg.GetEffectiveBlockTag(request.Tag)
+		// Preserve the deployed workflow's resolved numeric tag on the legacy
+		// version path so replayed activity commands remain compatible.
+		activityTag := tag
+		activityEligibilityCutoff := time.Time{}
+		if rangeSweepEnabled {
+			// Pin both values before crossing the workflow/activity boundary.
+			// Workers may observe a newer stable tag during a rolling deploy.
+			activityTag = encodeSingleBlockRetentionEffectiveTag(tag)
+			activityEligibilityCutoff = result.EligibilityCutoff
+		}
 		result.Tag = tag
 		result.SelectionStartHeight = request.StartHeight
 		result.SelectionEndHeight = request.EndHeight
@@ -235,13 +245,10 @@ func (w *SingleBlockRetention) execute(
 		logger.Info("single-block retention workflow started")
 		activityCtx := w.withActivityOptions(ctx)
 		selected, err := w.activity.Select(activityCtx, &activity.SingleBlockRetentionSelectRequest{
-			// Preserve the caller's tag encoding until the activity resolves it
-			// exactly once. In particular, MaxUint32 is the only encoding for
-			// effective tag zero.
-			Tag:               request.Tag,
+			Tag:               activityTag,
 			StartHeight:       request.StartHeight,
 			EndHeight:         request.EndHeight,
-			EligibilityCutoff: result.EligibilityCutoff,
+			EligibilityCutoff: activityEligibilityCutoff,
 			Limit:             maxObjectRanges,
 		})
 		if err != nil {
@@ -278,8 +285,9 @@ func (w *SingleBlockRetention) execute(
 				}
 			}
 			processRequest := &activity.SingleBlockRetentionProcessRequest{
-				Tag:                         request.Tag,
+				Tag:                         activityTag,
 				Cohort:                      cohort,
+				EligibilityCutoff:           activityEligibilityCutoff,
 				Execute:                     request.Execute,
 				ProductionDeleteEnabled:     request.ProductionDeleteEnabled,
 				DirectStorageClientsGuarded: request.DirectStorageClientsGuarded,
@@ -362,10 +370,10 @@ func (w *SingleBlockRetention) execute(
 			remaining, err := w.activity.Select(
 				activityCtx,
 				&activity.SingleBlockRetentionSelectRequest{
-					Tag:               request.Tag,
+					Tag:               activityTag,
 					StartHeight:       request.StartHeight,
 					EndHeight:         request.EndHeight,
-					EligibilityCutoff: result.EligibilityCutoff,
+					EligibilityCutoff: activityEligibilityCutoff,
 					Limit:             1,
 				},
 			)

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -35,6 +35,10 @@ type (
 		Tag         uint32
 		StartHeight uint64
 		EndHeight   uint64
+		// EligibilityCutoff freezes the destructive set. Dry runs may omit it
+		// and return the captured cutoff; new execute sweeps must reuse that
+		// exact dry-run cutoff across every continuation.
+		EligibilityCutoff time.Time
 		// MaxObjectRanges bounds each workflow run. Execute runs continue as new
 		// with the same approved envelope while more eligible cohorts remain.
 		MaxObjectRanges             int `validate:"omitempty,gt=0,lte=250"`
@@ -61,6 +65,7 @@ type (
 
 	SingleBlockRetentionCheckpoint struct {
 		StartedAt                 time.Time
+		EligibilityCutoff         time.Time
 		EffectiveTag              uint32
 		ContinueAsNewCount        uint64
 		SelectedObjectRanges      uint64
@@ -89,6 +94,7 @@ type (
 	SingleBlockRetentionResult struct {
 		StartedAt                 time.Time                           `json:"started_at"`
 		CompletedAt               time.Time                           `json:"completed_at"`
+		EligibilityCutoff         time.Time                           `json:"eligibility_cutoff"`
 		Tag                       uint32                              `json:"tag"`
 		SelectionStartHeight      uint64                              `json:"selection_start_height"`
 		SelectionEndHeight        uint64                              `json:"selection_end_height"`
@@ -183,6 +189,15 @@ func (w *SingleBlockRetention) execute(
 			singleBlockRetentionRangeSweepVersion,
 		) != workflow.DefaultVersion
 		isContinuation := workflow.GetInfo(ctx).ContinuedExecutionRunID != ""
+		if request.Execute && rangeSweepEnabled && request.EligibilityCutoff.IsZero() {
+			return xerrors.New("single-block retention range execution requires the eligibility cutoff from its approved dry run")
+		}
+		if result.EligibilityCutoff.After(workflow.Now(ctx).UTC()) {
+			return xerrors.Errorf(
+				"single-block retention eligibility cutoff %s is in the future",
+				result.EligibilityCutoff,
+			)
+		}
 
 		maxObjectRanges := cfg.MaxObjectRanges
 		if request.MaxObjectRanges > 0 {
@@ -213,15 +228,20 @@ func (w *SingleBlockRetention) execute(
 			zap.Int("max_object_ranges", maxObjectRanges),
 			zap.Uint64("selection_start_height", request.StartHeight),
 			zap.Uint64("selection_end_height", request.EndHeight),
+			zap.Time("eligibility_cutoff", result.EligibilityCutoff),
 			zap.Bool("execute", request.Execute),
 		)
 		logger.Info("single-block retention workflow started")
 		activityCtx := w.withActivityOptions(ctx)
 		selected, err := w.activity.Select(activityCtx, &activity.SingleBlockRetentionSelectRequest{
-			Tag:         tag,
-			StartHeight: request.StartHeight,
-			EndHeight:   request.EndHeight,
-			Limit:       maxObjectRanges,
+			// Preserve the caller's tag encoding until the activity resolves it
+			// exactly once. In particular, MaxUint32 is the only encoding for
+			// effective tag zero.
+			Tag:               request.Tag,
+			StartHeight:       request.StartHeight,
+			EndHeight:         request.EndHeight,
+			EligibilityCutoff: result.EligibilityCutoff,
+			Limit:             maxObjectRanges,
 		})
 		if err != nil {
 			return xerrors.Errorf("failed to select retention cohorts: %w", err)
@@ -257,7 +277,7 @@ func (w *SingleBlockRetention) execute(
 				}
 			}
 			processRequest := &activity.SingleBlockRetentionProcessRequest{
-				Tag:                         tag,
+				Tag:                         request.Tag,
 				Cohort:                      cohort,
 				Execute:                     request.Execute,
 				ProductionDeleteEnabled:     request.ProductionDeleteEnabled,
@@ -337,7 +357,32 @@ func (w *SingleBlockRetention) execute(
 				}
 			}
 		}
-		if request.Execute && rangeSweepEnabled && selected.HasMore {
+		if request.Execute && rangeSweepEnabled && !result.MoreEligibleRanges && len(selected.Cohorts) > 0 {
+			remaining, err := w.activity.Select(
+				activityCtx,
+				&activity.SingleBlockRetentionSelectRequest{
+					Tag:               request.Tag,
+					StartHeight:       request.StartHeight,
+					EndHeight:         request.EndHeight,
+					EligibilityCutoff: result.EligibilityCutoff,
+					Limit:             1,
+				},
+			)
+			if err != nil {
+				return xerrors.Errorf("failed to confirm retention sweep completion: %w", err)
+			}
+			if len(remaining.Cohorts) > 1 {
+				return xerrors.Errorf(
+					"single-block retention completion selector returned %d cohorts above limit 1",
+					len(remaining.Cohorts),
+				)
+			}
+			if remaining.HasMore && len(remaining.Cohorts) == 0 {
+				return xerrors.New("single-block retention completion selector reported a backlog without returning a cohort")
+			}
+			result.MoreEligibleRanges = remaining.HasMore || len(remaining.Cohorts) > 0
+		}
+		if request.Execute && rangeSweepEnabled && result.MoreEligibleRanges {
 			nextRequest := *request
 			nextRequest.Checkpoint = result.checkpoint()
 			nextRequest.Checkpoint.ContinueAsNewCount++
@@ -352,7 +397,7 @@ func (w *SingleBlockRetention) execute(
 			)
 			return w.continueAsNew(ctx, &nextRequest)
 		}
-		result.SweepCompleted = request.Execute && !selected.HasMore
+		result.SweepCompleted = request.Execute && !result.MoreEligibleRanges
 		logger.Info(
 			"single-block retention workflow completed",
 			zap.Bool("sweep_completed", result.SweepCompleted),
@@ -377,7 +422,10 @@ func newSingleBlockRetentionResult(
 	request *SingleBlockRetentionRequest,
 	now time.Time,
 ) *SingleBlockRetentionResult {
-	result := &SingleBlockRetentionResult{StartedAt: now}
+	result := &SingleBlockRetentionResult{
+		StartedAt:         now,
+		EligibilityCutoff: now,
+	}
 	if request == nil {
 		return result
 	}
@@ -388,12 +436,16 @@ func newSingleBlockRetentionResult(
 	result.ApprovedEndHeight = request.ApprovedEndHeight
 	result.FallbackReadsValidated = request.FallbackReadsValidated
 	result.FallbackErrorCount = request.FallbackErrorCount
+	if !request.EligibilityCutoff.IsZero() {
+		result.EligibilityCutoff = request.EligibilityCutoff.UTC()
+	}
 
 	checkpoint := request.Checkpoint
 	if checkpoint == nil {
 		return result
 	}
 	result.StartedAt = checkpoint.StartedAt
+	result.EligibilityCutoff = checkpoint.EligibilityCutoff
 	result.ContinueAsNewCount = checkpoint.ContinueAsNewCount
 	result.SelectedObjectRanges = checkpoint.SelectedObjectRanges
 	result.ProcessedObjectRanges = checkpoint.ProcessedObjectRanges
@@ -417,6 +469,7 @@ func newSingleBlockRetentionResult(
 func (r *SingleBlockRetentionResult) checkpoint() *SingleBlockRetentionCheckpoint {
 	return &SingleBlockRetentionCheckpoint{
 		StartedAt:                 r.StartedAt,
+		EligibilityCutoff:         r.EligibilityCutoff,
 		EffectiveTag:              r.Tag,
 		ContinueAsNewCount:        r.ContinueAsNewCount,
 		SelectedObjectRanges:      r.SelectedObjectRanges,
@@ -499,8 +552,18 @@ func validateSingleBlockRetentionCheckpoint(
 	if checkpoint == nil {
 		return xerrors.New("single-block retention continuation is missing its checkpoint")
 	}
-	if checkpoint.StartedAt.IsZero() || checkpoint.ContinueAsNewCount == 0 {
+	if checkpoint.StartedAt.IsZero() ||
+		checkpoint.EligibilityCutoff.IsZero() ||
+		checkpoint.EligibilityCutoff.After(checkpoint.StartedAt) ||
+		checkpoint.ContinueAsNewCount == 0 {
 		return xerrors.New("single-block retention continuation checkpoint is invalid")
+	}
+	if !checkpoint.EligibilityCutoff.Equal(request.EligibilityCutoff) {
+		return xerrors.Errorf(
+			"single-block retention eligibility cutoff changed across continuation: checkpoint=%s current=%s",
+			checkpoint.EligibilityCutoff,
+			request.EligibilityCutoff,
+		)
 	}
 	if checkpoint.EffectiveTag != effectiveTag {
 		return xerrors.Errorf(

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -2,13 +2,16 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
@@ -128,6 +131,7 @@ func (s *singleBlockRetentionTestSuite) TestDryRunReturnsPlannedRangesWithoutDel
 	require.True(s.T(), result.MoreEligibleRanges)
 	require.Equal(s.T(), uint64(1), result.ProcessedObjectRanges)
 	require.Equal(s.T(), uint64(10), result.PlannedRows)
+	require.False(s.T(), result.SweepCompleted)
 	require.Empty(s.T(), result.CompletedObjectRanges)
 	require.Empty(s.T(), result.FailureMessage)
 }
@@ -179,9 +183,17 @@ func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges()
 	require.Equal(s.T(), uint64(110), result.ApprovedEndHeight)
 	require.Equal(s.T(), uint64(1), result.SelectedObjectRanges)
 	require.Equal(s.T(), uint64(1), result.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(1), result.CompletedObjectRangeCount)
 	require.Equal(s.T(), uint64(10), result.DeletedVerifiedRows)
 	require.Equal(s.T(), uint64(10), result.DeletedVersions)
 	require.Equal(s.T(), uint64(1000), result.RetiredBytes)
+	require.True(s.T(), result.SweepCompleted)
+	require.Equal(s.T(), &SingleBlockRetentionCompletedRange{
+		ConsolidatedObjectKey: cohort.ConsolidatedObjectKey,
+		StartHeight:           100,
+		EndHeight:             110,
+		EligibleRows:          10,
+	}, result.LastCompletedObjectRange)
 	require.Equal(s.T(), []SingleBlockRetentionCompletedRange{
 		{
 			ConsolidatedObjectKey: cohort.ConsolidatedObjectKey,
@@ -192,12 +204,60 @@ func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges()
 	}, result.CompletedObjectRanges)
 }
 
-func (s *singleBlockRetentionTestSuite) TestExecuteFailsClosedWhenCohortDoesNotMatchApprovedRange() {
+func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInsideApprovedEnvelope() {
 	first := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
 	second := testRetentionCohort("consolidated/200-210.cscb.zstd", 200, 210)
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{first, second},
+		}, nil)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			require.Equal(s.T(), uint64(100), request.ApprovedStartHeight)
+			require.Equal(s.T(), uint64(210), request.ApprovedEndHeight)
+			return &activity.SingleBlockRetentionRangeResult{
+				Cohort:                   request.Cohort,
+				ScannedRows:              request.Cohort.RowCount,
+				DeletedVerifiedRows:      request.Cohort.RowCount,
+				VerifiedThroughExclusive: request.Cohort.EndHeight,
+				Terminal:                 true,
+			}, nil
+		}).Twice()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   210,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           210,
+	})
+	require.NoError(s.T(), err)
+
+	var result SingleBlockRetentionResult
+	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
+	require.True(s.T(), result.SweepCompleted)
+	require.Equal(s.T(), uint64(2), result.SelectedObjectRanges)
+	require.Equal(s.T(), uint64(2), result.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(2), result.CompletedObjectRangeCount)
+	require.Equal(s.T(), uint64(20), result.DeletedVerifiedRows)
+	require.Equal(s.T(), second.EndHeight, result.LastCompletedObjectRange.EndHeight)
+}
+
+func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortApproval() {
+	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	s.env.OnGetVersion(
+		singleBlockRetentionRangeSweepChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionRangeSweepVersion,
+	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{cohort},
 		}, nil)
 
 	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
@@ -213,6 +273,160 @@ func (s *singleBlockRetentionTestSuite) TestExecuteFailsClosedWhenCohortDoesNotM
 		ApprovedEndHeight:           210,
 	})
 	require.ErrorContains(s.T(), err, "does not exactly match the approved range")
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeCheckpoint() {
+	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{cohort},
+			HasMore: true,
+		}, nil)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionRangeResult{
+			Cohort:                   cohort,
+			ScannedRows:              10,
+			DeletedVerifiedRows:      10,
+			DeletedVersions:          10,
+			RetiredBytes:             1000,
+			VerifiedThroughExclusive: 110,
+			Terminal:                 true,
+		}, nil)
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		MaxObjectRanges:             1,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.Error(s.T(), err)
+	require.True(s.T(), IsContinueAsNewError(err))
+
+	var continueAsNewErr *temporalworkflow.ContinueAsNewError
+	require.True(s.T(), errors.As(err, &continueAsNewErr))
+	var nextRequest SingleBlockRetentionRequest
+	require.NoError(
+		s.T(),
+		converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextRequest),
+	)
+	require.Equal(s.T(), uint64(100), nextRequest.StartHeight)
+	require.Equal(s.T(), uint64(120), nextRequest.EndHeight)
+	require.Equal(s.T(), uint64(100), nextRequest.ApprovedStartHeight)
+	require.Equal(s.T(), uint64(120), nextRequest.ApprovedEndHeight)
+	require.NotNil(s.T(), nextRequest.Checkpoint)
+	require.Equal(s.T(), uint32(2), nextRequest.Checkpoint.EffectiveTag)
+	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.ContinueAsNewCount)
+	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.SelectedObjectRanges)
+	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.CompletedObjectRangeCount)
+	require.Equal(s.T(), uint64(10), nextRequest.Checkpoint.DeletedVerifiedRows)
+	require.Equal(s.T(), uint64(10), nextRequest.Checkpoint.DeletedVersions)
+	require.Equal(s.T(), uint64(1000), nextRequest.Checkpoint.RetiredBytes)
+	require.Equal(s.T(), uint64(110), nextRequest.Checkpoint.LastCompletedObjectRange.EndHeight)
+}
+
+func (s *singleBlockRetentionTestSuite) TestContinuationReturnsCumulativeFinalResult() {
+	startedAt := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	firstCompleted := &SingleBlockRetentionCompletedRange{
+		ConsolidatedObjectKey: "consolidated/100-110.cscb.zstd",
+		StartHeight:           100,
+		EndHeight:             110,
+		EligibleRows:          10,
+	}
+	second := testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120)
+	s.env.SetContinuedExecutionRunID("previous-run")
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{second},
+		}, nil)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionRangeResult{
+			Cohort:                   second,
+			ScannedRows:              10,
+			DeletedVerifiedRows:      10,
+			DeletedVersions:          10,
+			RetiredBytes:             1000,
+			VerifiedThroughExclusive: 120,
+			Terminal:                 true,
+		}, nil)
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		MaxObjectRanges:             1,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+		Checkpoint: &SingleBlockRetentionCheckpoint{
+			StartedAt:                 startedAt,
+			EffectiveTag:              2,
+			ContinueAsNewCount:        1,
+			SelectedObjectRanges:      1,
+			ProcessedObjectRanges:     1,
+			CompletedObjectRangeCount: 1,
+			ScannedRows:               10,
+			DeletedVerifiedRows:       10,
+			DeletedVersions:           10,
+			RetiredBytes:              1000,
+			LastCompletedObjectRange:  firstCompleted,
+		},
+	})
+	require.NoError(s.T(), err)
+
+	var result SingleBlockRetentionResult
+	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
+	require.Equal(s.T(), startedAt, result.StartedAt)
+	require.True(s.T(), result.SweepCompleted)
+	require.False(s.T(), result.MoreEligibleRanges)
+	require.Equal(s.T(), uint64(1), result.ContinueAsNewCount)
+	require.Equal(s.T(), uint64(2), result.SelectedObjectRanges)
+	require.Equal(s.T(), uint64(2), result.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(2), result.CompletedObjectRangeCount)
+	require.Equal(s.T(), uint64(20), result.DeletedVerifiedRows)
+	require.Equal(s.T(), uint64(20), result.DeletedVersions)
+	require.Equal(s.T(), uint64(2000), result.RetiredBytes)
+	require.Equal(s.T(), second.EndHeight, result.LastCompletedObjectRange.EndHeight)
+	require.Equal(s.T(), []SingleBlockRetentionCompletedRange{
+		{
+			ConsolidatedObjectKey: second.ConsolidatedObjectKey,
+			StartHeight:           second.StartHeight,
+			EndHeight:             second.EndHeight,
+			EligibleRows:          second.RowCount,
+		},
+	}, result.CompletedObjectRanges)
+	require.Len(s.T(), result.RangeResults, 1)
+}
+
+func (s *singleBlockRetentionTestSuite) TestInitialExecutionRejectsCallerSuppliedCheckpoint() {
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+		Checkpoint: &SingleBlockRetentionCheckpoint{
+			StartedAt:          time.Now().UTC(),
+			ContinueAsNewCount: 1,
+		},
+	})
+	require.ErrorContains(s.T(), err, "checkpoint is internal")
 }
 
 func (s *singleBlockRetentionTestSuite) TestExecuteRetriesSafetyQuiescenceOnce() {
@@ -357,17 +571,33 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 func TestValidateApprovedSingleBlockRetentionCohort(t *testing.T) {
 	request := &SingleBlockRetentionRequest{
 		ApprovedStartHeight: 100,
-		ApprovedEndHeight:   110,
+		ApprovedEndHeight:   120,
 	}
 	require.NoError(t, validateApprovedSingleBlockRetentionCohort(
-		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/105-110.cscb.zstd", 105, 110),
 		request,
+		true,
 	))
 	require.ErrorContains(
 		t,
 		validateApprovedSingleBlockRetentionCohort(
-			testRetentionCohort("consolidated/100-109.cscb.zstd", 100, 109),
+			testRetentionCohort("consolidated/99-110.cscb.zstd", 99, 110),
 			request,
+			true,
+		),
+		"outside the approved envelope",
+	)
+	require.NoError(t, validateApprovedSingleBlockRetentionCohort(
+		testRetentionCohort("consolidated/100-120.cscb.zstd", 100, 120),
+		request,
+		false,
+	))
+	require.ErrorContains(
+		t,
+		validateApprovedSingleBlockRetentionCohort(
+			testRetentionCohort("consolidated/105-110.cscb.zstd", 105, 110),
+			request,
+			false,
 		),
 		"does not exactly match the approved range",
 	)

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -291,6 +291,7 @@ func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortAppr
 
 func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeCheckpoint() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	effectiveTag := s.cfg.Workflows.SingleBlockRetention.GetEffectiveBlockTag(0)
 	var selectRequest *activity.SingleBlockRetentionSelectRequest
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
@@ -312,7 +313,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 		}, nil)
 
 	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
-		Tag:                         2,
+		Tag:                         0,
 		StartHeight:                 100,
 		EndHeight:                   120,
 		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
@@ -339,11 +340,12 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	require.Equal(s.T(), uint64(120), nextRequest.EndHeight)
 	require.Equal(s.T(), uint64(100), nextRequest.ApprovedStartHeight)
 	require.Equal(s.T(), uint64(120), nextRequest.ApprovedEndHeight)
+	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), nextRequest.Tag)
 	require.NotNil(s.T(), nextRequest.Checkpoint)
 	require.False(s.T(), selectRequest.EligibilityCutoff.IsZero())
 	require.Equal(s.T(), selectRequest.EligibilityCutoff, nextRequest.Checkpoint.EligibilityCutoff)
 	require.Equal(s.T(), testSingleBlockRetentionEligibilityCutoff, nextRequest.Checkpoint.EligibilityCutoff)
-	require.Equal(s.T(), uint32(2), nextRequest.Checkpoint.EffectiveTag)
+	require.Equal(s.T(), effectiveTag, nextRequest.Checkpoint.EffectiveTag)
 	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.ContinueAsNewCount)
 	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.SelectedObjectRanges)
 	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.ProcessedObjectRanges)
@@ -352,6 +354,11 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	require.Equal(s.T(), uint64(10), nextRequest.Checkpoint.DeletedVersions)
 	require.Equal(s.T(), uint64(1000), nextRequest.Checkpoint.RetiredBytes)
 	require.Equal(s.T(), uint64(110), nextRequest.Checkpoint.LastCompletedObjectRange.EndHeight)
+}
+
+func TestEncodeSingleBlockRetentionEffectiveTag(t *testing.T) {
+	require.Equal(t, uint32(math.MaxUint32), encodeSingleBlockRetentionEffectiveTag(0))
+	require.Equal(t, uint32(2), encodeSingleBlockRetentionEffectiveTag(2))
 }
 
 func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWhenCompletionProbeFindsBacklog() {

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -152,6 +152,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges()
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
 			require.True(s.T(), request.FallbackReadsValidated)
+			require.Equal(s.T(), testSingleBlockRetentionEligibilityCutoff, request.EligibilityCutoff)
 			// The operator approval must reach the activity verbatim, never
 			// rewritten to whatever cohort was selected.
 			require.Equal(s.T(), "solana-mainnet", request.ApprovedChain)
@@ -263,21 +264,24 @@ func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInsideApprove
 
 func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortApproval() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	var selectRequest *activity.SingleBlockRetentionSelectRequest
 	s.env.OnGetVersion(
 		singleBlockRetentionRangeSweepChangeID,
 		temporalworkflow.DefaultVersion,
 		singleBlockRetentionRangeSweepVersion,
 	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
-		Return(&activity.SingleBlockRetentionSelectResponse{
-			Cohorts: []retirement.RetentionCohort{cohort},
-		}, nil)
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
+			selectRequest = request
+			return &activity.SingleBlockRetentionSelectResponse{
+				Cohorts: []retirement.RetentionCohort{cohort},
+			}, nil
+		})
 
 	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
-		Tag:                         2,
+		Tag:                         0,
 		StartHeight:                 100,
 		EndHeight:                   210,
-		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -287,12 +291,63 @@ func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortAppr
 		ApprovedEndHeight:           210,
 	})
 	require.ErrorContains(s.T(), err, "does not exactly match the approved range")
+	require.Equal(
+		s.T(),
+		s.cfg.Workflows.SingleBlockRetention.GetEffectiveBlockTag(0),
+		selectRequest.Tag,
+	)
+	require.True(s.T(), selectRequest.EligibilityCutoff.IsZero())
+}
+
+func (s *singleBlockRetentionTestSuite) TestLegacyExecutePinsResolvedTagAcrossActivities() {
+	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	effectiveTag := s.cfg.Workflows.SingleBlockRetention.GetEffectiveBlockTag(0)
+	s.env.OnGetVersion(
+		singleBlockRetentionRangeSweepChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionRangeSweepVersion,
+	).Return(temporalworkflow.DefaultVersion)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
+			require.Equal(s.T(), effectiveTag, request.Tag)
+			require.True(s.T(), request.EligibilityCutoff.IsZero())
+			s.cfg.Workflows.SingleBlockRetention.BlockTag.Stable = effectiveTag + 1
+			return &activity.SingleBlockRetentionSelectResponse{
+				Cohorts: []retirement.RetentionCohort{cohort},
+			}, nil
+		})
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			require.Equal(s.T(), effectiveTag, request.Tag)
+			require.True(s.T(), request.EligibilityCutoff.IsZero())
+			return &activity.SingleBlockRetentionRangeResult{
+				Cohort:                   request.Cohort,
+				ScannedRows:              request.Cohort.RowCount,
+				DeletedVerifiedRows:      request.Cohort.RowCount,
+				VerifiedThroughExclusive: request.Cohort.EndHeight,
+				Terminal:                 true,
+			}, nil
+		})
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		StartHeight:                 cohort.StartHeight,
+		EndHeight:                   cohort.EndHeight,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         cohort.StartHeight,
+		ApprovedEndHeight:           cohort.EndHeight,
+	})
+	require.NoError(s.T(), err)
 }
 
 func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeCheckpoint() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
 	effectiveTag := s.cfg.Workflows.SingleBlockRetention.GetEffectiveBlockTag(0)
 	var selectRequest *activity.SingleBlockRetentionSelectRequest
+	var processRequest *activity.SingleBlockRetentionProcessRequest
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
 			selectRequest = request
@@ -302,15 +357,18 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 			}, nil
 		})
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
-		Return(&activity.SingleBlockRetentionRangeResult{
-			Cohort:                   cohort,
-			ScannedRows:              10,
-			DeletedVerifiedRows:      10,
-			DeletedVersions:          10,
-			RetiredBytes:             1000,
-			VerifiedThroughExclusive: 110,
-			Terminal:                 true,
-		}, nil)
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			processRequest = request
+			return &activity.SingleBlockRetentionRangeResult{
+				Cohort:                   cohort,
+				ScannedRows:              10,
+				DeletedVerifiedRows:      10,
+				DeletedVersions:          10,
+				RetiredBytes:             1000,
+				VerifiedThroughExclusive: 110,
+				Terminal:                 true,
+			}, nil
+		})
 
 	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
 		Tag:                         0,
@@ -341,6 +399,9 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	require.Equal(s.T(), uint64(100), nextRequest.ApprovedStartHeight)
 	require.Equal(s.T(), uint64(120), nextRequest.ApprovedEndHeight)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), nextRequest.Tag)
+	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), selectRequest.Tag)
+	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), processRequest.Tag)
+	require.Equal(s.T(), testSingleBlockRetentionEligibilityCutoff, processRequest.EligibilityCutoff)
 	require.NotNil(s.T(), nextRequest.Checkpoint)
 	require.False(s.T(), selectRequest.EligibilityCutoff.IsZero())
 	require.Equal(s.T(), selectRequest.EligibilityCutoff, nextRequest.Checkpoint.EligibilityCutoff)

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -31,6 +32,8 @@ type singleBlockRetentionTestSuite struct {
 	app      testapp.TestApp
 	cfg      *config.Config
 }
+
+var testSingleBlockRetentionEligibilityCutoff = time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 
 func TestSingleBlockRetentionWorkflowTestSuite(t *testing.T) {
 	suite.Run(t, new(singleBlockRetentionTestSuite))
@@ -114,17 +117,17 @@ func (s *singleBlockRetentionTestSuite) TestDryRunReturnsPlannedRangesWithoutDel
 		MaxObjectRanges: 1,
 	})
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), &activity.SingleBlockRetentionSelectRequest{
-		Tag:         2,
-		StartHeight: 100,
-		EndHeight:   110,
-		Limit:       1,
-	}, selectRequest)
+	require.Equal(s.T(), uint32(2), selectRequest.Tag)
+	require.Equal(s.T(), uint64(100), selectRequest.StartHeight)
+	require.Equal(s.T(), uint64(110), selectRequest.EndHeight)
+	require.False(s.T(), selectRequest.EligibilityCutoff.IsZero())
+	require.Equal(s.T(), 1, selectRequest.Limit)
 
 	var result SingleBlockRetentionResult
 	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
 	require.False(s.T(), result.Execute)
 	require.Equal(s.T(), uint32(2), result.Tag)
+	require.Equal(s.T(), selectRequest.EligibilityCutoff, result.EligibilityCutoff)
 	require.Equal(s.T(), uint64(100), result.SelectionStartHeight)
 	require.Equal(s.T(), uint64(110), result.SelectionEndHeight)
 	require.Equal(s.T(), uint64(1), result.SelectedObjectRanges)
@@ -141,7 +144,11 @@ func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges()
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{cohort},
-		}, nil)
+		}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{}, nil).
+		Once()
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
 			require.True(s.T(), request.FallbackReadsValidated)
@@ -165,6 +172,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges()
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   110,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -210,7 +218,11 @@ func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInsideApprove
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{first, second},
-		}, nil)
+		}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{}, nil).
+		Once()
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
 			require.Equal(s.T(), uint64(100), request.ApprovedStartHeight)
@@ -228,6 +240,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInsideApprove
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   210,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -264,6 +277,7 @@ func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortAppr
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   210,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -277,11 +291,15 @@ func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortAppr
 
 func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeCheckpoint() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	var selectRequest *activity.SingleBlockRetentionSelectRequest
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
-		Return(&activity.SingleBlockRetentionSelectResponse{
-			Cohorts: []retirement.RetentionCohort{cohort},
-			HasMore: true,
-		}, nil)
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
+			selectRequest = request
+			return &activity.SingleBlockRetentionSelectResponse{
+				Cohorts: []retirement.RetentionCohort{cohort},
+				HasMore: true,
+			}, nil
+		})
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionRangeResult{
 			Cohort:                   cohort,
@@ -297,6 +315,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		MaxObjectRanges:             1,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
@@ -321,6 +340,9 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	require.Equal(s.T(), uint64(100), nextRequest.ApprovedStartHeight)
 	require.Equal(s.T(), uint64(120), nextRequest.ApprovedEndHeight)
 	require.NotNil(s.T(), nextRequest.Checkpoint)
+	require.False(s.T(), selectRequest.EligibilityCutoff.IsZero())
+	require.Equal(s.T(), selectRequest.EligibilityCutoff, nextRequest.Checkpoint.EligibilityCutoff)
+	require.Equal(s.T(), testSingleBlockRetentionEligibilityCutoff, nextRequest.Checkpoint.EligibilityCutoff)
 	require.Equal(s.T(), uint32(2), nextRequest.Checkpoint.EffectiveTag)
 	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.ContinueAsNewCount)
 	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.SelectedObjectRanges)
@@ -330,6 +352,108 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	require.Equal(s.T(), uint64(10), nextRequest.Checkpoint.DeletedVersions)
 	require.Equal(s.T(), uint64(1000), nextRequest.Checkpoint.RetiredBytes)
 	require.Equal(s.T(), uint64(110), nextRequest.Checkpoint.LastCompletedObjectRange.EndHeight)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWhenCompletionProbeFindsBacklog() {
+	first := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	second := testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{first},
+		}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionRangeResult{
+			Cohort:                   first,
+			ScannedRows:              first.RowCount,
+			DeletedVerifiedRows:      first.RowCount,
+			VerifiedThroughExclusive: first.EndHeight,
+			Terminal:                 true,
+		}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{second},
+		}, nil).
+		Once()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             1,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.Error(s.T(), err)
+	require.True(s.T(), IsContinueAsNewError(err))
+
+	var continueAsNewErr *temporalworkflow.ContinueAsNewError
+	require.True(s.T(), errors.As(err, &continueAsNewErr))
+	var nextRequest SingleBlockRetentionRequest
+	require.NoError(
+		s.T(),
+		converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextRequest),
+	)
+	require.NotNil(s.T(), nextRequest.Checkpoint)
+	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.ContinueAsNewCount)
+	require.Equal(s.T(), uint64(1), nextRequest.Checkpoint.CompletedObjectRangeCount)
+	require.Equal(s.T(), first.EndHeight, nextRequest.Checkpoint.LastCompletedObjectRange.EndHeight)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecutePreservesExplicitTagZeroEncoding() {
+	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	selectCalls := 0
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
+			require.Equal(s.T(), uint32(math.MaxUint32), request.Tag)
+			selectCalls++
+			if selectCalls == 1 {
+				return &activity.SingleBlockRetentionSelectResponse{
+					Cohorts: []retirement.RetentionCohort{cohort},
+				}, nil
+			}
+			return &activity.SingleBlockRetentionSelectResponse{}, nil
+		}).
+		Twice()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			require.Equal(s.T(), uint32(math.MaxUint32), request.Tag)
+			return &activity.SingleBlockRetentionRangeResult{
+				Cohort:                   request.Cohort,
+				ScannedRows:              request.Cohort.RowCount,
+				DeletedVerifiedRows:      request.Cohort.RowCount,
+				VerifiedThroughExclusive: request.Cohort.EndHeight,
+				Terminal:                 true,
+			}, nil
+		}).
+		Once()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         math.MaxUint32,
+		StartHeight:                 100,
+		EndHeight:                   110,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           110,
+	})
+	require.NoError(s.T(), err)
+
+	var result SingleBlockRetentionResult
+	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
+	require.Equal(s.T(), uint32(0), result.Tag)
+	require.True(s.T(), result.SweepCompleted)
 }
 
 func (s *singleBlockRetentionTestSuite) TestContinuationReturnsCumulativeFinalResult() {
@@ -345,7 +469,11 @@ func (s *singleBlockRetentionTestSuite) TestContinuationReturnsCumulativeFinalRe
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{second},
-		}, nil)
+		}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{}, nil).
+		Once()
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionRangeResult{
 			Cohort:                   second,
@@ -361,6 +489,7 @@ func (s *singleBlockRetentionTestSuite) TestContinuationReturnsCumulativeFinalRe
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   120,
+		EligibilityCutoff:           startedAt,
 		MaxObjectRanges:             1,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
@@ -371,6 +500,7 @@ func (s *singleBlockRetentionTestSuite) TestContinuationReturnsCumulativeFinalRe
 		ApprovedEndHeight:           120,
 		Checkpoint: &SingleBlockRetentionCheckpoint{
 			StartedAt:                 startedAt,
+			EligibilityCutoff:         startedAt,
 			EffectiveTag:              2,
 			ContinueAsNewCount:        1,
 			SelectedObjectRanges:      1,
@@ -388,6 +518,7 @@ func (s *singleBlockRetentionTestSuite) TestContinuationReturnsCumulativeFinalRe
 	var result SingleBlockRetentionResult
 	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
 	require.Equal(s.T(), startedAt, result.StartedAt)
+	require.Equal(s.T(), startedAt, result.EligibilityCutoff)
 	require.True(s.T(), result.SweepCompleted)
 	require.False(s.T(), result.MoreEligibleRanges)
 	require.Equal(s.T(), uint64(1), result.ContinueAsNewCount)
@@ -414,6 +545,7 @@ func (s *singleBlockRetentionTestSuite) TestInitialExecutionRejectsCallerSupplie
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -429,12 +561,58 @@ func (s *singleBlockRetentionTestSuite) TestInitialExecutionRejectsCallerSupplie
 	require.ErrorContains(s.T(), err, "checkpoint is internal")
 }
 
+func (s *singleBlockRetentionTestSuite) TestRangeExecutionRequiresApprovedDryRunCutoff() {
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.ErrorContains(s.T(), err, "eligibility cutoff from its approved dry run")
+}
+
+func (s *singleBlockRetentionTestSuite) TestContinuationRejectsChangedEligibilityCutoff() {
+	startedAt := testSingleBlockRetentionEligibilityCutoff.Add(time.Hour)
+	s.env.SetContinuedExecutionRunID("previous-run")
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff.Add(-time.Minute),
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+		Checkpoint: &SingleBlockRetentionCheckpoint{
+			StartedAt:          startedAt,
+			EligibilityCutoff:  testSingleBlockRetentionEligibilityCutoff,
+			EffectiveTag:       2,
+			ContinueAsNewCount: 1,
+		},
+	})
+	require.ErrorContains(s.T(), err, "eligibility cutoff changed across continuation")
+}
+
 func (s *singleBlockRetentionTestSuite) TestExecuteRetriesSafetyQuiescenceOnce() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{cohort},
-		}, nil)
+		}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{}, nil).
+		Once()
 	attempt := 0
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
@@ -460,6 +638,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteRetriesSafetyQuiescenceOnce()
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   110,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -490,6 +669,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteFailsClosedWhenRangeIsIncompl
 		Tag:                         2,
 		StartHeight:                 100,
 		EndHeight:                   110,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -506,6 +686,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 		return &SingleBlockRetentionRequest{
 			StartHeight:                 100,
 			EndHeight:                   110,
+			EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 			Execute:                     true,
 			DirectStorageClientsGuarded: true,
 			SingleBlockWritersGuarded:   true,
@@ -609,6 +790,6 @@ func testRetentionCohort(key string, start uint64, end uint64) retirement.Retent
 		StartHeight:           start,
 		EndHeight:             end,
 		RowCount:              end - start,
-		EligibleAt:            time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC),
+		EligibleAt:            testSingleBlockRetentionEligibilityCutoff,
 	}
 }


### PR DESCRIPTION
## Summary
- make execute-mode single-block retention continue as new until a post-processing empty selection confirms the frozen sweep is complete
- freeze the destructive set with the dry-run `EligibilityCutoff` through selection, reconciliation, planning, apply-time revalidation, and every continuation
- pin the workflow-resolved effective block tag into every new-sweep activity request, including explicit tag zero, while preserving deployed legacy Temporal command inputs
- read pending and due cohorts in one read-only repeatable-read PostgreSQL snapshot and merge row-disjoint aggregates with exact counts
- preserve exact approval matching for direct admin callers and require an explicit workflow-only containing-envelope mode after independent cohort validation
- accept pre-sweep activity payloads without a cutoff using legacy wall-clock behavior, without weakening new sweep requests

## Verification
- `TEST_TYPE=unit go test -count=1 -p=1 ./...`
- `TEST_TYPE=unit go test -count=1 ./internal/storage/retirement ./internal/workflow`
- `TEST_TYPE=unit go test -count=1 -run SingleBlockRetention ./internal/workflow/activity`
- `TEST_TYPE=unit go test -count=1 ./internal/workflow/activity`
- `go vet -printfuncs=wrapf,statusf,warnf,infof,debugf,failf,equalf,containsf,fprintf,sprintf ./...`
- `errcheck -ignoretests -ignoregenerated ./...`
- `ineffassign ./...`
- `goimports` and `git diff --check`
- independent adversarial re-review: no constructive findings remain

Linear: https://linear.app/cipherowl/issue/INF-1126