### PR TITLE
feat(INF-1126): parallelize single-block retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,12 +719,17 @@ go run ./cmd/admin workflow start --workflow replicator --input '{"Tag": 0, "Sta
 Inspect currently due single-block retention cohorts in an exact repaired range
 without deleting:
 ```shell
-go run ./cmd/admin workflow start --workflow single_block_retention --input '{"Tag": 0, "StartHeight": 100000, "EndHeight": 110000, "MaxObjectRanges": 10}' --blockchain solana --network mainnet --env local
+go run ./cmd/admin workflow start --workflow single_block_retention --input '{"Tag": 0, "StartHeight": 100000, "EndHeight": 110000, "MaxObjectRanges": 20, "Parallelism": 20}' --blockchain solana --network mainnet --env local
 ```
 
 The workflow is manual-only while production retention is being verified; no
 recurring cron or Temporal Schedule starts it. `MaxObjectRanges` bounds each
-Temporal run. A read-only run remains bounded and reports the current backlog
+Temporal run, while optional `Parallelism` bounds concurrent CSCB cohort
+lifecycles from 1 to 20 and defaults to 1. Each concurrency slot schedules one
+CSCB cohort activity, which processes all covered single-block rows; Temporal
+may dispatch a bounded retry to a different worker. Selected cohorts are
+validated as unique and non-overlapping before parallel execution. A read-only
+run remains bounded and reports the current backlog
 through `MoreEligibleRanges` and returns its frozen `EligibilityCutoff`. A new
 execute sweep must supply that exact dry-run cutoff. It continues as new with
 the same cutoff, selection, and approval envelope until a final empty selection

--- a/README.md
+++ b/README.md
@@ -728,9 +728,12 @@ Temporal run, while optional `Parallelism` bounds concurrent CSCB cohort
 lifecycles from 1 to 20 and defaults to 1. Each concurrency slot schedules one
 CSCB cohort activity, which processes all covered single-block rows; Temporal
 may dispatch a bounded retry to a different worker. Selected cohorts are
-validated as unique and non-overlapping before parallel execution. A read-only
-run remains bounded and reports the current backlog
-through `MoreEligibleRanges` and returns its frozen `EligibilityCutoff`. A new
+validated as unique and non-overlapping before execution on new workflow
+histories. If any post-processing failure occurs after cohort activities start,
+the terminal Temporal application error includes structured outcomes for every
+cohort launched in that run; a failed wave starts no later wave. A read-only run
+remains bounded, reports the current backlog through `MoreEligibleRanges`, and
+returns its frozen `EligibilityCutoff`. A new
 execute sweep must supply that exact dry-run cutoff. It continues as new with
 the same cutoff, selection, and approval envelope until a final empty selection
 confirms that no cohort from the frozen set remains; it never admits cohorts

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -136,7 +137,28 @@ type (
 		FailureMessage        string                                      `json:"failure_message,omitempty"`
 	}
 
+	SingleBlockRetentionFailureDetails struct {
+		FailureMessage                 string                                     `json:"failure_message"`
+		Parallelism                    int                                        `json:"parallelism"`
+		CurrentRunSelectedObjectRanges uint64                                     `json:"current_run_selected_object_ranges"`
+		CurrentRunLaunchedObjectRanges uint64                                     `json:"current_run_launched_object_ranges"`
+		SelectedObjectRanges           uint64                                     `json:"selected_object_ranges"`
+		ProcessedObjectRanges          uint64                                     `json:"processed_object_ranges"`
+		CompletedObjectRangeCount      uint64                                     `json:"completed_object_range_count"`
+		DeletedVerifiedRows            uint64                                     `json:"deleted_verified_rows"`
+		FailedRows                     uint64                                     `json:"failed_rows"`
+		DeferredRows                   uint64                                     `json:"deferred_rows"`
+		CohortOutcomes                 []SingleBlockRetentionCohortFailureOutcome `json:"cohort_outcomes"`
+	}
+
+	SingleBlockRetentionCohortFailureOutcome struct {
+		Cohort         retirement.RetentionCohort                `json:"cohort"`
+		Result         *activity.SingleBlockRetentionRangeResult `json:"result,omitempty"`
+		FailureMessage string                                    `json:"failure_message,omitempty"`
+	}
+
 	singleBlockRetentionCohortOutcome struct {
+		cohort retirement.RetentionCohort
 		result *activity.SingleBlockRetentionRangeResult
 		err    error
 	}
