### PR TITLE
fix(INF-1126): allow retention approval envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,10 +741,12 @@ that become eligible later or bypasses each cohort's retention clock. Execution
 requires Postgres metadata plus versioned S3 storage, an explicit
 `FallbackReadsValidated` assertion with zero `FallbackErrorCount`, and a
 separate operator approval (`ApprovedChain`, `ApprovedStartHeight`,
-`ApprovedEndHeight`) that must exactly match the selection range. Every selected
-cohort must be fully contained by that immutable envelope across continuations;
-the approval is passed through unchanged and is never derived from selector
-output, so unbounded execution requests are rejected. API and SDK clients
+`ApprovedEndHeight`) that must fully contain the selection range. This permits
+one immutable campaign-wide approval to authorize separately bounded shards,
+while selections extending outside that envelope are rejected. Every selected
+cohort must also be fully contained by the envelope across continuations; the
+approval is passed through unchanged and is never derived from selector output,
+so unbounded execution requests are rejected. API and SDK clients
 continue to use the same Chainstorage interface; the
 `DirectStorageClientsGuarded` execution gate applies only to consumers that
 bypass Chainstorage and access object storage directly. The process activity

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -220,15 +220,15 @@ func (w *SingleBlockRetention) execute(
 		if err := w.readConfig(ctx, &cfg); err != nil {
 			return xerrors.Errorf("failed to read config: %w", err)
 		}
-		if err := validateSingleBlockRetentionExecutionRequest(request); err != nil {
-			return err
-		}
 		rangeSweepEnabled := workflow.GetVersion(
 			ctx,
 			singleBlockRetentionRangeSweepChangeID,
 			workflow.DefaultVersion,
 			singleBlockRetentionRangeSweepVersion,
 		) != workflow.DefaultVersion
+		if err := validateSingleBlockRetentionExecutionRequest(request, rangeSweepEnabled); err != nil {
+			return err
+		}
 		isContinuation := workflow.GetInfo(ctx).ContinuedExecutionRunID != ""
 		if request.Execute && rangeSweepEnabled && request.EligibilityCutoff.IsZero() {
 			return xerrors.New("single-block retention range execution requires the eligibility cutoff from its approved dry run")
@@ -1047,6 +1047,7 @@ func validateSingleBlockRetentionCheckpoint(
 
 func validateSingleBlockRetentionExecutionRequest(
 	request *SingleBlockRetentionRequest,
+	allowContainingApproval bool,
 ) error {
 	if request == nil {
 		return xerrors.New("single-block retention request is required")
@@ -1070,7 +1071,18 @@ func validateSingleBlockRetentionExecutionRequest(
 			request.ApprovedEndHeight,
 		)
 	}
-	if request.ApprovedStartHeight > request.StartHeight || request.ApprovedEndHeight < request.EndHeight {
+	if !allowContainingApproval &&
+		(request.ApprovedStartHeight != request.StartHeight || request.ApprovedEndHeight != request.EndHeight) {
+		return xerrors.Errorf(
+			"retention execution approved range [%d, %d) must exactly match the selection range [%d, %d)",
+			request.ApprovedStartHeight,
+			request.ApprovedEndHeight,
+			request.StartHeight,
+			request.EndHeight,
+		)
+	}
+	if allowContainingApproval &&
+		(request.ApprovedStartHeight > request.StartHeight || request.ApprovedEndHeight < request.EndHeight) {
 		return xerrors.Errorf(
 			"retention execution selection range [%d, %d) is outside the approved envelope [%d, %d)",
 			request.StartHeight,

--- a/internal/workflow/single_block_retention.go
+++ b/internal/workflow/single_block_retention.go
@@ -55,12 +55,12 @@ type (
 		SingleBlockWritersGuarded   bool
 		FallbackReadsValidated      bool
 		FallbackErrorCount          uint64
-		// Approved* are the operator's separate exact-envelope deletion approval.
-		// Execution requires them, requires the selection range to equal the
-		// approved envelope, and passes them through unchanged across every
-		// continuation. Selected cohorts must be contained by this envelope;
-		// approval is never derived from selector output. Read-only runs may
-		// omit them.
+		// Approved* are the operator's separate deletion approval envelope.
+		// Execution requires them, requires the selection range to be fully
+		// contained by the approved envelope, and passes them through unchanged
+		// across every continuation. Selected cohorts must also be contained by
+		// this envelope; approval is never derived from selector output. Read-only
+		// runs may omit them.
 		ApprovedChain       string
 		ApprovedStartHeight uint64
 		ApprovedEndHeight   uint64
@@ -1065,18 +1065,18 @@ func validateSingleBlockRetentionExecutionRequest(
 	}
 	if request.ApprovedEndHeight <= request.ApprovedStartHeight {
 		return xerrors.Errorf(
-			"retention execution requires a valid exact approved range, got [%d, %d)",
+			"retention execution requires a valid approved range, got [%d, %d)",
 			request.ApprovedStartHeight,
 			request.ApprovedEndHeight,
 		)
 	}
-	if request.ApprovedStartHeight != request.StartHeight || request.ApprovedEndHeight != request.EndHeight {
+	if request.ApprovedStartHeight > request.StartHeight || request.ApprovedEndHeight < request.EndHeight {
 		return xerrors.Errorf(
-			"retention execution approved range [%d, %d) must exactly match the selection range [%d, %d)",
-			request.ApprovedStartHeight,
-			request.ApprovedEndHeight,
+			"retention execution selection range [%d, %d) is outside the approved envelope [%d, %d)",
 			request.StartHeight,
 			request.EndHeight,
+			request.ApprovedStartHeight,
+			request.ApprovedEndHeight,
 		)
 	}
 	if !request.DirectStorageClientsGuarded {

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -931,8 +931,8 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 		SingleBlockWritersGuarded:   true,
 		FallbackReadsValidated:      true,
 		ApprovedChain:               "solana-mainnet",
-		ApprovedStartHeight:         100,
-		ApprovedEndHeight:           120,
+		ApprovedStartHeight:         90,
+		ApprovedEndHeight:           130,
 	})
 	require.Error(s.T(), err)
 	require.True(s.T(), IsContinueAsNewError(err))
@@ -946,13 +946,15 @@ func (s *singleBlockRetentionTestSuite) TestExecuteContinuesAsNewWithCumulativeC
 	)
 	require.Equal(s.T(), uint64(100), nextRequest.StartHeight)
 	require.Equal(s.T(), uint64(120), nextRequest.EndHeight)
-	require.Equal(s.T(), uint64(100), nextRequest.ApprovedStartHeight)
-	require.Equal(s.T(), uint64(120), nextRequest.ApprovedEndHeight)
+	require.Equal(s.T(), uint64(90), nextRequest.ApprovedStartHeight)
+	require.Equal(s.T(), uint64(130), nextRequest.ApprovedEndHeight)
 	require.Equal(s.T(), 2, nextRequest.Parallelism)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), nextRequest.Tag)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), selectRequest.Tag)
 	require.Equal(s.T(), encodeSingleBlockRetentionEffectiveTag(effectiveTag), processRequest.Tag)
 	require.Equal(s.T(), testSingleBlockRetentionEligibilityCutoff, processRequest.EligibilityCutoff)
+	require.Equal(s.T(), uint64(90), processRequest.ApprovedStartHeight)
+	require.Equal(s.T(), uint64(130), processRequest.ApprovedEndHeight)
 	require.NotNil(s.T(), nextRequest.Checkpoint)
 	require.False(s.T(), selectRequest.EligibilityCutoff.IsZero())
 	require.Equal(s.T(), selectRequest.EligibilityCutoff, nextRequest.Checkpoint.EligibilityCutoff)
@@ -1324,6 +1326,13 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	}
 	require.NoError(t, validateSingleBlockRetentionExecutionRequest(validRequest()))
 
+	campaignRequest := validRequest()
+	campaignRequest.StartHeight = 423300000
+	campaignRequest.EndHeight = 423550000
+	campaignRequest.ApprovedStartHeight = 423300000
+	campaignRequest.ApprovedEndHeight = 437068000
+	require.NoError(t, validateSingleBlockRetentionExecutionRequest(campaignRequest))
+
 	request := validRequest()
 	request.StartHeight = 0
 	request.EndHeight = 0
@@ -1347,7 +1356,15 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	require.ErrorContains(
 		t,
 		validateSingleBlockRetentionExecutionRequest(request),
-		"valid exact approved range",
+		"valid approved range",
+	)
+
+	request = validRequest()
+	request.ApprovedStartHeight = 101
+	require.ErrorContains(
+		t,
+		validateSingleBlockRetentionExecutionRequest(request),
+		"outside the approved envelope",
 	)
 
 	request = validRequest()
@@ -1355,7 +1372,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	require.ErrorContains(
 		t,
 		validateSingleBlockRetentionExecutionRequest(request),
-		"must exactly match the selection range",
+		"outside the approved envelope",
 	)
 
 	request = validRequest()

--- a/internal/workflow/single_block_retention_test.go
+++ b/internal/workflow/single_block_retention_test.go
@@ -781,6 +781,32 @@ func (s *singleBlockRetentionTestSuite) TestLegacyExecutionRejectsParallelism() 
 	require.ErrorContains(s.T(), err, "legacy single_block_retention execution requires parallelism=1")
 }
 
+func (s *singleBlockRetentionTestSuite) TestLegacyReplayRejectsContainingApprovalBeforeActivities() {
+	s.env.OnGetVersion(
+		singleBlockRetentionRangeSweepChangeID,
+		temporalworkflow.DefaultVersion,
+		singleBlockRetentionRangeSweepVersion,
+	).Return(temporalworkflow.DefaultVersion)
+
+	_, err := s.workflow.Execute(context.Background(), &SingleBlockRetentionRequest{
+		Tag:                         2,
+		StartHeight:                 423300000,
+		EndHeight:                   423550000,
+		EligibilityCutoff:           testSingleBlockRetentionEligibilityCutoff,
+		MaxObjectRanges:             250,
+		Parallelism:                 10,
+		Execute:                     true,
+		ProductionDeleteEnabled:     true,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         423300000,
+		ApprovedEndHeight:           437068000,
+	})
+	require.ErrorContains(s.T(), err, "must exactly match the selection range")
+}
+
 func (s *singleBlockRetentionTestSuite) TestReplayPreParallelismHistory() {
 	replayer := worker.NewWorkflowReplayer()
 	replayer.RegisterWorkflowWithOptions(s.workflow.execute, temporalworkflow.RegisterOptions{
@@ -1324,21 +1350,26 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 			ApprovedEndHeight:           110,
 		}
 	}
-	require.NoError(t, validateSingleBlockRetentionExecutionRequest(validRequest()))
+	require.NoError(t, validateSingleBlockRetentionExecutionRequest(validRequest(), true))
 
 	campaignRequest := validRequest()
 	campaignRequest.StartHeight = 423300000
 	campaignRequest.EndHeight = 423550000
 	campaignRequest.ApprovedStartHeight = 423300000
 	campaignRequest.ApprovedEndHeight = 437068000
-	require.NoError(t, validateSingleBlockRetentionExecutionRequest(campaignRequest))
+	require.NoError(t, validateSingleBlockRetentionExecutionRequest(campaignRequest, true))
+	require.ErrorContains(
+		t,
+		validateSingleBlockRetentionExecutionRequest(campaignRequest, false),
+		"must exactly match the selection range",
+	)
 
 	request := validRequest()
 	request.StartHeight = 0
 	request.EndHeight = 0
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"explicit exact selection range",
 	)
 
@@ -1346,7 +1377,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	request.ApprovedChain = ""
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"operator approval chain",
 	)
 
