### PR TITLE
feat(INF-1288): isolate historical consolidation workers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -349,10 +349,11 @@ type (
 	}
 
 	BatchConsolidatorWorkflowConfig struct {
-		WorkflowConfig `mapstructure:",squash"`
-		BatchSize      uint64 `mapstructure:"batch_size" validate:"required"`
-		CheckpointSize uint64 `mapstructure:"checkpoint_size" validate:"required,gtfield=BatchSize"`
-		MaxBlocks      uint64 `mapstructure:"max_blocks"`
+		WorkflowConfig     `mapstructure:",squash"`
+		BatchSize          uint64 `mapstructure:"batch_size" validate:"required"`
+		CheckpointSize     uint64 `mapstructure:"checkpoint_size" validate:"required,gtfield=BatchSize"`
+		MaxBlocks          uint64 `mapstructure:"max_blocks"`
+		HistoricalTaskList string `mapstructure:"historical_task_list"`
 	}
 
 	SingleBlockRetentionWorkflowConfig struct {

--- a/internal/cron/batch_consolidator.go
+++ b/internal/cron/batch_consolidator.go
@@ -379,6 +379,9 @@ func (t *batchConsolidatorTask) verifyAutoConsolidateCoverage(ctx context.Contex
 
 func (t *batchConsolidatorTask) openBatchConsolidatorWorkflow(ctx context.Context) (string, bool, error) {
 	workflowIdentity := t.config.Workflows.BatchConsolidator.WorkflowIdentity
+	defaultTaskList := t.config.Workflows.BatchConsolidator.TaskList
+	historicalTaskList := t.config.Workflows.BatchConsolidator.HistoricalTaskList
+	hasIsolatedHistoricalTaskList := historicalTaskList != "" && historicalTaskList != defaultTaskList
 	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, batchConsolidatorOpenPageSize, workflowIdentity)
 	if err != nil {
 		return "", false, xerrors.Errorf("failed to list open workflows for batch_consolidator cron: %w", err)
@@ -388,6 +391,11 @@ func (t *batchConsolidatorTask) openBatchConsolidatorWorkflow(ctx context.Contex
 	}
 	for _, wf := range openWorkflows.Executions {
 		if wf.GetType().GetName() == workflowIdentity {
+			// Only the dedicated historical queue is resource-isolated. Missing or
+			// shared task-queue metadata remains blocking so the guard fails closed.
+			if hasIsolatedHistoricalTaskList && wf.GetTaskQueue() == historicalTaskList {
+				continue
+			}
 			workflowID := wf.GetExecution().GetWorkflowId()
 			return workflowID, true, nil
 		}

--- a/internal/cron/batch_consolidator_test.go
+++ b/internal/cron/batch_consolidator_test.go
@@ -30,6 +30,7 @@ type (
 	batchConsolidatorCronRuntime struct {
 		logger                *zap.Logger
 		openWorkflowID        []string
+		openWorkflowTaskQueue map[string]string
 		requestedWorkflowType string
 		executions            []batchConsolidatorCronExecution
 	}
@@ -73,6 +74,31 @@ func TestBatchConsolidatorCronStartsFullWindowAutoConsolidateWorkflow(t *testing
 		StartHeight: 3_000,
 		EndHeight:   4_000,
 	}, runtime.executions[0].request)
+}
+
+func TestBatchConsolidatorRoutesHistoricalWorkflowToDedicatedTaskQueue(t *testing.T) {
+	task, runtime, _, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Workflows.BatchConsolidator.TaskList = "batch_consolidator"
+	cfg.Workflows.BatchConsolidator.HistoricalTaskList = "batch_consolidator_backfill"
+
+	_, err := task.batchConsolidator.Execute(context.Background(), &workflowpkg.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		StartHeight: 100,
+		EndHeight:   200,
+	})
+	require.NoError(t, err)
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, "batch_consolidator_backfill", runtime.executions[0].options.TaskQueue)
+
+	_, err = task.batchConsolidator.Execute(context.Background(), &workflowpkg.BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeAutoConsolidate,
+		StartHeight: 200,
+		EndHeight:   300,
+	})
+	require.NoError(t, err)
+	require.Len(t, runtime.executions, 2)
+	require.Equal(t, "batch_consolidator", runtime.executions[1].options.TaskQueue)
 }
 
 func TestBatchConsolidatorCronRunsToNearestSafeFullWindow(t *testing.T) {
@@ -369,6 +395,73 @@ func TestBatchConsolidatorCronSkipsWhenBatchConsolidatorWorkflowIsAlreadyOpen(t 
 	require.Empty(t, runtime.executions)
 }
 
+func TestBatchConsolidatorCronRunsWhileHistoricalBackfillIsOnDedicatedTaskQueue(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Workflows.BatchConsolidator.TaskList = "batch_consolidator"
+	cfg.Workflows.BatchConsolidator.HistoricalTaskList = "batch_consolidator_backfill"
+	cfg.Cron.BatchConsolidator.StartHeight = 1_000
+	runtime.openWorkflowID = []string{"workflow.batch_consolidator/historical_backfill"}
+	runtime.openWorkflowTaskQueue = map[string]string{
+		"workflow.batch_consolidator/historical_backfill": "batch_consolidator_backfill",
+	}
+
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(0), false, nil)
+	metaStorage.EXPECT().
+		GetLatestBlock(gomock.Any(), tag).
+		Return(&api.BlockMetadata{Tag: tag, Height: 5_000}, nil)
+	metaStorage.EXPECT().
+		GetFirstBlockMissingConsolidationShadow(gomock.Any(), tag, uint64(1_000), uint64(4_901)).
+		Return(uint64(3_500), true, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, "batch_consolidator", runtime.executions[0].options.TaskQueue)
+}
+
+func TestBatchConsolidatorCronBlocksHistoricalBackfillOnSharedTaskQueue(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Workflows.BatchConsolidator.TaskList = "batch_consolidator"
+	cfg.Workflows.BatchConsolidator.HistoricalTaskList = "batch_consolidator_backfill"
+	runtime.openWorkflowID = []string{"workflow.batch_consolidator/historical_backfill"}
+	runtime.openWorkflowTaskQueue = map[string]string{
+		"workflow.batch_consolidator/historical_backfill": "batch_consolidator",
+	}
+
+	metaStorage.EXPECT().GetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestBatchConsolidatorCronStillBlocksAutoWorkflowAfterIgnoringDedicatedBackfill(t *testing.T) {
+	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
+	defer ctrl.Finish()
+	cfg.Workflows.BatchConsolidator.TaskList = "batch_consolidator"
+	cfg.Workflows.BatchConsolidator.HistoricalTaskList = "batch_consolidator_backfill"
+	runtime.openWorkflowID = []string{
+		"workflow.batch_consolidator/historical_backfill",
+		"workflow.batch_consolidator/auto_consolidate",
+	}
+	runtime.openWorkflowTaskQueue = map[string]string{
+		"workflow.batch_consolidator/historical_backfill": "batch_consolidator_backfill",
+		"workflow.batch_consolidator/auto_consolidate":    "batch_consolidator",
+	}
+
+	metaStorage.EXPECT().GetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetLatestBlock(gomock.Any(), gomock.Any()).Times(0)
+	metaStorage.EXPECT().GetFirstBlockMissingConsolidationShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
 func TestBatchConsolidatorCronRequiresAutoConsolidateMode(t *testing.T) {
 	task, runtime, metaStorage, cfg, ctrl := newBatchConsolidatorCronTask(t)
 	defer ctrl.Finish()
@@ -491,6 +584,7 @@ func (r *batchConsolidatorCronRuntime) ListOpenWorkflows(ctx context.Context, na
 		executions = append(executions, &workflowpb.WorkflowExecutionInfo{
 			Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
 			Type:      &commonpb.WorkflowType{Name: workflowType},
+			TaskQueue: r.openWorkflowTaskQueue[workflowID],
 		})
 	}
 	return &workflowservice.ListOpenWorkflowExecutionsResponse{Executions: executions}, nil

--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -23,6 +23,7 @@ type (
 	BatchConsolidator struct {
 		baseWorkflow
 		batchConsolidator *activity.BatchConsolidator
+		workflowConfig    *config.BatchConsolidatorWorkflowConfig
 	}
 
 	BatchConsolidatorParams struct {
@@ -79,6 +80,7 @@ func NewBatchConsolidator(params BatchConsolidatorParams) *BatchConsolidator {
 	w := &BatchConsolidator{
 		baseWorkflow:      newBaseWorkflow(&params.Config.Workflows.BatchConsolidator, params.Runtime),
 		batchConsolidator: params.BatchConsolidator,
+		workflowConfig:    &params.Config.Workflows.BatchConsolidator,
 	}
 	w.registerWorkflow(w.execute)
 	return w
@@ -89,7 +91,15 @@ func (w *BatchConsolidator) Execute(ctx context.Context, request *BatchConsolida
 	if override, ok := workflowIDFromContext(ctx); ok {
 		workflowID = override
 	}
-	return w.startWorkflow(ctx, workflowID, request)
+	taskList := w.workflowConfig.TaskList
+	mode := w.workflowConfig.Storage.Consolidation.Mode
+	if request != nil && request.Mode != "" {
+		mode = request.Mode
+	}
+	if mode == config.ConsolidationModeHistoricalBackfill && w.workflowConfig.HistoricalTaskList != "" {
+		taskList = w.workflowConfig.HistoricalTaskList
+	}
+	return w.startWorkflowOnTaskList(ctx, workflowID, taskList, request)
 }
 
 func (r *BatchConsolidatorRequest) GetTags() map[string]string {
@@ -165,9 +175,13 @@ func (w *BatchConsolidator) execute(ctx workflow.Context, request *BatchConsolid
 			zap.String("mode", string(mode)),
 		)
 		logger.Info("workflow started")
-		ctx = w.withActivityOptions(ctx)
-		statsCtx := w.withShadowStatsActivityOptions(ctx, cfg)
-		cursorCtx := w.withCursorActivityOptions(ctx, cfg)
+		activityTaskList := cfg.TaskList
+		if mode == config.ConsolidationModeHistoricalBackfill && cfg.HistoricalTaskList != "" {
+			activityTaskList = cfg.HistoricalTaskList
+		}
+		ctx = w.withActivityOptionsOnTaskList(ctx, activityTaskList)
+		statsCtx := w.withShadowStatsActivityOptions(ctx, cfg, activityTaskList)
+		cursorCtx := w.withCursorActivityOptions(ctx, cfg, activityTaskList)
 		if mode.IsRepairExistingCSCB() {
 			repairParallelismVersion := workflow.GetVersion(
 				ctx,
@@ -1186,11 +1200,12 @@ func batchConsolidatorSafeEndHeight(latestHeight uint64, irreversibleDistance ui
 func (w *BatchConsolidator) withShadowStatsActivityOptions(
 	ctx workflow.Context,
 	cfg config.BatchConsolidatorWorkflowConfig,
+	taskList string,
 ) workflow.Context {
 	base := cfg.Base()
 	retryPolicy := w.getShadowStatsActivityRetryPolicy(base.ActivityRetry)
 	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		TaskQueue:              base.TaskList,
+		TaskQueue:              taskList,
 		StartToCloseTimeout:    base.ActivityStartToCloseTimeout,
 		ScheduleToCloseTimeout: base.ActivityScheduleToCloseTimeout,
 		HeartbeatTimeout:       base.ActivityHeartbeatTimeout,
@@ -1214,11 +1229,12 @@ func (w *BatchConsolidator) getShadowStatsActivityRetryPolicy(cfg *config.RetryP
 func (w *BatchConsolidator) withCursorActivityOptions(
 	ctx workflow.Context,
 	cfg config.BatchConsolidatorWorkflowConfig,
+	taskList string,
 ) workflow.Context {
 	base := cfg.Base()
 	retryPolicy := w.getCursorActivityRetryPolicy(base.ActivityRetry)
 	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		TaskQueue:              base.TaskList,
+		TaskQueue:              taskList,
 		StartToCloseTimeout:    base.ActivityStartToCloseTimeout,
 		ScheduleToCloseTimeout: base.ActivityScheduleToCloseTimeout,
 		HeartbeatTimeout:       base.ActivityHeartbeatTimeout,

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	temporalactivity "go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
 	temporalworkflow "go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
@@ -353,6 +354,53 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParalle
 			EndHeight:   startHeight + 1000,
 			MaxBlocks:   1000,
 		}, request)
+	}
+}
+
+func (s *batchConsolidatorTestSuite) TestHistoricalBackfillUsesDedicatedTaskQueueForEveryActivity() {
+	require := testutil.Require(s.T())
+
+	const historicalTaskList = "batch_consolidator_backfill"
+	s.cfg.Workflows.BatchConsolidator.HistoricalTaskList = historicalTaskList
+	s.cfg.Workflows.BatchConsolidator.IrreversibleDistance = 10
+
+	var taskQueues []string
+	recordTaskQueue := func(ctx context.Context) {
+		taskQueues = append(taskQueues, temporalactivity.GetInfo(ctx).TaskQueue)
+	}
+	s.env.OnActivity(activity.ActivityBatchConsolidatorLatestBlock, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorLatestBlockRequest) (*activity.BatchConsolidatorLatestBlockResponse, error) {
+			recordTaskQueue(ctx)
+			return &activity.BatchConsolidatorLatestBlockResponse{Tag: request.Tag, Height: 220}, nil
+		})
+	s.env.OnActivity(activity.ActivityBatchConsolidatorStats, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorStatsRequest) (*activity.BatchConsolidatorStatsResponse, error) {
+			recordTaskQueue(ctx)
+			return &activity.BatchConsolidatorStatsResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		})
+	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
+			recordTaskQueue(ctx)
+			return &activity.BatchConsolidatorResponse{
+				StartHeight: request.StartHeight,
+				EndHeight:   request.EndHeight,
+			}, nil
+		})
+
+	_, err := s.batchConsolidator.Execute(context.Background(), &BatchConsolidatorRequest{
+		Mode:        config.ConsolidationModeHistoricalBackfill,
+		Tag:         2,
+		StartHeight: 100,
+		EndHeight:   200,
+		MaxBlocks:   25,
+	})
+	require.NoError(err)
+	require.NotEmpty(taskQueues)
+	for _, taskQueue := range taskQueues {
+		require.Equal(historicalTaskList, taskQueue)
 	}
 }
 

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -167,6 +167,10 @@ func (w *baseWorkflow) validateRequestCtx(ctx context.Context, request any) erro
 }
 
 func (w *baseWorkflow) startWorkflow(ctx context.Context, workflowID string, request any) (client.WorkflowRun, error) {
+	return w.startWorkflowOnTaskList(ctx, workflowID, w.config.Base().TaskList, request)
+}
+
+func (w *baseWorkflow) startWorkflowOnTaskList(ctx context.Context, workflowID string, taskList string, request any) (client.WorkflowRun, error) {
 	if err := w.validateRequestCtx(ctx, request); err != nil {
 		return nil, err
 	}
@@ -174,7 +178,7 @@ func (w *baseWorkflow) startWorkflow(ctx context.Context, workflowID string, req
 	cfg := w.config.Base()
 	workflowOptions := client.StartWorkflowOptions{
 		ID:                                       workflowID,
-		TaskQueue:                                cfg.TaskList,
+		TaskQueue:                                taskList,
 		WorkflowRunTimeout:                       cfg.WorkflowRunTimeout,
 		WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		WorkflowExecutionErrorWhenAlreadyStarted: true,
@@ -257,9 +261,13 @@ func (w *baseWorkflow) getMetricsHandler(ctx workflow.Context) client.MetricsHan
 }
 
 func (w *baseWorkflow) withActivityOptions(ctx workflow.Context) workflow.Context {
+	return w.withActivityOptionsOnTaskList(ctx, w.config.Base().TaskList)
+}
+
+func (w *baseWorkflow) withActivityOptionsOnTaskList(ctx workflow.Context, taskList string) workflow.Context {
 	cfg := w.config.Base()
 	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		TaskQueue:              cfg.TaskList,
+		TaskQueue:              taskList,
 		StartToCloseTimeout:    cfg.ActivityStartToCloseTimeout,
 		ScheduleToCloseTimeout: cfg.ActivityScheduleToCloseTimeout,
 		HeartbeatTimeout:       cfg.ActivityHeartbeatTimeout,


### PR DESCRIPTION
## Summary

- route historical batch-consolidation workflows and activities to an optional dedicated Temporal task queue
- let auto consolidation proceed while an isolated historical workflow is open
- keep shared or unknown queues blocking, preserving fail-closed behavior and legacy behavior when no historical queue is configured

## Tests

- make test

Linear: https://linear.app/cipherowl/issue/INF-1288/cscb-add-generation-aware-solana-block-storage-routing