@@ -152,6 +174,7 @@ const (
 	singleBlockRetentionRangeSweepVersion   = 1
 	singleBlockRetentionParallelismChangeID = "single_block_retention.parallelism"
 	singleBlockRetentionParallelismVersion  = 1
+	singleBlockRetentionPartialFailureType  = "single_block_retention_partial_failure"
 )
 
 func NewSingleBlockRetention(params SingleBlockRetentionParams) *SingleBlockRetention {
@@ -189,6 +212,9 @@ func (w *SingleBlockRetention) execute(
 	request *SingleBlockRetentionRequest,
 ) (*SingleBlockRetentionResult, error) {
 	result := newSingleBlockRetentionResult(request, workflow.Now(ctx).UTC())
+	failureDetailsEnabled := false
+	currentRunSelectedObjectRanges := uint64(0)
+	cohortOutcomes := make([]SingleBlockRetentionCohortFailureOutcome, 0)
 	err := w.executeWorkflow(ctx, request, func() error {
 		var cfg config.SingleBlockRetentionWorkflowConfig
 		if err := w.readConfig(ctx, &cfg); err != nil {
@@ -242,6 +268,7 @@ func (w *SingleBlockRetention) execute(
 			workflow.DefaultVersion,
 			singleBlockRetentionParallelismVersion,
 		)
+		failureDetailsEnabled = parallelismVersion != workflow.DefaultVersion
 		if parallelismVersion == workflow.DefaultVersion && parallelism != 1 {
 			return xerrors.Errorf(
 				"legacy single_block_retention execution requires parallelism=1, got %d",
@@ -304,17 +331,20 @@ func (w *SingleBlockRetention) execute(
 			return xerrors.New("single-block retention selector reported a backlog without returning a cohort")
 		}
 		result.SelectedObjectRanges += uint64(len(selected.Cohorts))
+		currentRunSelectedObjectRanges = uint64(len(selected.Cohorts))
 		result.MoreEligibleRanges = selected.HasMore
 
-		if parallelismVersion != workflow.DefaultVersion && parallelism > 1 {
-			if err := validateParallelSingleBlockRetentionCohorts(
+		if parallelismVersion != workflow.DefaultVersion {
+			if err := validateSingleBlockRetentionCohorts(
 				selected.Cohorts,
 				request,
 				rangeSweepEnabled,
 			); err != nil {
 				return err
 			}
-			if err := w.processSingleBlockRetentionCohortsParallel(
+		}
+		if parallelismVersion != workflow.DefaultVersion && parallelism > 1 {
+			outcomes, err := w.processSingleBlockRetentionCohortsParallel(
 				ctx,
 				activityCtx,
 				logger,
@@ -324,8 +354,11 @@ func (w *SingleBlockRetention) execute(
 				selected.Cohorts,
 				parallelism,
 				rangeSweepEnabled,
+				failureDetailsEnabled,
 				result,
-			); err != nil {
+			)
+			cohortOutcomes = append(cohortOutcomes, outcomes...)
+			if err != nil {
 				return err
 			}
 		} else {
@@ -339,8 +372,15 @@ func (w *SingleBlockRetention) execute(
 					activityEligibilityCutoff,
 					cohort,
 					rangeSweepEnabled,
+					failureDetailsEnabled,
 				)
 				result.addRangeResult(rangeResult)
+				if failureDetailsEnabled {
+					cohortOutcomes = append(
+						cohortOutcomes,
+						newSingleBlockRetentionCohortFailureOutcome(cohort, rangeResult, err),
+					)
+				}
 				if err != nil {
 					return err
 				}
@@ -404,6 +444,29 @@ func (w *SingleBlockRetention) execute(
 	result.CompletedAt = workflow.Now(ctx).UTC()
 	if err != nil {
 		result.FailureMessage = err.Error()
+		if failureDetailsEnabled && len(cohortOutcomes) > 0 && !IsContinueAsNewError(err) {
+			failureDetails := SingleBlockRetentionFailureDetails{
+				FailureMessage:                 err.Error(),
+				Parallelism:                    result.Parallelism,
+				CurrentRunSelectedObjectRanges: currentRunSelectedObjectRanges,
+				CurrentRunLaunchedObjectRanges: uint64(len(cohortOutcomes)),
+				SelectedObjectRanges:           result.SelectedObjectRanges,
+				ProcessedObjectRanges:          result.ProcessedObjectRanges,
+				CompletedObjectRangeCount:      result.CompletedObjectRangeCount,
+				DeletedVerifiedRows:            result.DeletedVerifiedRows,
+				FailedRows:                     result.FailedRows,
+				DeferredRows:                   result.DeferredRows,
+				CohortOutcomes:                 cohortOutcomes,
+			}
+			return result, temporal.NewApplicationErrorWithOptions(
+				err.Error(),
+				singleBlockRetentionPartialFailureType,
+				temporal.ApplicationErrorOptions{
+					Cause:   err,
+					Details: []interface{}{failureDetails},
+				},
+			)
+		}
 	}
 	return result, err
 }
@@ -418,8 +481,10 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohortsParallel(
 	cohorts []retirement.RetentionCohort,
 	parallelism int,
 	rangeSweepEnabled bool,
+	resultValidationEnabled bool,
 	result *SingleBlockRetentionResult,
-) error {
+) ([]SingleBlockRetentionCohortFailureOutcome, error) {
+	cohortOutcomes := make([]SingleBlockRetentionCohortFailureOutcome, 0, len(cohorts))
 	for start := 0; start < len(cohorts); start += parallelism {
 		end := start + parallelism
 		if end > len(cohorts) {
@@ -440,8 +505,10 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohortsParallel(
 					activityEligibilityCutoff,
 					cohort,
 					rangeSweepEnabled,
+					resultValidationEnabled,
 				)
 				settable.Set(&singleBlockRetentionCohortOutcome{
+					cohort: cohort,
 					result: rangeResult,
 					err:    err,
 				}, nil)
@@ -450,30 +517,44 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohortsParallel(
 		}
 
 		var firstErr error
-		for _, future := range futures {
+		for i, future := range futures {
+			cohort := cohorts[start+i]
 			var outcome *singleBlockRetentionCohortOutcome
 			if err := future.Get(ctx, &outcome); err != nil {
+				cohortOutcomes = append(
+					cohortOutcomes,
+					newSingleBlockRetentionCohortFailureOutcome(cohort, nil, err),
+				)
 				if firstErr == nil {
 					firstErr = xerrors.Errorf("failed to await parallel retention cohort: %w", err)
 				}
 				continue
 			}
 			if outcome == nil {
+				outcomeErr := xerrors.New("parallel retention cohort returned no outcome")
+				cohortOutcomes = append(
+					cohortOutcomes,
+					newSingleBlockRetentionCohortFailureOutcome(cohort, nil, outcomeErr),
+				)
 				if firstErr == nil {
-					firstErr = xerrors.New("parallel retention cohort returned no outcome")
+					firstErr = outcomeErr
 				}
 				continue
 			}
 			result.addRangeResult(outcome.result)
+			cohortOutcomes = append(
+				cohortOutcomes,
+				newSingleBlockRetentionCohortFailureOutcome(outcome.cohort, outcome.result, outcome.err),
+			)
 			if outcome.err != nil && firstErr == nil {
 				firstErr = outcome.err
 			}
 		}
 		if firstErr != nil {
-			return firstErr
+			return cohortOutcomes, firstErr
 		}
 	}
-	return nil
+	return cohortOutcomes, nil
 }
 
 func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
@@ -485,6 +566,7 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
 	activityEligibilityCutoff time.Time,
 	cohort retirement.RetentionCohort,
 	rangeSweepEnabled bool,
+	resultValidationEnabled bool,
 ) (*activity.SingleBlockRetentionRangeResult, error) {
 	if err := validateSelectedSingleBlockRetentionCohort(
 		cohort,
@@ -527,12 +609,15 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
 			err,
 		)
 	}
-	if err := validateSingleBlockRetentionRangeResult(cohort, rangeResult); err != nil {
-		return nil, err
+	if resultValidationEnabled {
+		if err := validateSingleBlockRetentionRangeResult(cohort, rangeResult); err != nil {
+			return nil, err
+		}
 	}
+	latestValidResult := rangeResult
 	if request.Execute && rangeResult.RetryAfter > 0 {
 		if rangeResult.RetryAfter > maxSingleBlockRetentionRetryDelay {
-			return nil, xerrors.Errorf(
+			return latestValidResult, xerrors.Errorf(
 				"retention cohort %q requested retry delay %s above maximum %s",
 				cohort.ConsolidatedObjectKey,
 				rangeResult.RetryAfter,
@@ -548,11 +633,11 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
 			zap.String("retry_reason", rangeResult.RetryReason),
 		)
 		if err := workflow.Sleep(ctx, rangeResult.RetryAfter); err != nil {
-			return nil, xerrors.Errorf("failed to wait before retention retry: %w", err)
+			return latestValidResult, xerrors.Errorf("failed to wait before retention retry: %w", err)
 		}
-		rangeResult, err = w.activity.Process(activityCtx, processRequest)
+		retryResult, err := w.activity.Process(activityCtx, processRequest)
 		if err != nil {
-			return nil, xerrors.Errorf(
+			return latestValidResult, xerrors.Errorf(
 				"failed to retry retention cohort %q [%d, %d): %w",
 				cohort.ConsolidatedObjectKey,
 				cohort.StartHeight,
@@ -560,9 +645,12 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
 				err,
 			)
 		}
-		if err := validateSingleBlockRetentionRangeResult(cohort, rangeResult); err != nil {
-			return nil, err
+		if resultValidationEnabled {
+			if err := validateSingleBlockRetentionRangeResult(cohort, retryResult); err != nil {
+				return latestValidResult, err
+			}
 		}
+		rangeResult = retryResult
 	}
 	if !request.Execute {
 		return rangeResult, nil
@@ -593,7 +681,22 @@ func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
 	return rangeResult, nil
 }
 
-func validateParallelSingleBlockRetentionCohorts(
+func newSingleBlockRetentionCohortFailureOutcome(
+	cohort retirement.RetentionCohort,
+	result *activity.SingleBlockRetentionRangeResult,
+	err error,
+) SingleBlockRetentionCohortFailureOutcome {
+	outcome := SingleBlockRetentionCohortFailureOutcome{
+		Cohort: cohort,
+		Result: result,
+	}
+	if err != nil {
+		outcome.FailureMessage = err.Error()
+	}
+	return outcome
+}
+
+func validateSingleBlockRetentionCohorts(
 	cohorts []retirement.RetentionCohort,
 	request *SingleBlockRetentionRequest,
 	rangeSweepEnabled bool,
@@ -619,7 +722,7 @@ func validateParallelSingleBlockRetentionCohorts(
 		}
 		if _, ok := seenKeys[cohort.ConsolidatedObjectKey]; ok {
 			return xerrors.Errorf(
-				"parallel retention selection contains duplicate CSCB object %q",
+				"retention selection contains duplicate CSCB object %q",
 				cohort.ConsolidatedObjectKey,
 			)
 		}
@@ -636,7 +739,7 @@ func validateParallelSingleBlockRetentionCohorts(
 		current := ordered[i]
 		if current.StartHeight < previous.EndHeight {
 			return xerrors.Errorf(
-				"parallel retention CSCB ranges overlap: %q [%d, %d) and %q [%d, %d)",
+				"retention CSCB ranges overlap: %q [%d, %d) and %q [%d, %d)",
 				previous.ConsolidatedObjectKey,
 				previous.StartHeight,
 				previous.EndHeight,
@@ -672,6 +775,95 @@ func validateSingleBlockRetentionRangeResult(
 			"retention result cohort does not match request: expected=%+v actual=%+v",
 			expected,
 			actual,
+		)
+	}
+	if result.VerifiedThroughExclusive < expected.StartHeight ||
+		result.VerifiedThroughExclusive > expected.EndHeight {
+		return xerrors.Errorf(
+			"retention result verified-through height %d is outside cohort [%d, %d)",
+			result.VerifiedThroughExclusive,
+			expected.StartHeight,
+			expected.EndHeight,
+		)
+	}
+	if result.FirstIncompleteHeight == nil {
+		if result.VerifiedThroughExclusive != expected.EndHeight ||
+			result.ScannedRows == 0 ||
+			!result.Terminal {
+			return xerrors.Errorf(
+				"retention result has inconsistent terminal progress: terminal=%t scanned_rows=%d verified_through_exclusive=%d first_incomplete_height=nil expected_end=%d",
+				result.Terminal,
+				result.ScannedRows,
+				result.VerifiedThroughExclusive,
+				expected.EndHeight,
+			)
+		}
+	} else {
+		firstIncompleteHeight := *result.FirstIncompleteHeight
+		if firstIncompleteHeight < expected.StartHeight ||
+			firstIncompleteHeight >= expected.EndHeight ||
+			firstIncompleteHeight != result.VerifiedThroughExclusive ||
+			result.Terminal {
+			return xerrors.Errorf(
+				"retention result has inconsistent incomplete progress: terminal=%t verified_through_exclusive=%d first_incomplete_height=%d cohort=[%d, %d)",
+				result.Terminal,
+				result.VerifiedThroughExclusive,
+				firstIncompleteHeight,
+				expected.StartHeight,
+				expected.EndHeight,
+			)
+		}
+	}
+	classifiedRows := []struct {
+		name  string
+		value uint64
+	}{
+		{name: "planned_rows", value: result.PlannedRows},
+		{name: "deleted_verified_rows", value: result.DeletedVerifiedRows},
+		{name: "already_retired_rows", value: result.AlreadyRetiredRows},
+		{name: "skipped_slots", value: result.SkippedSlots},
+		{name: "deferred_rows", value: result.DeferredRows},
+		{name: "failed_rows", value: result.FailedRows},
+	}
+	remainingRows := result.ScannedRows
+	for _, classified := range classifiedRows {
+		if classified.value > remainingRows {
+			return xerrors.Errorf(
+				"retention result row accounting exceeds scanned rows at %s: value=%d remaining=%d scanned_rows=%d",
+				classified.name,
+				classified.value,
+				remainingRows,
+				result.ScannedRows,
+			)
+		}
+		remainingRows -= classified.value
+	}
+	if remainingRows != 0 {
+		return xerrors.Errorf(
+			"retention result row accounting is incomplete: unclassified_rows=%d scanned_rows=%d",
+			remainingRows,
+			result.ScannedRows,
+		)
+	}
+	if result.RetryAfter < 0 || (result.RetryAfter > 0) != (result.RetryReason != "") {
+		return xerrors.Errorf(
+			"retention result has inconsistent retry state: retry_after=%s retry_reason=%q",
+			result.RetryAfter,
+			result.RetryReason,
+		)
+	}
+	if result.Terminal && (result.PlannedRows != 0 ||
+		result.DeferredRows != 0 ||
+		result.FailedRows != 0 ||
+		result.RetryAfter != 0 ||
+		result.FailureMessage != "") {
+		return xerrors.Errorf(
+			"terminal retention result contains nonterminal accounting: planned_rows=%d deferred_rows=%d failed_rows=%d retry_after=%s failure_message=%q",
+			result.PlannedRows,
+			result.DeferredRows,
+			result.FailedRows,
+			result.RetryAfter,
+			result.FailureMessage,
 		)
 	}
 	return nil

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"math"
+	"sort"
 	"strconv"
 	"time"
 
@@ -42,7 +43,11 @@ type (
 		EligibilityCutoff time.Time
 		// MaxObjectRanges bounds each workflow run. Execute runs continue as new
 		// with the same approved envelope while more eligible cohorts remain.
-		MaxObjectRanges             int `validate:"omitempty,gt=0,lte=250"`
+		MaxObjectRanges int `validate:"omitempty,gt=0,lte=250"`
+		// Parallelism bounds concurrent cohort lifecycles. Each lifecycle owns
+		// one CSCB object, including its optional safety-quiescence retry.
+		// Zero preserves the serial default for existing callers.
+		Parallelism                 int `validate:"omitempty,gt=0"`
 		Execute                     bool
 		ProductionDeleteEnabled     bool
 		DirectStorageClientsGuarded bool
@@ -105,6 +110,7 @@ type (
 		ApprovedEndHeight         uint64                              `json:"approved_end_height,omitempty"`
 		FallbackReadsValidated    bool                                `json:"fallback_reads_validated"`
 		FallbackErrorCount        uint64                              `json:"fallback_error_count"`
+		Parallelism               int                                 `json:"parallelism"`
 		ContinueAsNewCount        uint64                              `json:"continue_as_new_count"`
 		SweepCompleted            bool                                `json:"sweep_completed"`
 		SelectedObjectRanges      uint64                              `json:"selected_object_ranges"`
@@ -129,15 +135,23 @@ type (
 		RetiredBytes          uint64                                      `json:"retired_bytes"`
 		FailureMessage        string                                      `json:"failure_message,omitempty"`
 	}
+
+	singleBlockRetentionCohortOutcome struct {
+		result *activity.SingleBlockRetentionRangeResult
+		err    error
+	}
 )
 
 var _ InstrumentedRequest = (*SingleBlockRetentionRequest)(nil)
 
 const (
-	maxSingleBlockRetentionRetryDelay = 30 * time.Minute
+	maxSingleBlockRetentionRetryDelay  = 30 * time.Minute
+	singleBlockRetentionMaxParallelism = 20
 
-	singleBlockRetentionRangeSweepChangeID = "single_block_retention.range_sweep"
-	singleBlockRetentionRangeSweepVersion  = 1
+	singleBlockRetentionRangeSweepChangeID  = "single_block_retention.range_sweep"
+	singleBlockRetentionRangeSweepVersion   = 1
+	singleBlockRetentionParallelismChangeID = "single_block_retention.parallelism"
+	singleBlockRetentionParallelismVersion  = 1
 )
 
 func NewSingleBlockRetention(params SingleBlockRetentionParams) *SingleBlockRetention {
@@ -211,6 +225,29 @@ func (w *SingleBlockRetention) execute(
 				maxObjectRanges,
 			)
 		}
+		parallelism := 1
+		if request.Parallelism > 0 {
+			parallelism = request.Parallelism
+		}
+		if parallelism > singleBlockRetentionMaxParallelism {
+			return xerrors.Errorf(
+				"single_block_retention parallelism(%d) exceeds max(%d)",
+				parallelism,
+				singleBlockRetentionMaxParallelism,
+			)
+		}
+		parallelismVersion := workflow.GetVersion(
+			ctx,
+			singleBlockRetentionParallelismChangeID,
+			workflow.DefaultVersion,
+			singleBlockRetentionParallelismVersion,
+		)
+		if parallelismVersion == workflow.DefaultVersion && parallelism != 1 {
+			return xerrors.Errorf(
+				"legacy single_block_retention execution requires parallelism=1, got %d",
+				parallelism,
+			)
+		}
 		tag := cfg.GetEffectiveBlockTag(request.Tag)
 		// Preserve the deployed workflow's resolved numeric tag on the legacy
 		// version path so replayed activity commands remain compatible.
@@ -223,6 +260,7 @@ func (w *SingleBlockRetention) execute(
 			activityEligibilityCutoff = result.EligibilityCutoff
 		}
 		result.Tag = tag
+		result.Parallelism = parallelism
 		result.SelectionStartHeight = request.StartHeight
 		result.SelectionEndHeight = request.EndHeight
 		if err := validateSingleBlockRetentionCheckpoint(
@@ -237,6 +275,7 @@ func (w *SingleBlockRetention) execute(
 		logger := w.getLogger(ctx).With(
 			zap.Uint32("effective_tag", tag),
 			zap.Int("max_object_ranges", maxObjectRanges),
+			zap.Int("parallelism", parallelism),
 			zap.Uint64("selection_start_height", request.StartHeight),
 			zap.Uint64("selection_end_height", request.EndHeight),
 			zap.Time("eligibility_cutoff", result.EligibilityCutoff),
@@ -267,102 +306,43 @@ func (w *SingleBlockRetention) execute(
 		result.SelectedObjectRanges += uint64(len(selected.Cohorts))
 		result.MoreEligibleRanges = selected.HasMore
 
-		for _, cohort := range selected.Cohorts {
-			if err := validateSelectedSingleBlockRetentionCohort(
-				cohort,
-				request.StartHeight,
-				request.EndHeight,
+		if parallelismVersion != workflow.DefaultVersion && parallelism > 1 {
+			if err := validateParallelSingleBlockRetentionCohorts(
+				selected.Cohorts,
+				request,
+				rangeSweepEnabled,
 			); err != nil {
 				return err
 			}
-			if request.Execute {
-				if err := validateApprovedSingleBlockRetentionCohort(
-					cohort,
+			if err := w.processSingleBlockRetentionCohortsParallel(
+				ctx,
+				activityCtx,
+				logger,
+				request,
+				activityTag,
+				activityEligibilityCutoff,
+				selected.Cohorts,
+				parallelism,
+				rangeSweepEnabled,
+				result,
+			); err != nil {
+				return err
+			}
+		} else {
+			for _, cohort := range selected.Cohorts {
+				rangeResult, err := w.processSingleBlockRetentionCohort(
+					ctx,
+					activityCtx,
+					logger,
 					request,
+					activityTag,
+					activityEligibilityCutoff,
+					cohort,
 					rangeSweepEnabled,
-				); err != nil {
-					return err
-				}
-			}
-			processRequest := &activity.SingleBlockRetentionProcessRequest{
-				Tag:                         activityTag,
-				Cohort:                      cohort,
-				EligibilityCutoff:           activityEligibilityCutoff,
-				Execute:                     request.Execute,
-				ProductionDeleteEnabled:     request.ProductionDeleteEnabled,
-				DirectStorageClientsGuarded: request.DirectStorageClientsGuarded,
-				SingleBlockWritersGuarded:   request.SingleBlockWritersGuarded,
-				FallbackReadsValidated:      request.FallbackReadsValidated,
-				FallbackErrorCount:          request.FallbackErrorCount,
-				ApprovedChain:               request.ApprovedChain,
-				ApprovedStartHeight:         request.ApprovedStartHeight,
-				ApprovedEndHeight:           request.ApprovedEndHeight,
-			}
-			rangeResult, err := w.activity.Process(activityCtx, processRequest)
-			if err != nil {
-				return xerrors.Errorf(
-					"failed to process retention cohort %q [%d, %d): %w",
-					cohort.ConsolidatedObjectKey,
-					cohort.StartHeight,
-					cohort.EndHeight,
-					err,
 				)
-			}
-			if request.Execute && rangeResult.RetryAfter > 0 {
-				if rangeResult.RetryAfter > maxSingleBlockRetentionRetryDelay {
-					return xerrors.Errorf(
-						"retention cohort %q requested retry delay %s above maximum %s",
-						cohort.ConsolidatedObjectKey,
-						rangeResult.RetryAfter,
-						maxSingleBlockRetentionRetryDelay,
-					)
-				}
-				logger.Info(
-					"single-block retention cohort deferred for bounded retry",
-					zap.String("consolidated_object_key", cohort.ConsolidatedObjectKey),
-					zap.Uint64("start_height", cohort.StartHeight),
-					zap.Uint64("end_height", cohort.EndHeight),
-					zap.Duration("retry_after", rangeResult.RetryAfter),
-					zap.String("retry_reason", rangeResult.RetryReason),
-				)
-				if err := workflow.Sleep(ctx, rangeResult.RetryAfter); err != nil {
-					return xerrors.Errorf("failed to wait before retention retry: %w", err)
-				}
-				rangeResult, err = w.activity.Process(activityCtx, processRequest)
+				result.addRangeResult(rangeResult)
 				if err != nil {
-					return xerrors.Errorf(
-						"failed to retry retention cohort %q [%d, %d): %w",
-						cohort.ConsolidatedObjectKey,
-						cohort.StartHeight,
-						cohort.EndHeight,
-						err,
-					)
-				}
-			}
-			result.addRangeResult(rangeResult)
-			if request.Execute {
-				if rangeResult.RetryAfter > 0 {
-					return xerrors.Errorf(
-						"retention cohort %q remained deferred after bounded retry: %s",
-						cohort.ConsolidatedObjectKey,
-						rangeResult.RetryReason,
-					)
-				}
-				if rangeResult.FailureMessage != "" {
-					return xerrors.Errorf(
-						"retention cohort %q failed: %s",
-						cohort.ConsolidatedObjectKey,
-						rangeResult.FailureMessage,
-					)
-				}
-				if rangeResult.FailedRows > 0 || rangeResult.DeferredRows > 0 || !rangeResult.Terminal {
-					return xerrors.Errorf(
-						"retention cohort %q did not finish: failed_rows=%d deferred_rows=%d verified_through_exclusive=%d",
-						cohort.ConsolidatedObjectKey,
-						rangeResult.FailedRows,
-						rangeResult.DeferredRows,
-						rangeResult.VerifiedThroughExclusive,
-					)
+					return err
 				}
 			}
 		}
@@ -426,6 +406,275 @@ func (w *SingleBlockRetention) execute(
 		result.FailureMessage = err.Error()
 	}
 	return result, err
+}
+
+func (w *SingleBlockRetention) processSingleBlockRetentionCohortsParallel(
+	ctx workflow.Context,
+	activityCtx workflow.Context,
+	logger *zap.Logger,
+	request *SingleBlockRetentionRequest,
+	activityTag uint32,
+	activityEligibilityCutoff time.Time,
+	cohorts []retirement.RetentionCohort,
+	parallelism int,
+	rangeSweepEnabled bool,
+	result *SingleBlockRetentionResult,
+) error {
+	for start := 0; start < len(cohorts); start += parallelism {
+		end := start + parallelism
+		if end > len(cohorts) {
+			end = len(cohorts)
+		}
+
+		futures := make([]workflow.Future, 0, end-start)
+		for i := start; i < end; i++ {
+			cohort := cohorts[i]
+			future, settable := workflow.NewFuture(ctx)
+			workflow.Go(activityCtx, func(cohortCtx workflow.Context) {
+				rangeResult, err := w.processSingleBlockRetentionCohort(
+					cohortCtx,
+					cohortCtx,
+					logger,
+					request,
+					activityTag,
+					activityEligibilityCutoff,
+					cohort,
+					rangeSweepEnabled,
+				)
+				settable.Set(&singleBlockRetentionCohortOutcome{
+					result: rangeResult,
+					err:    err,
+				}, nil)
+			})
+			futures = append(futures, future)
+		}
+
+		var firstErr error
+		for _, future := range futures {
+			var outcome *singleBlockRetentionCohortOutcome
+			if err := future.Get(ctx, &outcome); err != nil {
+				if firstErr == nil {
+					firstErr = xerrors.Errorf("failed to await parallel retention cohort: %w", err)
+				}
+				continue
+			}
+			if outcome == nil {
+				if firstErr == nil {
+					firstErr = xerrors.New("parallel retention cohort returned no outcome")
+				}
+				continue
+			}
+			result.addRangeResult(outcome.result)
+			if outcome.err != nil && firstErr == nil {
+				firstErr = outcome.err
+			}
+		}
+		if firstErr != nil {
+			return firstErr
+		}
+	}
+	return nil
+}
+
+func (w *SingleBlockRetention) processSingleBlockRetentionCohort(
+	ctx workflow.Context,
+	activityCtx workflow.Context,
+	logger *zap.Logger,
+	request *SingleBlockRetentionRequest,
+	activityTag uint32,
+	activityEligibilityCutoff time.Time,
+	cohort retirement.RetentionCohort,
+	rangeSweepEnabled bool,
+) (*activity.SingleBlockRetentionRangeResult, error) {
+	if err := validateSelectedSingleBlockRetentionCohort(
+		cohort,
+		request.StartHeight,
+		request.EndHeight,
+	); err != nil {
+		return nil, err
+	}
+	if request.Execute {
+		if err := validateApprovedSingleBlockRetentionCohort(
+			cohort,
+			request,
+			rangeSweepEnabled,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	processRequest := &activity.SingleBlockRetentionProcessRequest{
+		Tag:                         activityTag,
+		Cohort:                      cohort,
+		EligibilityCutoff:           activityEligibilityCutoff,
+		Execute:                     request.Execute,
+		ProductionDeleteEnabled:     request.ProductionDeleteEnabled,
+		DirectStorageClientsGuarded: request.DirectStorageClientsGuarded,
+		SingleBlockWritersGuarded:   request.SingleBlockWritersGuarded,
+		FallbackReadsValidated:      request.FallbackReadsValidated,
+		FallbackErrorCount:          request.FallbackErrorCount,
+		ApprovedChain:               request.ApprovedChain,
+		ApprovedStartHeight:         request.ApprovedStartHeight,
+		ApprovedEndHeight:           request.ApprovedEndHeight,
+	}
+	rangeResult, err := w.activity.Process(activityCtx, processRequest)
+	if err != nil {
+		return nil, xerrors.Errorf(
+			"failed to process retention cohort %q [%d, %d): %w",
+			cohort.ConsolidatedObjectKey,
+			cohort.StartHeight,
+			cohort.EndHeight,
+			err,
+		)
+	}
+	if err := validateSingleBlockRetentionRangeResult(cohort, rangeResult); err != nil {
+		return nil, err
+	}
+	if request.Execute && rangeResult.RetryAfter > 0 {
+		if rangeResult.RetryAfter > maxSingleBlockRetentionRetryDelay {
+			return nil, xerrors.Errorf(
+				"retention cohort %q requested retry delay %s above maximum %s",
+				cohort.ConsolidatedObjectKey,
+				rangeResult.RetryAfter,
+				maxSingleBlockRetentionRetryDelay,
+			)
+		}
+		logger.Info(
+			"single-block retention cohort deferred for bounded retry",
+			zap.String("consolidated_object_key", cohort.ConsolidatedObjectKey),
+			zap.Uint64("start_height", cohort.StartHeight),
+			zap.Uint64("end_height", cohort.EndHeight),
+			zap.Duration("retry_after", rangeResult.RetryAfter),
+			zap.String("retry_reason", rangeResult.RetryReason),
+		)
+		if err := workflow.Sleep(ctx, rangeResult.RetryAfter); err != nil {
+			return nil, xerrors.Errorf("failed to wait before retention retry: %w", err)
+		}
+		rangeResult, err = w.activity.Process(activityCtx, processRequest)
+		if err != nil {
+			return nil, xerrors.Errorf(
+				"failed to retry retention cohort %q [%d, %d): %w",
+				cohort.ConsolidatedObjectKey,
+				cohort.StartHeight,
+				cohort.EndHeight,
+				err,
+			)
+		}
+		if err := validateSingleBlockRetentionRangeResult(cohort, rangeResult); err != nil {
+			return nil, err
+		}
+	}
+	if !request.Execute {
+		return rangeResult, nil
+	}
+	if rangeResult.RetryAfter > 0 {
+		return rangeResult, xerrors.Errorf(
+			"retention cohort %q remained deferred after bounded retry: %s",
+			cohort.ConsolidatedObjectKey,
+			rangeResult.RetryReason,
+		)
+	}
+	if rangeResult.FailureMessage != "" {
+		return rangeResult, xerrors.Errorf(
+			"retention cohort %q failed: %s",
+			cohort.ConsolidatedObjectKey,
+			rangeResult.FailureMessage,
+		)
+	}
+	if rangeResult.FailedRows > 0 || rangeResult.DeferredRows > 0 || !rangeResult.Terminal {
+		return rangeResult, xerrors.Errorf(
+			"retention cohort %q did not finish: failed_rows=%d deferred_rows=%d verified_through_exclusive=%d",
+			cohort.ConsolidatedObjectKey,
+			rangeResult.FailedRows,
+			rangeResult.DeferredRows,
+			rangeResult.VerifiedThroughExclusive,
+		)
+	}
+	return rangeResult, nil
+}
+
+func validateParallelSingleBlockRetentionCohorts(
+	cohorts []retirement.RetentionCohort,
+	request *SingleBlockRetentionRequest,
+	rangeSweepEnabled bool,
+) error {
+	ordered := append([]retirement.RetentionCohort(nil), cohorts...)
+	seenKeys := make(map[string]struct{}, len(ordered))
+	for _, cohort := range ordered {
+		if err := validateSelectedSingleBlockRetentionCohort(
+			cohort,
+			request.StartHeight,
+			request.EndHeight,
+		); err != nil {
+			return err
+		}
+		if request.Execute {
+			if err := validateApprovedSingleBlockRetentionCohort(
+				cohort,
+				request,
+				rangeSweepEnabled,
+			); err != nil {
+				return err
+			}
+		}
+		if _, ok := seenKeys[cohort.ConsolidatedObjectKey]; ok {
+			return xerrors.Errorf(
+				"parallel retention selection contains duplicate CSCB object %q",
+				cohort.ConsolidatedObjectKey,
+			)
+		}
+		seenKeys[cohort.ConsolidatedObjectKey] = struct{}{}
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].StartHeight != ordered[j].StartHeight {
+			return ordered[i].StartHeight < ordered[j].StartHeight
+		}
+		return ordered[i].EndHeight < ordered[j].EndHeight
+	})
+	for i := 1; i < len(ordered); i++ {
+		previous := ordered[i-1]
+		current := ordered[i]
+		if current.StartHeight < previous.EndHeight {
+			return xerrors.Errorf(
+				"parallel retention CSCB ranges overlap: %q [%d, %d) and %q [%d, %d)",
+				previous.ConsolidatedObjectKey,
+				previous.StartHeight,
+				previous.EndHeight,
+				current.ConsolidatedObjectKey,
+				current.StartHeight,
+				current.EndHeight,
+			)
+		}
+	}
+	return nil
+}
+
+func validateSingleBlockRetentionRangeResult(
+	expected retirement.RetentionCohort,
+	result *activity.SingleBlockRetentionRangeResult,
+) error {
+	if result == nil {
+		return xerrors.Errorf(
+			"retention cohort %q [%d, %d) returned no result",
+			expected.ConsolidatedObjectKey,
+			expected.StartHeight,
+			expected.EndHeight,
+		)
+	}
+	actual := result.Cohort
+	if actual.ConsolidatedObjectKey != expected.ConsolidatedObjectKey ||
+		actual.StartHeight != expected.StartHeight ||
+		actual.EndHeight != expected.EndHeight ||
+		actual.RowCount != expected.RowCount ||
+		!actual.EligibleAt.Equal(expected.EligibleAt) ||
+		actual.Pending != expected.Pending {
+		return xerrors.Errorf(
+			"retention result cohort does not match request: expected=%+v actual=%+v",
+			expected,
+			actual,
+		)
+	}
+	return nil
 }
 
 func encodeSingleBlockRetentionEffectiveTag(tag uint32) uint32 {

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -141,6 +143,11 @@ func (s *singleBlockRetentionTestSuite) TestDryRunReturnsPlannedRangesWithoutDel
 
 func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	s.env.OnGetVersion(
+		singleBlockRetentionParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionParallelismVersion,
+	).Return(temporalworkflow.DefaultVersion)
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{cohort},
@@ -191,6 +198,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteReturnsExactCompletedRanges()
 	require.Equal(s.T(), uint64(100), result.ApprovedStartHeight)
 	require.Equal(s.T(), uint64(110), result.ApprovedEndHeight)
 	require.Equal(s.T(), uint64(1), result.SelectedObjectRanges)
+	require.Equal(s.T(), 1, result.Parallelism)
 	require.Equal(s.T(), uint64(1), result.ProcessedObjectRanges)
 	require.Equal(s.T(), uint64(1), result.CompletedObjectRangeCount)
 	require.Equal(s.T(), uint64(10), result.DeletedVerifiedRows)
@@ -260,6 +268,237 @@ func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInsideApprove
 	require.Equal(s.T(), uint64(2), result.CompletedObjectRangeCount)
 	require.Equal(s.T(), uint64(20), result.DeletedVerifiedRows)
 	require.Equal(s.T(), second.EndHeight, result.LastCompletedObjectRange.EndHeight)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInParallelBatches() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+		testRetentionCohort("consolidated/120-130.cscb.zstd", 120, 130),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{}, nil).
+		Once()
+
+	var active int32
+	var maxActive int32
+	var mu sync.Mutex
+	processedKeys := make([]string, 0, len(cohorts))
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			current := atomic.AddInt32(&active, 1)
+			for {
+				previous := atomic.LoadInt32(&maxActive)
+				if current <= previous || atomic.CompareAndSwapInt32(&maxActive, previous, current) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+			mu.Lock()
+			processedKeys = append(processedKeys, request.Cohort.ConsolidatedObjectKey)
+			mu.Unlock()
+			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
+		}).
+		Times(len(cohorts))
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   130,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           130,
+	})
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int32(2), atomic.LoadInt32(&maxActive))
+	require.ElementsMatch(s.T(), []string{
+		cohorts[0].ConsolidatedObjectKey,
+		cohorts[1].ConsolidatedObjectKey,
+		cohorts[2].ConsolidatedObjectKey,
+	}, processedKeys)
+
+	var result SingleBlockRetentionResult
+	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
+	require.Equal(s.T(), 2, result.Parallelism)
+	require.Equal(s.T(), uint64(3), result.CompletedObjectRangeCount)
+	require.Len(s.T(), result.CompletedObjectRanges, 3)
+	for i, completed := range result.CompletedObjectRanges {
+		require.Equal(s.T(), cohorts[i].ConsolidatedObjectKey, completed.ConsolidatedObjectKey)
+	}
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteRetriesParallelCohortsConcurrently() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{}, nil).
+		Once()
+
+	attempts := make(map[string]int, len(cohorts))
+	var mu sync.Mutex
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			mu.Lock()
+			attempts[request.Cohort.ConsolidatedObjectKey]++
+			attempt := attempts[request.Cohort.ConsolidatedObjectKey]
+			mu.Unlock()
+			if attempt == 1 {
+				return &activity.SingleBlockRetentionRangeResult{
+					Cohort:       request.Cohort,
+					DeferredRows: request.Cohort.RowCount,
+					RetryAfter:   time.Minute,
+					RetryReason:  retirement.SkipCSCBSafetyQuiescenceActive,
+				}, nil
+			}
+			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
+		}).
+		Times(4)
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), 2, attempts[cohorts[0].ConsolidatedObjectKey])
+	require.Equal(s.T(), 2, attempts[cohorts[1].ConsolidatedObjectKey])
+
+	var result SingleBlockRetentionResult
+	require.NoError(s.T(), s.env.GetWorkflowResult(&result))
+	require.Less(s.T(), result.CompletedAt.Sub(result.StartedAt), 2*time.Minute)
+	require.Equal(s.T(), uint64(2), result.CompletedObjectRangeCount)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteRejectsOverlappingParallelCohortsBeforeProcessing() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-115.cscb.zstd", 100, 115),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.ErrorContains(s.T(), err, "parallel retention CSCB ranges overlap")
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteParallelFailureStopsBeforeNextBatch() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+		testRetentionCohort("consolidated/120-130.cscb.zstd", 120, 130),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+
+	var mu sync.Mutex
+	processedKeys := make([]string, 0, 2)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			mu.Lock()
+			processedKeys = append(processedKeys, request.Cohort.ConsolidatedObjectKey)
+			mu.Unlock()
+			if request.Cohort.ConsolidatedObjectKey == cohorts[0].ConsolidatedObjectKey {
+				return &activity.SingleBlockRetentionRangeResult{
+					Cohort:                   request.Cohort,
+					ScannedRows:              request.Cohort.RowCount,
+					FailedRows:               1,
+					VerifiedThroughExclusive: request.Cohort.StartHeight,
+				}, nil
+			}
+			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
+		}).
+		Twice()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   130,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           130,
+	})
+	require.ErrorContains(s.T(), err, "did not finish")
+	require.ElementsMatch(s.T(), []string{
+		cohorts[0].ConsolidatedObjectKey,
+		cohorts[1].ConsolidatedObjectKey,
+	}, processedKeys)
+}
+
+func (s *singleBlockRetentionTestSuite) TestLegacyExecutionRejectsParallelism() {
+	s.env.OnGetVersion(
+		singleBlockRetentionParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionParallelismVersion,
+	).Return(temporalworkflow.DefaultVersion)
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:             2,
+		StartHeight:     100,
+		EndHeight:       120,
+		Parallelism:     2,
+		MaxObjectRanges: 2,
+	})
+	require.ErrorContains(s.T(), err, "legacy single_block_retention execution requires parallelism=1")
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecutionRejectsParallelismAboveMaximum() {
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:             2,
+		StartHeight:     100,
+		EndHeight:       120,
+		Parallelism:     singleBlockRetentionMaxParallelism + 1,
+		MaxObjectRanges: 2,
+	})
+	require.ErrorContains(s.T(), err, "parallelism(21) exceeds max(20)")
 }
 
 func (s *singleBlockRetentionTestSuite) TestLegacyExecuteRequiresExactCohortApproval() {
@@ -376,6 +615,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 		EndHeight:                   120,
 		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
 		MaxObjectRanges:             1,
+		Parallelism:                 2,
 		Execute:                     true,
 		DirectStorageClientsGuarded: true,
 		SingleBlockWritersGuarded:   true,
@@ -398,6 +638,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	require.Equal(s.T(), uint64(120), nextRequest.EndHeight)
 	require.Equal(s.T(), uint64(100), nextRequest.ApprovedStartHeight)
 	require.Equal(s.T(), uint64(120), nextRequest.ApprovedEndHeight)
+	require.Equal(s.T(), 2, nextRequest.Parallelism)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), nextRequest.Tag)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), selectRequest.Tag)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), processRequest.Tag)
@@ -852,6 +1093,39 @@ func TestValidateApprovedSingleBlockRetentionCohort(t *testing.T) {
 	)
 }
 
+func TestValidateParallelSingleBlockRetentionCohorts(t *testing.T) {
+	request := &SingleBlockRetentionRequest{
+		StartHeight: 100,
+		EndHeight:   130,
+	}
+	first := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	second := testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120)
+	require.NoError(t, validateParallelSingleBlockRetentionCohorts(
+		[]retirement.RetentionCohort{second, first},
+		request,
+		true,
+	))
+
+	duplicate := second
+	duplicate.ConsolidatedObjectKey = first.ConsolidatedObjectKey
+	require.ErrorContains(t, validateParallelSingleBlockRetentionCohorts(
+		[]retirement.RetentionCohort{first, duplicate},
+		request,
+		true,
+	), "duplicate CSCB object")
+}
+
+func TestValidateSingleBlockRetentionRangeResult(t *testing.T) {
+	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	require.NoError(t, validateSingleBlockRetentionRangeResult(
+		cohort,
+		terminalSingleBlockRetentionRangeResult(cohort),
+	))
+	mismatch := terminalSingleBlockRetentionRangeResult(cohort)
+	mismatch.Cohort.EndHeight++
+	require.ErrorContains(t, validateSingleBlockRetentionRangeResult(cohort, mismatch), "does not match request")
+}
+
 func testRetentionCohort(key string, start uint64, end uint64) retirement.RetentionCohort {
 	return retirement.RetentionCohort{
 		ConsolidatedObjectKey: key,
@@ -859,5 +1133,18 @@ func testRetentionCohort(key string, start uint64, end uint64) retirement.Retent
 		EndHeight:             end,
 		RowCount:              end - start,
 		EligibleAt:            testSingleBlockRetentionEligibilityCutoff,
+	}
+}
+
+func terminalSingleBlockRetentionRangeResult(
+	cohort retirement.RetentionCohort,
+) *activity.SingleBlockRetentionRangeResult {
+	return &activity.SingleBlockRetentionRangeResult{
+		Cohort:                   cohort,
+		ScannedRows:              cohort.RowCount,
+		DeletedVerifiedRows:      cohort.RowCount,
+		DeletedVersions:          cohort.RowCount,
+		VerifiedThroughExclusive: cohort.EndHeight,
+		Terminal:                 true,
 	}
 }

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 	temporalworkflow "go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 
@@ -95,6 +97,7 @@ func (s *singleBlockRetentionTestSuite) TearDownTest() {
 
 func (s *singleBlockRetentionTestSuite) TestDryRunReturnsPlannedRangesWithoutDeleting() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	firstIncompleteHeight := cohort.StartHeight
 	var selectRequest *activity.SingleBlockRetentionSelectRequest
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
@@ -110,6 +113,7 @@ func (s *singleBlockRetentionTestSuite) TestDryRunReturnsPlannedRangesWithoutDel
 			ScannedRows:              10,
 			PlannedRows:              10,
 			VerifiedThroughExclusive: 100,
+			FirstIncompleteHeight:    &firstIncompleteHeight,
 		}, nil)
 
 	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
@@ -276,6 +280,11 @@ func (s *singleBlockRetentionTestSuite) TestExecuteProcessesCohortsInParallelBat
 		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
 		testRetentionCohort("consolidated/120-130.cscb.zstd", 120, 130),
 	}
+	s.env.OnGetVersion(
+		singleBlockRetentionParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionParallelismVersion,
+	).Return(temporalworkflow.Version(singleBlockRetentionParallelismVersion))
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
 		Once()
@@ -359,11 +368,15 @@ func (s *singleBlockRetentionTestSuite) TestExecuteRetriesParallelCohortsConcurr
 			attempt := attempts[request.Cohort.ConsolidatedObjectKey]
 			mu.Unlock()
 			if attempt == 1 {
+				firstIncompleteHeight := request.Cohort.StartHeight
 				return &activity.SingleBlockRetentionRangeResult{
-					Cohort:       request.Cohort,
-					DeferredRows: request.Cohort.RowCount,
-					RetryAfter:   time.Minute,
-					RetryReason:  retirement.SkipCSCBSafetyQuiescenceActive,
+					Cohort:                   request.Cohort,
+					ScannedRows:              request.Cohort.RowCount,
+					DeferredRows:             request.Cohort.RowCount,
+					VerifiedThroughExclusive: request.Cohort.StartHeight,
+					FirstIncompleteHeight:    &firstIncompleteHeight,
+					RetryAfter:               time.Minute,
+					RetryReason:              retirement.SkipCSCBSafetyQuiescenceActive,
 				}, nil
 			}
 			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
@@ -419,7 +432,67 @@ func (s *singleBlockRetentionTestSuite) TestExecuteRejectsOverlappingParallelCoh
 		ApprovedStartHeight:         100,
 		ApprovedEndHeight:           120,
 	})
-	require.ErrorContains(s.T(), err, "parallel retention CSCB ranges overlap")
+	require.ErrorContains(s.T(), err, "retention CSCB ranges overlap")
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteRejectsDuplicateSerialCohortsBeforeProcessing() {
+	first := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	second := testRetentionCohort(first.ConsolidatedObjectKey, 110, 120)
+	s.env.OnGetVersion(
+		singleBlockRetentionParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionParallelismVersion,
+	).Return(temporalworkflow.Version(singleBlockRetentionParallelismVersion))
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{first, second},
+		}, nil).
+		Once()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:             2,
+		StartHeight:     100,
+		EndHeight:       120,
+		MaxObjectRanges: 2,
+		Parallelism:     1,
+	})
+	require.ErrorContains(s.T(), err, "retention selection contains duplicate CSCB object")
+	s.env.AssertActivityNotCalled(
+		s.T(),
+		activity.ActivitySingleBlockRetentionProcess,
+		mock.Anything,
+		mock.Anything,
+	)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteRejectsOverlappingSerialCohortsBeforeProcessing() {
+	first := testRetentionCohort("consolidated/100-115.cscb.zstd", 100, 115)
+	second := testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120)
+	s.env.OnGetVersion(
+		singleBlockRetentionParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionParallelismVersion,
+	).Return(temporalworkflow.Version(singleBlockRetentionParallelismVersion))
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{
+			Cohorts: []retirement.RetentionCohort{first, second},
+		}, nil).
+		Once()
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:             2,
+		StartHeight:     100,
+		EndHeight:       120,
+		MaxObjectRanges: 2,
+		Parallelism:     1,
+	})
+	require.ErrorContains(s.T(), err, "retention CSCB ranges overlap")
+	s.env.AssertActivityNotCalled(
+		s.T(),
+		activity.ActivitySingleBlockRetentionProcess,
+		mock.Anything,
+		mock.Anything,
+	)
 }
 
 func (s *singleBlockRetentionTestSuite) TestExecuteParallelFailureStopsBeforeNextBatch() {
@@ -440,11 +513,14 @@ func (s *singleBlockRetentionTestSuite) TestExecuteParallelFailureStopsBeforeNex
 			processedKeys = append(processedKeys, request.Cohort.ConsolidatedObjectKey)
 			mu.Unlock()
 			if request.Cohort.ConsolidatedObjectKey == cohorts[0].ConsolidatedObjectKey {
+				firstIncompleteHeight := request.Cohort.StartHeight
 				return &activity.SingleBlockRetentionRangeResult{
 					Cohort:                   request.Cohort,
 					ScannedRows:              request.Cohort.RowCount,
+					AlreadyRetiredRows:       request.Cohort.RowCount - 1,
 					FailedRows:               1,
 					VerifiedThroughExclusive: request.Cohort.StartHeight,
+					FirstIncompleteHeight:    &firstIncompleteHeight,
 				}, nil
 			}
 			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
@@ -471,6 +547,221 @@ func (s *singleBlockRetentionTestSuite) TestExecuteParallelFailureStopsBeforeNex
 		cohorts[0].ConsolidatedObjectKey,
 		cohorts[1].ConsolidatedObjectKey,
 	}, processedKeys)