@@ -1355,7 +1386,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	request.ApprovedEndHeight = 110
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"valid approved range",
 	)
 
@@ -1363,7 +1394,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	request.ApprovedStartHeight = 101
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"outside the approved envelope",
 	)
 
@@ -1371,7 +1402,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	request.ApprovedEndHeight = 109
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"outside the approved envelope",
 	)
 
@@ -1379,7 +1410,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	request.FallbackReadsValidated = false
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"explicit fallback-disabled read validation",
 	)
 
@@ -1387,7 +1418,7 @@ func TestValidateSingleBlockRetentionExecutionRequestGates(t *testing.T) {
 	request.FallbackErrorCount = 3
 	require.ErrorContains(
 		t,
-		validateSingleBlockRetentionExecutionRequest(request),
+		validateSingleBlockRetentionExecutionRequest(request, true),
 		"zero fallback read errors",
 	)
 }


### PR DESCRIPTION
## Summary
- accept an explicit retention selection when it is fully contained by the operator-approved campaign envelope
- retain exact-match approval semantics for legacy Temporal histories through the existing range-sweep version gate
- retain independent selection, cohort, activity, chain, and planner containment gates
- cover the exact Solana campaign/shard bounds and broader-envelope propagation across continue-as-new
- align the operator documentation with campaign-wide approvals

## Safety analysis
New range-sweep executions use half-open containment: ApprovedStartHeight <= StartHeight and EndHeight <= ApprovedEndHeight. Existing exact approvals continue to pass. Selections extending below or above the approval envelope are rejected, and the activity and retirement planner independently revalidate each cohort against the original operator bounds.

The approval behavior is gated by the existing range-sweep Temporal version marker. Histories without that marker retain the legacy exact-equality failure; new version-1 histories allow containment. The exact six-event failed production history was replayed against this branch and reproduced its original pre-activity failure without nondeterminism.

## Validation
- focused exact production campaign/shard regression
- focused legacy-version replay-path regression
- exact failed production history through Temporal WorkflowReplayer
- go test ./internal/workflow/... -count=1
- go test ./internal/storage/retirement -count=1
- TEST_TYPE=unit go test ./... -run=. -count=1
- repository go vet command
- git diff --check

Linear: https://linear.app/cipherowl/issue/INF-1126