+
+	var applicationErr *temporal.ApplicationError
+	require.ErrorAs(s.T(), s.env.GetWorkflowError(), &applicationErr)
+	require.Equal(s.T(), singleBlockRetentionPartialFailureType, applicationErr.Type())
+	require.True(s.T(), applicationErr.HasDetails())
+	var failureDetails SingleBlockRetentionFailureDetails
+	require.NoError(s.T(), applicationErr.Details(&failureDetails))
+	require.ErrorContains(s.T(), errors.New(failureDetails.FailureMessage), "did not finish")
+	require.Equal(s.T(), 2, failureDetails.Parallelism)
+	require.Equal(s.T(), uint64(3), failureDetails.CurrentRunSelectedObjectRanges)
+	require.Equal(s.T(), uint64(2), failureDetails.CurrentRunLaunchedObjectRanges)
+	require.Equal(s.T(), uint64(3), failureDetails.SelectedObjectRanges)
+	require.Equal(s.T(), uint64(2), failureDetails.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(1), failureDetails.CompletedObjectRangeCount)
+	require.Len(s.T(), failureDetails.CohortOutcomes, 2)
+	require.Equal(s.T(), cohorts[0], failureDetails.CohortOutcomes[0].Cohort)
+	require.ErrorContains(
+		s.T(),
+		errors.New(failureDetails.CohortOutcomes[0].FailureMessage),
+		"did not finish",
+	)
+	require.NotNil(s.T(), failureDetails.CohortOutcomes[0].Result)
+	require.Equal(s.T(), cohorts[1], failureDetails.CohortOutcomes[1].Cohort)
+	require.Empty(s.T(), failureDetails.CohortOutcomes[1].FailureMessage)
+	require.True(s.T(), failureDetails.CohortOutcomes[1].Result.Terminal)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteParallelFailureDetailsIncludeEarlierWaves() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+		testRetentionCohort("consolidated/120-130.cscb.zstd", 120, 130),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			if request.Cohort.ConsolidatedObjectKey == cohorts[2].ConsolidatedObjectKey {
+				firstIncompleteHeight := request.Cohort.StartHeight
+				return &activity.SingleBlockRetentionRangeResult{
+					Cohort:                   request.Cohort,
+					ScannedRows:              request.Cohort.RowCount,
+					AlreadyRetiredRows:       request.Cohort.RowCount - 1,
+					FailedRows:               1,
+					VerifiedThroughExclusive: request.Cohort.StartHeight,
+					FirstIncompleteHeight:    &firstIncompleteHeight,
+				}, nil
+			}
+			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
+		}).
+		Times(len(cohorts))
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   130,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           130,
+	})
+	require.ErrorContains(s.T(), err, "did not finish")
+
+	var applicationErr *temporal.ApplicationError
+	require.ErrorAs(s.T(), s.env.GetWorkflowError(), &applicationErr)
+	var failureDetails SingleBlockRetentionFailureDetails
+	require.NoError(s.T(), applicationErr.Details(&failureDetails))
+	require.Equal(s.T(), uint64(3), failureDetails.CurrentRunSelectedObjectRanges)
+	require.Equal(s.T(), uint64(3), failureDetails.CurrentRunLaunchedObjectRanges)
+	require.Equal(s.T(), uint64(3), failureDetails.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(2), failureDetails.CompletedObjectRangeCount)
+	require.Len(s.T(), failureDetails.CohortOutcomes, 3)
+	for i, cohort := range cohorts {
+		require.Equal(s.T(), cohort, failureDetails.CohortOutcomes[i].Cohort)
+	}
+	require.Empty(s.T(), failureDetails.CohortOutcomes[0].FailureMessage)
+	require.Empty(s.T(), failureDetails.CohortOutcomes[1].FailureMessage)
+	require.ErrorContains(
+		s.T(),
+		errors.New(failureDetails.CohortOutcomes[2].FailureMessage),
+		"did not finish",
+	)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteParallelRetryFailurePreservesLatestValidResult() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+
+	var mu sync.Mutex
+	attempts := make(map[string]int)
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			mu.Lock()
+			attempts[request.Cohort.ConsolidatedObjectKey]++
+			attempt := attempts[request.Cohort.ConsolidatedObjectKey]
+			mu.Unlock()
+			if request.Cohort.ConsolidatedObjectKey != cohorts[0].ConsolidatedObjectKey {
+				return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
+			}
+			if attempt == 1 {
+				firstIncompleteHeight := request.Cohort.StartHeight
+				return &activity.SingleBlockRetentionRangeResult{
+					Cohort:                   request.Cohort,
+					ScannedRows:              request.Cohort.RowCount,
+					DeferredRows:             request.Cohort.RowCount,
+					VerifiedThroughExclusive: request.Cohort.StartHeight,
+					FirstIncompleteHeight:    &firstIncompleteHeight,
+					RetryAfter:               time.Minute,
+					RetryReason:              retirement.SkipCSCBSafetyQuiescenceActive,
+				}, nil
+			}
+			return nil, temporal.NewNonRetryableApplicationError(
+				"retry unavailable",
+				"test_retry_failure",
+				nil,
+			)
+		}).
+		Times(3)
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.ErrorContains(s.T(), err, "failed to retry retention cohort")
+
+	var applicationErr *temporal.ApplicationError
+	require.ErrorAs(s.T(), s.env.GetWorkflowError(), &applicationErr)
+	var failureDetails SingleBlockRetentionFailureDetails
+	require.NoError(s.T(), applicationErr.Details(&failureDetails))
+	require.Equal(s.T(), uint64(2), failureDetails.CurrentRunLaunchedObjectRanges)
+	require.Equal(s.T(), uint64(2), failureDetails.ProcessedObjectRanges)
+	require.Equal(s.T(), uint64(1), failureDetails.CompletedObjectRangeCount)
+	require.Equal(s.T(), cohorts[0].RowCount, failureDetails.DeferredRows)
+	require.Len(s.T(), failureDetails.CohortOutcomes, 2)
+	require.Equal(s.T(), cohorts[0], failureDetails.CohortOutcomes[0].Cohort)
+	require.NotNil(s.T(), failureDetails.CohortOutcomes[0].Result)
+	require.Equal(s.T(), cohorts[0].RowCount, failureDetails.CohortOutcomes[0].Result.DeferredRows)
+	require.ErrorContains(
+		s.T(),
+		errors.New(failureDetails.CohortOutcomes[0].FailureMessage),
+		"failed to retry retention cohort",
+	)
+	require.Equal(s.T(), cohorts[1], failureDetails.CohortOutcomes[1].Cohort)
+	require.True(s.T(), failureDetails.CohortOutcomes[1].Result.Terminal)
+}
+
+func (s *singleBlockRetentionTestSuite) TestExecuteCompletionProbeFailureIncludesProcessedCohorts() {
+	cohorts := []retirement.RetentionCohort{
+		testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110),
+		testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120),
+	}
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return(&activity.SingleBlockRetentionSelectResponse{Cohorts: cohorts}, nil).
+		Once()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionProcess, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
+			return terminalSingleBlockRetentionRangeResult(request.Cohort), nil
+		}).
+		Twice()
+	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
+		Return((*activity.SingleBlockRetentionSelectResponse)(nil), errors.New("completion probe unavailable"))
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 100,
+		EndHeight:                   120,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             len(cohorts),
+		Parallelism:                 2,
+		Execute:                     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         100,
+		ApprovedEndHeight:           120,
+	})
+	require.ErrorContains(s.T(), err, "failed to confirm retention sweep completion")
+
+	var applicationErr *temporal.ApplicationError
+	require.ErrorAs(s.T(), s.env.GetWorkflowError(), &applicationErr)
+	var failureDetails SingleBlockRetentionFailureDetails
+	require.NoError(s.T(), applicationErr.Details(&failureDetails))
+	require.ErrorContains(
+		s.T(),
+		errors.New(failureDetails.FailureMessage),
+		"completion probe unavailable",
+	)
+	require.Equal(s.T(), uint64(2), failureDetails.CurrentRunSelectedObjectRanges)
+	require.Equal(s.T(), uint64(2), failureDetails.CurrentRunLaunchedObjectRanges)
+	require.Equal(s.T(), uint64(2), failureDetails.CompletedObjectRangeCount)
+	require.Len(s.T(), failureDetails.CohortOutcomes, 2)
 }
 
 func (s *singleBlockRetentionTestSuite) TestLegacyExecutionRejectsParallelism() {
@@ -488,6 +779,20 @@ func (s *singleBlockRetentionTestSuite) TestLegacyExecutionRejectsParallelism() 
 		MaxObjectRanges: 2,
 	})
 	require.ErrorContains(s.T(), err, "legacy single_block_retention execution requires parallelism=1")
+}
+
+func (s *singleBlockRetentionTestSuite) TestReplayPreParallelismHistory() {
+	replayer := worker.NewWorkflowReplayer()
+	replayer.RegisterWorkflowWithOptions(s.workflow.execute, temporalworkflow.RegisterOptions{
+		Name: s.workflow.name,
+	})
+	require.NoError(
+		s.T(),
+		replayer.ReplayWorkflowHistoryFromJSONFile(
+			nil,
+			"testdata/single_block_retention_pre_parallelism_history.json",
+		),
+	)
 }
 
 func (s *singleBlockRetentionTestSuite) TestExecutionRejectsParallelismAboveMaximum() {
@@ -587,6 +892,11 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	effectiveTag := s.cfg.Workflows.SingleBlockRetention.GetEffectiveBlockTag(0)
 	var selectRequest *activity.SingleBlockRetentionSelectRequest
 	var processRequest *activity.SingleBlockRetentionProcessRequest
+	s.env.OnGetVersion(
+		singleBlockRetentionParallelismChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionParallelismVersion,
+	).Return(temporalworkflow.Version(singleBlockRetentionParallelismVersion))
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionSelectRequest) (*activity.SingleBlockRetentionSelectResponse, error) {
 			selectRequest = request
@@ -927,11 +1237,15 @@ func (s *singleBlockRetentionTestSuite) TestExecuteRetriesSafetyQuiescenceOnce()
 		Return(func(_ context.Context, request *activity.SingleBlockRetentionProcessRequest) (*activity.SingleBlockRetentionRangeResult, error) {
 			attempt++
 			if attempt == 1 {
+				firstIncompleteHeight := request.Cohort.StartHeight
 				return &activity.SingleBlockRetentionRangeResult{
-					Cohort:       request.Cohort,
-					DeferredRows: request.Cohort.RowCount,
-					RetryAfter:   time.Minute,
-					RetryReason:  retirement.SkipCSCBSafetyQuiescenceActive,
+					Cohort:                   request.Cohort,
+					ScannedRows:              request.Cohort.RowCount,
+					DeferredRows:             request.Cohort.RowCount,
+					VerifiedThroughExclusive: request.Cohort.StartHeight,
+					FirstIncompleteHeight:    &firstIncompleteHeight,
+					RetryAfter:               time.Minute,
+					RetryReason:              retirement.SkipCSCBSafetyQuiescenceActive,
 				}, nil
 			}
 			return &activity.SingleBlockRetentionRangeResult{
@@ -962,6 +1276,7 @@ func (s *singleBlockRetentionTestSuite) TestExecuteRetriesSafetyQuiescenceOnce()
 
 func (s *singleBlockRetentionTestSuite) TestExecuteFailsClosedWhenRangeIsIncomplete() {
 	cohort := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
+	firstIncompleteHeight := uint64(105)
 	s.env.OnActivity(activity.ActivitySingleBlockRetentionSelect, mock.Anything, mock.Anything).
 		Return(&activity.SingleBlockRetentionSelectResponse{
 			Cohorts: []retirement.RetentionCohort{cohort},
@@ -970,8 +1285,10 @@ func (s *singleBlockRetentionTestSuite) TestExecuteFailsClosedWhenRangeIsIncompl
 		Return(&activity.SingleBlockRetentionRangeResult{
 			Cohort:                   cohort,
 			ScannedRows:              10,
+			AlreadyRetiredRows:       9,
 			FailedRows:               1,
 			VerifiedThroughExclusive: 105,
+			FirstIncompleteHeight:    &firstIncompleteHeight,
 		}, nil)
 
 	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
@@ -1093,14 +1410,14 @@ func TestValidateApprovedSingleBlockRetentionCohort(t *testing.T) {
 	)
 }
 
-func TestValidateParallelSingleBlockRetentionCohorts(t *testing.T) {
+func TestValidateSingleBlockRetentionCohorts(t *testing.T) {
 	request := &SingleBlockRetentionRequest{
 		StartHeight: 100,
 		EndHeight:   130,
 	}
 	first := testRetentionCohort("consolidated/100-110.cscb.zstd", 100, 110)
 	second := testRetentionCohort("consolidated/110-120.cscb.zstd", 110, 120)
-	require.NoError(t, validateParallelSingleBlockRetentionCohorts(
+	require.NoError(t, validateSingleBlockRetentionCohorts(
 		[]retirement.RetentionCohort{second, first},
 		request,
 		true,
@@ -1108,7 +1425,7 @@ func TestValidateParallelSingleBlockRetentionCohorts(t *testing.T) {
 
 	duplicate := second
 	duplicate.ConsolidatedObjectKey = first.ConsolidatedObjectKey
-	require.ErrorContains(t, validateParallelSingleBlockRetentionCohorts(
+	require.ErrorContains(t, validateSingleBlockRetentionCohorts(
 		[]retirement.RetentionCohort{first, duplicate},
 		request,
 		true,
@@ -1124,6 +1441,32 @@ func TestValidateSingleBlockRetentionRangeResult(t *testing.T) {
 	mismatch := terminalSingleBlockRetentionRangeResult(cohort)
 	mismatch.Cohort.EndHeight++
 	require.ErrorContains(t, validateSingleBlockRetentionRangeResult(cohort, mismatch), "does not match request")
+
+	incompleteTerminal := terminalSingleBlockRetentionRangeResult(cohort)
+	incompleteTerminal.VerifiedThroughExclusive--
+	require.ErrorContains(
+		t,
+		validateSingleBlockRetentionRangeResult(cohort, incompleteTerminal),
+		"inconsistent terminal progress",
+	)
+
+	firstIncompleteHeight := cohort.EndHeight - 1
+	contradictoryTerminal := terminalSingleBlockRetentionRangeResult(cohort)
+	contradictoryTerminal.VerifiedThroughExclusive = firstIncompleteHeight
+	contradictoryTerminal.FirstIncompleteHeight = &firstIncompleteHeight
+	require.ErrorContains(
+		t,
+		validateSingleBlockRetentionRangeResult(cohort, contradictoryTerminal),
+		"inconsistent incomplete progress",
+	)
+
+	impossibleAccounting := terminalSingleBlockRetentionRangeResult(cohort)
+	impossibleAccounting.DeletedVerifiedRows++
+	require.ErrorContains(
+		t,
+		validateSingleBlockRetentionRangeResult(cohort, impossibleAccounting),
+		"row accounting exceeds scanned rows",
+	)
 }
 
 func testRetentionCohort(key string, start uint64, end uint64) retirement.RetentionCohort {

--- a/internal/workflow/testdata/single_block_retention_pre_parallelism_history.json
+++ b/internal/workflow/testdata/single_block_retention_pre_parallelism_history.json
@@ -1,0 +1,315 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-07-31T09:44:30.036495606Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "90177805",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "workflow.single_block_retention"
+        },
+        "taskQueue": {
+          "name": "default",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJUYWciOjIsIlN0YXJ0SGVpZ2h0Ijo0MjMwNTAwMDAsIkVuZEhlaWdodCI6NDIzMDYwMDAwLCJFbGlnaWJpbGl0eUN1dG9mZiI6IjAwMDEtMDEtMDFUMDA6MDA6MDBaIiwiTWF4T2JqZWN0UmFuZ2VzIjoxMCwiRXhlY3V0ZSI6ZmFsc2UsIlByb2R1Y3Rpb25EZWxldGVFbmFibGVkIjpmYWxzZSwiRGlyZWN0U3RvcmFnZUNsaWVudHNHdWFyZGVkIjpmYWxzZSwiU2luZ2xlQmxvY2tXcml0ZXJzR3VhcmRlZCI6ZmFsc2UsIkZhbGxiYWNrUmVhZHNWYWxpZGF0ZWQiOmZhbHNlLCJGYWxsYmFja0Vycm9yQ291bnQiOjAsIkFwcHJvdmVkQ2hhaW4iOiIiLCJBcHByb3ZlZFN0YXJ0SGVpZ2h0IjowLCJBcHByb3ZlZEVuZEhlaWdodCI6MCwiQ2hlY2twb2ludCI6bnVsbH0="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "86400s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fb78f-9c54-778c-b942-62fa83bbbdaa",
+        "identity": "15@chainstorage-admin-prod-console-6996ff5857-sr6vl@",
+        "firstExecutionRunId": "019fb78f-9c54-778c-b942-62fa83bbbdaa",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "workflow.single_block_retention/dry_run_423050000_423060000_m10_20260731T094425Z"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-07-31T09:44:30.036581948Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "90177806",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "default",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-07-31T09:44:30.139796386Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "90177812",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "1@chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz@",
+        "requestId": "ae08caf4-b038-42fc-b89a-1b87f35794f6",
+        "historySizeBytes": "763",
+        "workerVersion": {
+          "buildId": "e5ae63fbb744056987768260864c191c"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-07-31T09:44:30.170040004Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "90177816",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "1@chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz@",
+        "workerVersion": {
+          "buildId": "e5ae63fbb744056987768260864c191c"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3,
+            1
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.35.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-07-31T09:44:30.170079565Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "90177817",
+      "markerRecordedEventAttributes": {
+        "markerName": "SideEffect",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJXb3JrZmxvd0lkZW50aXR5Ijoid29ya2Zsb3cuc2luZ2xlX2Jsb2NrX3JldGVudGlvbiIsIkVuYWJsZWQiOmZhbHNlLCJUYXNrTGlzdCI6ImRlZmF1bHQiLCJXb3JrZmxvd1J1blRpbWVvdXQiOjg2NDAwMDAwMDAwMDAwLCJXb3JrZmxvd1JldHJ5IjpudWxsLCJBY3Rpdml0eVNjaGVkdWxlVG9DbG9zZVRpbWVvdXQiOjQzMjAwMDAwMDAwMDAwLCJBY3Rpdml0eVN0YXJ0VG9DbG9zZVRpbWVvdXQiOjIxNjAwMDAwMDAwMDAwLCJBY3Rpdml0eUhlYXJ0YmVhdFRpbWVvdXQiOjMwMDAwMDAwMDAwMCwiQWN0aXZpdHlSZXRyeSI6eyJNYXhpbXVtQXR0ZW1wdHMiOjMsIkJhY2tvZmZDb2VmZmljaWVudCI6MiwiSW5pdGlhbEludGVydmFsIjoxMDAwMDAwMDAwMCwiTWF4aW11bUludGVydmFsIjoxODAwMDAwMDAwMDB9LCJCbG9ja1RhZyI6eyJTdGFibGUiOjIsIkxhdGVzdCI6Mn0sIkV2ZW50VGFnIjp7IlN0YWJsZSI6MiwiTGF0ZXN0IjoyfSwiU3RvcmFnZSI6eyJEYXRhQ29tcHJlc3Npb24iOjIsIkNvbnNvbGlkYXRpb24iOnsiRW5hYmxlZCI6dHJ1ZSwiTW9kZSI6ImF1dG9fY29uc29saWRhdGUiLCJDb2RlYyI6MiwiQ29kZWNMZXZlbCI6MTIsIlpzdGRMb25nRGlzdGFuY2VXaW5kb3dMb2ciOjI3LCJNYXhDb21wcmVzc2VkQnl0ZXMiOjIxNDc0ODM2NDgsIk1heFVuY29tcHJlc3NlZEJ5dGVzIjoxMzc0Mzg5NTM0NzIsIk1heEJsb2NrcyI6MTAwMCwiQ29tcHJlc3Npb25DaHVua0Jsb2NrcyI6MjUsIk1heENodW5rQ29tcHJlc3NlZEJ5dGVzIjpudWxsLCJNYXhDaHVua1VuY29tcHJlc3NlZEJ5dGVzIjpudWxsLCJGbHVzaEludGVydmFsIjo2MDAwMDAwMDAwMCwiU2hhZG93VGltZW91dCI6MzAwMDAwMDAwMDAsIk1heEluZmxpZ2h0UmF3QmxvY2tzIjo0LCJNZW1vcnlCdWRnZXRCeXRlcyI6MjY4NDM1NDU2LCJMb2NhbFNwaWxsRGlyIjoiL3RtcC9jaGFpbnN0b3JhZ2UtY3NjYiIsIkxvY2FsU3BpbGxNYXhCeXRlcyI6NDI5NDk2NzI5NjAsIlNoYXJkU2l6ZSI6MTAwMDAsIk11bHRpcGFydFRocmVzaG9sZCI6MTM0MjE3NzI4LCJSZWFkU2hhZG93Rmlyc3QiOnRydWUsIlByb21vdGlvbkdhdGVIZWlnaHQiOm51bGwsIlNhZmVQcm9tb3Rpb25MYWciOm51bGwsIlNpbmdsZUJsb2NrT2JqZWN0UmV0ZW50aW9uIjoyNTkyMDAwMDAwMDAwMDAsIlNpbmdsZUJsb2NrU2hhZG93V3JpdGVBZnRlclN5bmNlckN1dG92ZXIiOmZhbHNlfX0sIklycmV2ZXJzaWJsZURpc3RhbmNlIjozMiwiRmFpbG92ZXJFbmFibGVkIjpmYWxzZSwiQ29uc2Vuc3VzRmFpbG92ZXJFbmFibGVkIjpmYWxzZSwiU0xBIjp7IlRpZXIiOjEsIkJsb2NrSGVpZ2h0RGVsdGEiOjEwLCJCbG9ja1RpbWVEZWx0YSI6MTIwMDAwMDAwMDAwLCJUaW1lU2luY2VMYXN0QmxvY2siOjEyMDAwMDAwMDAwMCwiRXZlbnRIZWlnaHREZWx0YSI6MTAsIkV2ZW50VGltZURlbHRhIjoxMjAwMDAwMDAwMDAsIlRpbWVTaW5jZUxhc3RFdmVudCI6MTIwMDAwMDAwMDAwLCJPdXRPZlN5bmNOb2RlRGlzdGFuY2UiOjEwLCJPdXRPZlN5bmNWYWxpZGF0b3JOb2RlRGlzdGFuY2UiOjAsIkV4cGVjdGVkV29ya2Zsb3dzIjpbIm1vbml0b3IiLCJwb2xsZXIiLCJzdHJlYW1lciIsImNyb3NzX3ZhbGlkYXRvciIsIm1pZ3JhdG9yIl19LCJNYXhPYmplY3RSYW5nZXMiOjF9"
+              }
+            ]
+          },
+          "side-effect-id": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-07-31T09:44:30.170085285Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "90177818",
+      "markerRecordedEventAttributes": {
+        "markerName": "Version",
+        "details": {
+          "change-id": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "InNpbmdsZV9ibG9ja19yZXRlbnRpb24ucmFuZ2Vfc3dlZXAi"
+              }
+            ]
+          },
+          "version": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-07-31T09:44:30.170116576Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "taskId": "90177819",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJzaW5nbGVfYmxvY2tfcmV0ZW50aW9uLnJhbmdlX3N3ZWVwLTEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-07-31T09:44:30.170149856Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "90177820",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "8",
+        "activityType": {
+          "name": "activity.single_block_retention.select"
+        },
+        "taskQueue": {
+          "name": "default",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJUYWciOjIsIlN0YXJ0SGVpZ2h0Ijo0MjMwNTAwMDAsIkVuZEhlaWdodCI6NDIzMDYwMDAwLCJFbGlnaWJpbGl0eUN1dG9mZiI6IjIwMjYtMDctMzFUMDk6NDQ6MzAuMTM5Nzk2Mzg2WiIsIkxpbWl0IjoxMH0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "43200s",
+        "scheduleToStartTimeout": "43200s",
+        "startToCloseTimeout": "21600s",
+        "heartbeatTimeout": "300s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "10s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "180s",
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-07-31T09:44:30.205234392Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "90177827",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "1@chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz@",
+        "requestId": "b0c0a3fe-894d-42d7-9c7d-def761f542fa",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "e5ae63fbb744056987768260864c191c"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-07-31T09:44:30.713323092Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "90177828",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJjb2hvcnRzIjpbXSwiaGFzX21vcmUiOmZhbHNlfQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "1@chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz@"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-07-31T09:44:30.713339823Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "90177829",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz:48a12dd6-3ede-442b-967e-5c1512b0bdcf",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "default"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-07-31T09:44:30.809501777Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "90177833",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "1@chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz@",
+        "requestId": "56b04dd7-3421-409f-b124-8eb21b5624cc",
+        "historySizeBytes": "3896",
+        "workerVersion": {
+          "buildId": "e5ae63fbb744056987768260864c191c"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-07-31T09:44:30.967081384Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "90177837",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "1@chainstorage-solana-mainnet-prod-worker-6bcb454886-f84qz@",
+        "workerVersion": {
+          "buildId": "e5ae63fbb744056987768260864c191c"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-07-31T09:44:30.967116695Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "90177838",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGFydGVkX2F0IjoiMjAyNi0wNy0zMVQwOTo0NDozMC4xMzk3OTYzODZaIiwiY29tcGxldGVkX2F0IjoiMjAyNi0wNy0zMVQwOTo0NDozMC44MDk1MDE3NzdaIiwiZWxpZ2liaWxpdHlfY3V0b2ZmIjoiMjAyNi0wNy0zMVQwOTo0NDozMC4xMzk3OTYzODZaIiwidGFnIjoyLCJzZWxlY3Rpb25fc3RhcnRfaGVpZ2h0Ijo0MjMwNTAwMDAsInNlbGVjdGlvbl9lbmRfaGVpZ2h0Ijo0MjMwNjAwMDAsImV4ZWN1dGUiOmZhbHNlLCJmYWxsYmFja19yZWFkc192YWxpZGF0ZWQiOmZhbHNlLCJmYWxsYmFja19lcnJvcl9jb3VudCI6MCwiY29udGludWVfYXNfbmV3X2NvdW50IjowLCJzd2VlcF9jb21wbGV0ZWQiOmZhbHNlLCJzZWxlY3RlZF9vYmplY3RfcmFuZ2VzIjowLCJtb3JlX2VsaWdpYmxlX3JhbmdlcyI6ZmFsc2UsInByb2Nlc3NlZF9vYmplY3RfcmFuZ2VzIjowLCJjb21wbGV0ZWRfb2JqZWN0X3JhbmdlX2NvdW50IjowLCJzY2FubmVkX3Jvd3MiOjAsInBsYW5uZWRfcm93cyI6MCwiZGVsZXRlZF92ZXJpZmllZF9yb3dzIjowLCJhbHJlYWR5X3JldGlyZWRfcm93cyI6MCwic2tpcHBlZF9zbG90cyI6MCwiZGVmZXJyZWRfcm93cyI6MCwiZmFpbGVkX3Jvd3MiOjAsImRlbGV0ZWRfdmVyc2lvbnMiOjAsImRlbGV0ZWRfbWFya2VycyI6MCwicmV0aXJlZF9ieXRlcyI6MH0="
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "13"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add optional bounded `Parallelism` for single-block retention, defaulting to serial and capped at 20
- schedule one CSCB cohort lifecycle per activity while each activity processes every covered single-block row
- preserve safety-quiescence retries, deterministic result ordering, frozen cutoff/tag/approval semantics, and serial replay compatibility
- reject duplicate or overlapping cohorts and inconsistent activity results before aggregate accounting
- attach structured current-run outcomes to post-processing failures, including work from earlier waves and the latest valid result before a retry lifecycle failure

## Operational behavior
- `MaxObjectRanges` remains the per-run selection bound; `Parallelism` is the active cohort bound
- existing and running inputs with `Parallelism` omitted remain serial
- Temporal distributes cohort activities across available workers but does not guarantee pod affinity; retries may run on a different worker
- strict one-retention-activity-per-pod behavior, if needed, should use a dedicated task queue with `max_concurrent_activity_execution_size: 1`; applying that limit to the shared default queue would also throttle unrelated workflows
- production rollout should canary at low parallelism before increasing toward the available worker fleet

## Verification
- `TEST_TYPE=unit go test -count=1 -p=1 ./...`
- `TEST_TYPE=unit go test -count=1 ./internal/workflow ./internal/workflow/activity ./internal/storage/retirement`
- focused retention tests with `-race`
- actual pre-parallelism Solana production dry-run history replay
- `go vet -printfuncs=wrapf,statusf,warnf,infof,debugf,failf,equalf,containsf,fprintf,sprintf ./...`
- `errcheck -ignoretests -ignoregenerated ./...`
- `ineffassign ./...`
- `goimports -l` and `git diff --check`

Follow-up to #186.

Linear: https://linear.app/cipherowl/issue/INF-1126