### PR TITLE
perf(INF-1327): cut single-block retention overhead and parallelize rows

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -360,8 +360,10 @@ type (
 		WorkflowConfig  `mapstructure:",squash"`
 		MaxObjectRanges int `mapstructure:"max_object_ranges" validate:"required,gt=0,lte=250"`
 		// RowParallelism bounds how many rows the retention planner processes
-		// concurrently inside one cohort activity. Zero or one is serial.
-		RowParallelism int `mapstructure:"row_parallelism" validate:"omitempty,gte=0,lte=64"`
+		// concurrently inside one cohort activity. Zero or one is serial. The
+		// cap also bounds worker memory: each Apply worker pins up to two
+		// decompressed CSCB chunks.
+		RowParallelism int `mapstructure:"row_parallelism" validate:"omitempty,gte=0,lte=16"`
 	}
 
 	RosettaConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -359,6 +359,9 @@ type (
 	SingleBlockRetentionWorkflowConfig struct {
 		WorkflowConfig  `mapstructure:",squash"`
 		MaxObjectRanges int `mapstructure:"max_object_ranges" validate:"required,gt=0,lte=250"`
+		// RowParallelism bounds how many rows the retention planner processes
+		// concurrently inside one cohort activity. Zero or one is serial.
+		RowParallelism int `mapstructure:"row_parallelism" validate:"omitempty,gte=0,lte=64"`
 	}
 
 	RosettaConfig struct {

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -39,9 +39,12 @@ const (
 	// expires, so renewing at half-life preserves the fencing guarantee while
 	// removing a database write per destructive step.
 	retirementClaimRenewalFraction = 2
-	maxRetirementRowParallelism    = 64
-	s3MutableNullVersionID         = "null"
-	versionedDeleteMode            = "exact_pinned_versions_and_delete_markers"
+	// maxRetirementRowParallelism also bounds memory: each Apply worker holds
+	// two payload verifiers, and each verifier pins one decompressed CSCB
+	// chunk (tens of MB for Solana), so the cap must fit worker pod limits.
+	maxRetirementRowParallelism = 16
+	s3MutableNullVersionID      = "null"
+	versionedDeleteMode         = "exact_pinned_versions_and_delete_markers"
 )
 
 var unverifiedRetentionSafetySHA256 = keySHA256("unverified-retention-safety-configuration")
@@ -89,6 +92,10 @@ type retentionSafetyCache struct {
 	mu       sync.Mutex
 	now      func() time.Time
 	outcomes map[string]retentionSafetyOutcome
+	// maxQuiescenceRetry keeps the longest quiescence wait ever observed by
+	// this pass, so a later successful re-verification of the same key cannot
+	// erase the retry hint the deferred rows still need.
+	maxQuiescenceRetry time.Duration
 }
 
 func (p *Planner) newRetentionSafetyCache() *retentionSafetyCache {
@@ -254,43 +261,33 @@ func (p *Planner) Apply(ctx context.Context, req PlanRequest, report *Report) er
 			deleteIndexes = append(deleteIndexes, i)
 		}
 	}
-	var (
-		firstErrMu sync.Mutex
-		firstErr   error
-	)
-	applyCtx, cancelApply := context.WithCancel(ctx)
-	defer cancelApply()
-	recordApplyError := func(err error) {
-		firstErrMu.Lock()
-		if firstErr == nil {
-			firstErr = err
-		}
-		firstErrMu.Unlock()
-		cancelApply()
-	}
-	var workers sync.WaitGroup
+	group, groupCtx := errgroup.WithContext(ctx)
 	// Contiguous segments keep each worker's verifiers local to height-adjacent
 	// rows. Rows are independent single-block objects; the first error cancels
 	// the pass and every not-yet-started row is marked not-attempted, matching
 	// the serial halt-on-failure contract.
 	for _, segment := range rowSegments(len(deleteIndexes), p.effectiveRowParallelism()) {
-		workers.Add(1)
-		go func() {
-			defer workers.Done()
+		group.Go(func() error {
 			preVerifier := p.verifierFactory()
 			postVerifier := p.verifierFactory()
-			for _, itemIndex := range deleteIndexes[segment.start:segment.end] {
-				item := &report.Items[itemIndex]
-				if applyCtx.Err() != nil {
-					if ctxErr := ctx.Err(); ctxErr != nil {
-						recordApplyError(xerrors.Errorf("single-block retirement apply canceled: %w", ctxErr))
-					}
-					item.Action = ActionSkip
-					item.SkipReason = SkipNotAttemptedAfterFailure
-					continue
+			markNotAttempted := func(itemIndexes []int) {
+				for _, itemIndex := range itemIndexes {
+					report.Items[itemIndex].Action = ActionSkip
+					report.Items[itemIndex].SkipReason = SkipNotAttemptedAfterFailure
 				}
-				p.recordHeartbeat(applyCtx, "retirement.apply.row", item.Height)
-				reason, err := p.applyCandidate(applyCtx, req, item, preVerifier, postVerifier, safetyCache)
+			}
+			indexes := deleteIndexes[segment.start:segment.end]
+			for position, itemIndex := range indexes {
+				item := &report.Items[itemIndex]
+				if groupCtx.Err() != nil {
+					markNotAttempted(indexes[position:])
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return xerrors.Errorf("single-block retirement apply canceled: %w", ctxErr)
+					}
+					return nil
+				}
+				p.recordHeartbeat(groupCtx, "retirement.apply.row", item.Height)
+				reason, err := p.applyCandidate(groupCtx, req, item, preVerifier, postVerifier, safetyCache)
 				if reason != "" {
 					if item.RetirementState != RetirementStateDeletedPendingVerification {
 						item.Action = ActionSkip
@@ -299,12 +296,14 @@ func (p *Planner) Apply(ctx context.Context, req PlanRequest, report *Report) er
 					item.RetirementOutcome = reason
 				}
 				if err != nil {
-					recordApplyError(err)
+					markNotAttempted(indexes[position+1:])
+					return err
 				}
 			}
-		}()
+			return nil
+		})
 	}
-	workers.Wait()
+	firstErr := group.Wait()
 	report.QuiescenceRetryAfter = safetyCache.maxQuiescenceRetryAfter()
 	report.SafetyGates.CSCBWriteOncePolicyVerified = writeOncePolicyGateVerified(report.Items)
 	report.Summary = summarize(report.Items)
@@ -445,17 +444,41 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 	return report, firstErr
 }
 
-func (s *planShared) cachedHead(key string) (ObjectHead, bool) {
+// headFor and policyFor hold the shared mutex across the fetch: every row of a
+// cohort shares one CSCB key, so a check-then-fetch cache would stampede up to
+// row-parallelism duplicate bucket calls at pass start. Serializing the
+// singleton loads is the point; per-row topology lookups stay un-serialized.
+func (s *planShared) headFor(
+	ctx context.Context,
+	load func(ctx context.Context) (ObjectHead, error),
+	key string,
+) (ObjectHead, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	head, ok := s.heads[key]
-	return head, ok
+	if head, ok := s.heads[key]; ok {
+		return head, nil
+	}
+	head, err := load(ctx)
+	if err != nil {
+		return ObjectHead{}, err
+	}
+	s.heads[key] = head
+	return head, nil
 }
 
-func (s *planShared) storeHead(key string, head ObjectHead) {
+func (s *planShared) policyFor(
+	ctx context.Context,
+	load func(ctx context.Context) bool,
+	key string,
+) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.heads[key] = head
+	if verified, ok := s.policies[key]; ok {
+		return verified
+	}
+	verified := load(ctx)
+	s.policies[key] = verified
+	return verified
 }
 
 func (s *planShared) cachedTopology(key string) (ObjectVersionTopology, bool) {
@@ -469,19 +492,6 @@ func (s *planShared) storeTopology(key string, topology ObjectVersionTopology) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.topologies[key] = topology
-}
-
-func (s *planShared) cachedPolicy(key string) (bool, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	verified, ok := s.policies[key]
-	return verified, ok
-}
-
-func (s *planShared) storePolicy(key string, verified bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.policies[key] = verified
 }
 
 func (p *Planner) planRow(
@@ -644,15 +654,12 @@ func (p *Planner) planRow(
 	item.SingleBlockETag = version.ETag
 	item.SingleBlockBytes = version.Bytes
 
-	head, ok := shared.cachedHead(shadow.ConsolidatedObjectKey)
-	if !ok {
-		var err error
-		head, err = p.store.HeadObject(ctx, req.Bucket, shadow.ConsolidatedObjectKey)
-		if err != nil {
-			item.SkipReason = SkipObjectInspectionFailed
-			return item
-		}
-		shared.storeHead(shadow.ConsolidatedObjectKey, head)
+	head, err := shared.headFor(ctx, func(ctx context.Context) (ObjectHead, error) {
+		return p.store.HeadObject(ctx, req.Bucket, shadow.ConsolidatedObjectKey)
+	}, shadow.ConsolidatedObjectKey)
+	if err != nil {
+		item.SkipReason = SkipObjectInspectionFailed
+		return item
 	}
 	if !head.Exists || head.DeleteMark || !isImmutableVersionID(head.VersionID) || head.ETag == "" {
 		item.SkipReason = SkipMissingCSCBObject
@@ -676,12 +683,10 @@ func (p *Planner) planRow(
 		return item
 	}
 	item.PayloadSHA256 = payloadSHA256
-	writeOncePolicyVerified, checked := shared.cachedPolicy(shadow.ConsolidatedObjectKey)
-	if !checked {
+	writeOncePolicyVerified := shared.policyFor(ctx, func(ctx context.Context) bool {
 		_, policyErr := p.store.InspectObjectRetentionSafety(ctx, req.Bucket, shadow.ConsolidatedObjectKey)
-		writeOncePolicyVerified = policyErr == nil
-		shared.storePolicy(shadow.ConsolidatedObjectKey, writeOncePolicyVerified)
-	}
+		return policyErr == nil
+	}, shadow.ConsolidatedObjectKey)
 	item.CSCBWriteOncePolicy = writeOncePolicyVerified
 	if !writeOncePolicyVerified {
 		item.SkipReason = SkipCSCBWriteOncePolicyUnverified
@@ -711,15 +716,13 @@ func (p *Planner) applyCandidate(
 	safetyCache *retentionSafetyCache,
 ) (string, error) {
 	item.SingleBlockKeySHA256 = keySHA256(item.Key)
-	// A database-only precheck keeps rows whose canonical, shadow, or
-	// retirement metadata drifted since Plan from ever persisting a manifest or
-	// fencing their single-block path.
-	row, err := p.repo.GetMetadataRow(ctx, item.BlockMetadataID)
-	if err != nil {
-		return SkipMetadataChanged, err
-	}
-	if !candidateMatchesRow(req, *item, row, true) {
-		return SkipMetadataChanged, xerrors.Errorf("canonical, shadow, or retirement metadata changed before retirement: block_metadata_id=%d", item.BlockMetadataID)
+	// PrepareRetirement stamps the irreversible single-block upload fence, so
+	// the row must re-prove its canonical metadata and its live pinned CSCB
+	// object (fresh current + versioned HEADs) before fencing. Only the
+	// payload re-read moves after the claim: the pinned version is immutable,
+	// so the digest check there re-proves the same bytes Plan verified.
+	if _, reason, err := p.revalidateMetadataAndCSCB(ctx, req, *item, true); err != nil {
+		return reason, err
 	}
 	// The manifest pins Plan's verified digest; the post-claim revalidation
 	// below must reproduce it from live S3 before anything is deleted.
@@ -902,16 +905,23 @@ func (p *Planner) verifyCSCBRetentionSafetyCached(
 		err:        err,
 		verifiedAt: cache.now(),
 	}
+	if reason == SkipCSCBSafetyQuiescenceActive && retryAfter > cache.maxQuiescenceRetry {
+		cache.maxQuiescenceRetry = retryAfter
+	}
 	cache.mu.Unlock()
 	return reason, err
 }
 
 // PrimeRetentionSafety records safety observations for upcoming CSCB keys so
 // their quiescence clocks start before any execute attempt reaches them. The
-// verified configuration (bucket policy + lifecycle) is bucket-level, so one
-// inspection covers every key; recording the observation earlier only lengthens
-// the stability window the quiescence gate later requires. Destructive paths
-// still re-inspect live configuration through verifyCSCBRetentionSafety.
+// inspected configuration (bucket policy + lifecycle) is bucket-level, but the
+// pass/fail evaluation matches Resource ARNs and lifecycle prefixes against
+// the specific key, so the keys[0] result is fanned out on the assumption that
+// consolidated keys share one pattern. That assumption is only an
+// optimization: the destructive path re-inspects every key through
+// verifyCSCBRetentionSafety, and a key whose own inspection disagrees records
+// a different configuration digest there, which resets its quiescence clock
+// and fails closed.
 func (p *Planner) PrimeRetentionSafety(ctx context.Context, bucket string, keys []string) (int, error) {
 	if len(keys) == 0 {
 		return 0, nil
@@ -948,13 +958,7 @@ func (p *Planner) PrimeRetentionSafety(ctx context.Context, bucket string, keys 
 func (c *retentionSafetyCache) maxQuiescenceRetryAfter() time.Duration {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var max time.Duration
-	for _, outcome := range c.outcomes {
-		if outcome.reason == SkipCSCBSafetyQuiescenceActive && outcome.retryAfter > max {
-			max = outcome.retryAfter
-		}
-	}
-	return max
+	return c.maxQuiescenceRetry
 }
 
 func (p *Planner) inspectCSCBRetentionSafety(ctx context.Context, item *Candidate) (string, error) {
@@ -1042,13 +1046,22 @@ func (p *Planner) withRetirementClaim(
 
 // maybeRenewRetirementClaim renews once the claim has consumed half of its
 // lease. The claim cannot be taken over before the full lease expires, so a
-// half-life cadence keeps exclusive ownership provable while dropping the
-// per-operation renewal write.
+// half-life cadence keeps exclusive ownership provable on non-destructive
+// steps; renewRetirementClaim below remains the unconditional fence
+// immediately before a row's destructive sequence.
 func (p *Planner) maybeRenewRetirementClaim(ctx context.Context, blockMetadataID int64, claim *retirementClaim) error {
-	renewedAt := time.Now().UTC()
-	if renewedAt.Sub(claim.lastRenewedAt) < RetirementClaimLease/retirementClaimRenewalFraction {
+	if time.Now().UTC().Sub(claim.lastRenewedAt) < RetirementClaimLease/retirementClaimRenewalFraction {
 		return nil
 	}
+	return p.renewRetirementClaim(ctx, blockMetadataID, claim)
+}
+
+// renewRetirementClaim unconditionally renews and thereby re-asserts exclusive
+// claim ownership against the database. It is the fence before destructive S3
+// work: a claim that was taken over after a long stall fails here instead of
+// deleting unfenced.
+func (p *Planner) renewRetirementClaim(ctx context.Context, blockMetadataID int64, claim *retirementClaim) error {
+	renewedAt := time.Now().UTC()
 	if err := p.repo.RenewRetirementClaim(ctx, blockMetadataID, claim.token, renewedAt, renewedAt.Add(RetirementClaimLease)); err != nil {
 		return err
 	}
@@ -1070,6 +1083,13 @@ func (p *Planner) deletePinnedSingleBlockTopology(
 			"single-block object version topology changed before exact deletion: block_metadata_id=%d",
 			item.BlockMetadataID,
 		)
+	}
+
+	// Unconditional fence: prove exclusive claim ownership against the
+	// database immediately before this row's destructive sequence, regardless
+	// of how recently the claim was renewed.
+	if err := p.renewRetirementClaim(ctx, item.BlockMetadataID, claim); err != nil {
+		return SkipRetirementClaimActive, err
 	}
 
 	remainingVersions := make(map[string]struct{}, len(topology.Versions))
@@ -1169,7 +1189,12 @@ func (p *Planner) finalizeRecordedDeletion(
 	// first read of each CSCB chunk happens post-delete and is then shared by
 	// height-adjacent rows in the same chunk. Every row still re-heads the
 	// pinned CSCB object freshly inside revalidateConsolidatedCandidate, so a
-	// vanished or changed CSCB fails this row even on a cached chunk.
+	// vanished or changed CSCB fails this row even on a cached chunk. Residual
+	// window accepted by this reuse: an S3 data-loss event that keeps the
+	// pinned version's HEAD metadata intact while its bytes become unreadable
+	// would pass later rows in the same chunk against the cached read; content
+	// verification at the exact instant of finalize was never atomic with the
+	// delete either, this widens that instant to at most one chunk of rows.
 	payloadSHA256, reason, err := p.revalidateConsolidatedCandidate(ctx, req, *item, postVerifier)
 	if err != nil {
 		return reason, err

--- a/internal/storage/retirement/planner.go
+++ b/internal/storage/retirement/planner.go
@@ -9,8 +9,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
@@ -26,8 +28,20 @@ const (
 	retirementClaimTokenBytes         = 16
 	RetirementClaimLease              = 15 * time.Minute
 	RetentionSafetyQuiescencePeriod   = 15 * time.Minute
-	s3MutableNullVersionID            = "null"
-	versionedDeleteMode               = "exact_pinned_versions_and_delete_markers"
+	// retentionSafetyRevalidationInterval bounds how stale a successful
+	// bucket-safety verification may be before a destructive row re-verifies it
+	// against live S3. The preflight verifies every cohort's configuration at
+	// the start of an Apply pass; rows within this interval reuse that result
+	// instead of re-issuing two control-plane calls per row.
+	retentionSafetyRevalidationInterval = time.Minute
+	// retirementClaimRenewalFraction renews a claim once the elapsed lease
+	// fraction exceeds 1/2. The claim cannot be taken over until the full lease
+	// expires, so renewing at half-life preserves the fencing guarantee while
+	// removing a database write per destructive step.
+	retirementClaimRenewalFraction = 2
+	maxRetirementRowParallelism    = 64
+	s3MutableNullVersionID         = "null"
+	versionedDeleteMode            = "exact_pinned_versions_and_delete_markers"
 )
 
 var unverifiedRetentionSafetySHA256 = keySHA256("unverified-retention-safety-configuration")
@@ -37,9 +51,74 @@ type Planner struct {
 	store           ObjectStore
 	verifierFactory func() blockPayloadVerifier
 	heartbeat       func(ctx context.Context, details ...any)
+	rowParallelism  int
+	// retentionSafetyClock feeds the safety cache's staleness checks; tests
+	// override it to exercise revalidation-interval expiry.
+	retentionSafetyClock func() time.Time
 }
 
 type PlannerOption func(*Planner)
+
+// WithRowParallelism bounds how many independent rows Plan and Apply process
+// concurrently. Zero or one preserves the serial default for existing callers.
+func WithRowParallelism(parallelism int) PlannerOption {
+	return func(p *Planner) {
+		p.rowParallelism = parallelism
+	}
+}
+
+// retirementClaim carries the claim token together with its renewal clock so
+// destructive steps can renew on lease half-life instead of before every
+// operation.
+type retirementClaim struct {
+	token         string
+	lastRenewedAt time.Time
+}
+
+// retentionSafetyOutcome memoizes one bucket-safety verification for a CSCB
+// key so an Apply or Reconcile pass re-verifies at most once per
+// retentionSafetyRevalidationInterval rather than once per row.
+type retentionSafetyOutcome struct {
+	reason     string
+	retryAfter time.Duration
+	err        error
+	verifiedAt time.Time
+}
+
+type retentionSafetyCache struct {
+	mu       sync.Mutex
+	now      func() time.Time
+	outcomes map[string]retentionSafetyOutcome
+}
+
+func (p *Planner) newRetentionSafetyCache() *retentionSafetyCache {
+	now := p.retentionSafetyClock
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &retentionSafetyCache{
+		now:      now,
+		outcomes: make(map[string]retentionSafetyOutcome),
+	}
+}
+
+// planShared holds the per-plan caches that independent row workers share.
+// Lookups and stores are mutex-guarded; a cache miss may fetch the same
+// immutable object from S3 on more than one worker, which is benign.
+type planShared struct {
+	mu         sync.Mutex
+	heads      map[string]ObjectHead
+	topologies map[string]ObjectVersionTopology
+	policies   map[string]bool
+}
+
+func newPlanShared() *planShared {
+	return &planShared{
+		heads:      make(map[string]ObjectHead),
+		topologies: make(map[string]ObjectVersionTopology),
+		policies:   make(map[string]bool),
+	}
+}
 
 // WithHeartbeat wires a liveness callback invoked from the long-running
 // row/version loops, so a Temporal activity heartbeat timeout can bound the
@@ -80,21 +159,66 @@ func (p *Planner) Plan(ctx context.Context, req PlanRequest) (*Report, error) {
 	}
 
 	report := newReport(req)
-	cscbHeads := make(map[string]ObjectHead)
-	singleBlockTopologies := make(map[string]ObjectVersionTopology)
-	writeOncePolicies := make(map[string]bool)
-	verifier := p.verifierFactory()
-	for _, row := range rows {
-		if err := ctx.Err(); err != nil {
-			return nil, xerrors.Errorf("single-block retention plan canceled at height %d: %w", row.Height, err)
-		}
-		p.recordHeartbeat(ctx, "retirement.plan.row", row.Height)
-		item := p.planRow(ctx, req, row, cscbHeads, singleBlockTopologies, writeOncePolicies, verifier)
-		report.Items = append(report.Items, item)
+	shared := newPlanShared()
+	items := make([]Candidate, len(rows))
+	group, groupCtx := errgroup.WithContext(ctx)
+	// Contiguous segments keep each worker's verifier chunk cache local to
+	// height-adjacent rows, which share CSCB chunks.
+	for _, segment := range rowSegments(len(rows), p.effectiveRowParallelism()) {
+		group.Go(func() error {
+			verifier := p.verifierFactory()
+			for i := segment.start; i < segment.end; i++ {
+				row := rows[i]
+				if err := groupCtx.Err(); err != nil {
+					return xerrors.Errorf("single-block retention plan canceled at height %d: %w", row.Height, err)
+				}
+				p.recordHeartbeat(groupCtx, "retirement.plan.row", row.Height)
+				items[i] = p.planRow(groupCtx, req, row, shared, verifier)
+			}
+			return nil
+		})
 	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	report.Items = append(report.Items, items...)
 	report.SafetyGates.CSCBWriteOncePolicyVerified = writeOncePolicyGateVerified(report.Items)
 	report.Summary = summarize(report.Items)
 	return report, nil
+}
+
+type rowSegment struct {
+	start int
+	end   int
+}
+
+func rowSegments(total int, parallelism int) []rowSegment {
+	if total <= 0 {
+		return nil
+	}
+	if parallelism > total {
+		parallelism = total
+	}
+	segments := make([]rowSegment, 0, parallelism)
+	size := (total + parallelism - 1) / parallelism
+	for start := 0; start < total; start += size {
+		end := start + size
+		if end > total {
+			end = total
+		}
+		segments = append(segments, rowSegment{start: start, end: end})
+	}
+	return segments
+}
+
+func (p *Planner) effectiveRowParallelism() int {
+	if p.rowParallelism <= 1 {
+		return 1
+	}
+	if p.rowParallelism > maxRetirementRowParallelism {
+		return maxRetirementRowParallelism
+	}
+	return p.rowParallelism
 }
 
 func (p *Planner) Apply(ctx context.Context, req PlanRequest, report *Report) error {
@@ -116,49 +240,72 @@ func (p *Planner) Apply(ctx context.Context, req PlanRequest, report *Report) er
 	if err := validateApplyReport(req, report); err != nil {
 		return err
 	}
-	if err := p.preflightApplyRetentionSafety(ctx, report); err != nil {
+	safetyCache := p.newRetentionSafetyCache()
+	if err := p.preflightApplyRetentionSafety(ctx, report, safetyCache); err != nil {
+		report.QuiescenceRetryAfter = safetyCache.maxQuiescenceRetryAfter()
 		report.SafetyGates.CSCBWriteOncePolicyVerified = writeOncePolicyGateVerified(report.Items)
 		report.Summary = summarize(report.Items)
 		return err
 	}
 
-	verifier := p.verifierFactory()
-	var firstErr error
-	halted := false
+	deleteIndexes := make([]int, 0, len(report.Items))
 	for i := range report.Items {
-		item := &report.Items[i]
-		if item.Action != ActionDeleteObjectVersion {
-			continue
-		}
-		if !halted {
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				if firstErr == nil {
-					firstErr = xerrors.Errorf("single-block retirement apply canceled: %w", ctxErr)
-				}
-				halted = true
-			}
-		}
-		if halted {
-			item.Action = ActionSkip
-			item.SkipReason = SkipNotAttemptedAfterFailure
-			continue
-		}
-		p.recordHeartbeat(ctx, "retirement.apply.row", item.Height)
-		reason, err := p.applyCandidate(ctx, req, item, verifier)
-		if reason != "" {
-			if item.RetirementState != RetirementStateDeletedPendingVerification {
-				item.Action = ActionSkip
-			}
-			item.SkipReason = reason
-			item.RetirementOutcome = reason
-		}
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			halted = true
+		if report.Items[i].Action == ActionDeleteObjectVersion {
+			deleteIndexes = append(deleteIndexes, i)
 		}
 	}
+	var (
+		firstErrMu sync.Mutex
+		firstErr   error
+	)
+	applyCtx, cancelApply := context.WithCancel(ctx)
+	defer cancelApply()
+	recordApplyError := func(err error) {
+		firstErrMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+		}
+		firstErrMu.Unlock()
+		cancelApply()
+	}
+	var workers sync.WaitGroup
+	// Contiguous segments keep each worker's verifiers local to height-adjacent
+	// rows. Rows are independent single-block objects; the first error cancels
+	// the pass and every not-yet-started row is marked not-attempted, matching
+	// the serial halt-on-failure contract.
+	for _, segment := range rowSegments(len(deleteIndexes), p.effectiveRowParallelism()) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			preVerifier := p.verifierFactory()
+			postVerifier := p.verifierFactory()
+			for _, itemIndex := range deleteIndexes[segment.start:segment.end] {
+				item := &report.Items[itemIndex]
+				if applyCtx.Err() != nil {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						recordApplyError(xerrors.Errorf("single-block retirement apply canceled: %w", ctxErr))
+					}
+					item.Action = ActionSkip
+					item.SkipReason = SkipNotAttemptedAfterFailure
+					continue
+				}
+				p.recordHeartbeat(applyCtx, "retirement.apply.row", item.Height)
+				reason, err := p.applyCandidate(applyCtx, req, item, preVerifier, postVerifier, safetyCache)
+				if reason != "" {
+					if item.RetirementState != RetirementStateDeletedPendingVerification {
+						item.Action = ActionSkip
+					}
+					item.SkipReason = reason
+					item.RetirementOutcome = reason
+				}
+				if err != nil {
+					recordApplyError(err)
+				}
+			}
+		}()
+	}
+	workers.Wait()
+	report.QuiescenceRetryAfter = safetyCache.maxQuiescenceRetryAfter()
 	report.SafetyGates.CSCBWriteOncePolicyVerified = writeOncePolicyGateVerified(report.Items)
 	report.Summary = summarize(report.Items)
 	return firstErr
@@ -186,6 +333,9 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 		return nil, err
 	}
 	report := newReport(req)
+	safetyCache := p.newRetentionSafetyCache()
+	preVerifier := p.verifierFactory()
+	postVerifier := p.verifierFactory()
 	var firstErr error
 	halted := false
 	for _, manifest := range manifests {
@@ -261,7 +411,7 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 			report.Items = append(report.Items, item)
 			continue
 		}
-		if reason, err := p.verifyCSCBRetentionSafety(ctx, &item); err != nil {
+		if reason, err := p.verifyCSCBRetentionSafetyCached(ctx, &item, safetyCache); err != nil {
 			markCandidateBlocked(&item, reason)
 			item.RetirementOutcome = reason
 			report.Items = append(report.Items, item)
@@ -273,7 +423,7 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 			}
 			continue
 		}
-		reason, err := p.reconcileManifest(ctx, req, &item, manifest)
+		reason, err := p.reconcileManifest(ctx, req, &item, manifest, preVerifier, postVerifier, safetyCache)
 		if reason != "" {
 			if item.RetirementState != RetirementStateDeletedPendingVerification {
 				item.Action = ActionSkip
@@ -289,18 +439,56 @@ func (p *Planner) Reconcile(ctx context.Context, req PlanRequest) (*Report, erro
 		}
 		report.Items = append(report.Items, item)
 	}
+	report.QuiescenceRetryAfter = safetyCache.maxQuiescenceRetryAfter()
 	report.SafetyGates.CSCBWriteOncePolicyVerified = writeOncePolicyGateVerified(report.Items)
 	report.Summary = summarize(report.Items)
 	return report, firstErr
+}
+
+func (s *planShared) cachedHead(key string) (ObjectHead, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	head, ok := s.heads[key]
+	return head, ok
+}
+
+func (s *planShared) storeHead(key string, head ObjectHead) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.heads[key] = head
+}
+
+func (s *planShared) cachedTopology(key string) (ObjectVersionTopology, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	topology, ok := s.topologies[key]
+	return topology, ok
+}
+
+func (s *planShared) storeTopology(key string, topology ObjectVersionTopology) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.topologies[key] = topology
+}
+
+func (s *planShared) cachedPolicy(key string) (bool, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	verified, ok := s.policies[key]
+	return verified, ok
+}
+
+func (s *planShared) storePolicy(key string, verified bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.policies[key] = verified
 }
 
 func (p *Planner) planRow(
 	ctx context.Context,
 	req PlanRequest,
 	row MetadataRow,
-	cscbHeads map[string]ObjectHead,
-	singleBlockTopologies map[string]ObjectVersionTopology,
-	writeOncePolicies map[string]bool,
+	shared *planShared,
 	verifier blockPayloadVerifier,
 ) Candidate {
 	item := Candidate{
@@ -429,7 +617,7 @@ func (p *Planner) planRow(
 		return item
 	}
 
-	topology, ok := singleBlockTopologies[row.SingleBlockObjectKey]
+	topology, ok := shared.cachedTopology(row.SingleBlockObjectKey)
 	if !ok {
 		var err error
 		topology, err = p.store.ListObjectVersions(ctx, req.Bucket, row.SingleBlockObjectKey)
@@ -437,7 +625,7 @@ func (p *Planner) planRow(
 			item.SkipReason = SkipObjectInspectionFailed
 			return item
 		}
-		singleBlockTopologies[row.SingleBlockObjectKey] = topology
+		shared.storeTopology(row.SingleBlockObjectKey, topology)
 	}
 	item.SingleBlockVersions = len(topology.Versions)
 	item.DeleteMarkers = len(topology.DeleteMarkers)
@@ -456,7 +644,7 @@ func (p *Planner) planRow(
 	item.SingleBlockETag = version.ETag
 	item.SingleBlockBytes = version.Bytes
 
-	head, ok := cscbHeads[shadow.ConsolidatedObjectKey]
+	head, ok := shared.cachedHead(shadow.ConsolidatedObjectKey)
 	if !ok {
 		var err error
 		head, err = p.store.HeadObject(ctx, req.Bucket, shadow.ConsolidatedObjectKey)
@@ -464,7 +652,7 @@ func (p *Planner) planRow(
 			item.SkipReason = SkipObjectInspectionFailed
 			return item
 		}
-		cscbHeads[shadow.ConsolidatedObjectKey] = head
+		shared.storeHead(shadow.ConsolidatedObjectKey, head)
 	}
 	if !head.Exists || head.DeleteMark || !isImmutableVersionID(head.VersionID) || head.ETag == "" {
 		item.SkipReason = SkipMissingCSCBObject
@@ -488,11 +676,11 @@ func (p *Planner) planRow(
 		return item
 	}
 	item.PayloadSHA256 = payloadSHA256
-	writeOncePolicyVerified, checked := writeOncePolicies[shadow.ConsolidatedObjectKey]
+	writeOncePolicyVerified, checked := shared.cachedPolicy(shadow.ConsolidatedObjectKey)
 	if !checked {
 		_, policyErr := p.store.InspectObjectRetentionSafety(ctx, req.Bucket, shadow.ConsolidatedObjectKey)
 		writeOncePolicyVerified = policyErr == nil
-		writeOncePolicies[shadow.ConsolidatedObjectKey] = writeOncePolicyVerified
+		shared.storePolicy(shadow.ConsolidatedObjectKey, writeOncePolicyVerified)
 	}
 	item.CSCBWriteOncePolicy = writeOncePolicyVerified
 	if !writeOncePolicyVerified {
@@ -514,35 +702,55 @@ func (p *Planner) planRow(
 	return item
 }
 
-func (p *Planner) applyCandidate(ctx context.Context, req PlanRequest, item *Candidate, verifier blockPayloadVerifier) (string, error) {
-	payloadSHA256, reason, err := p.revalidateCandidate(ctx, req, *item, verifier)
-	if err != nil {
-		return reason, err
-	}
-	item.PayloadSHA256 = payloadSHA256
+func (p *Planner) applyCandidate(
+	ctx context.Context,
+	req PlanRequest,
+	item *Candidate,
+	preVerifier blockPayloadVerifier,
+	postVerifier blockPayloadVerifier,
+	safetyCache *retentionSafetyCache,
+) (string, error) {
 	item.SingleBlockKeySHA256 = keySHA256(item.Key)
+	// A database-only precheck keeps rows whose canonical, shadow, or
+	// retirement metadata drifted since Plan from ever persisting a manifest or
+	// fencing their single-block path.
+	row, err := p.repo.GetMetadataRow(ctx, item.BlockMetadataID)
+	if err != nil {
+		return SkipMetadataChanged, err
+	}
+	if !candidateMatchesRow(req, *item, row, true) {
+		return SkipMetadataChanged, xerrors.Errorf("canonical, shadow, or retirement metadata changed before retirement: block_metadata_id=%d", item.BlockMetadataID)
+	}
+	// The manifest pins Plan's verified digest; the post-claim revalidation
+	// below must reproduce it from live S3 before anything is deleted.
 	manifest := manifestFromCandidate(*item, req.Now)
 	if err := p.repo.PrepareRetirement(ctx, manifest, req.StorageGeneration); err != nil {
 		return SkipMetadataChanged, err
 	}
-	return p.withRetirementClaim(ctx, item, func(claimToken string) (string, error) {
-		preDeleteSHA256, reason, err := p.revalidateCandidate(ctx, req, *item, verifier)
+	return p.withRetirementClaim(ctx, item, func(claim *retirementClaim) (string, error) {
+		// One full revalidation after the claim covers the plan-to-delete
+		// window: canonical metadata, the pinned CSCB object, the pinned
+		// version topology, and the payload digest must all still match what
+		// Plan verified. The pinned S3 version is immutable, so a second
+		// content read between here and the delete would re-prove the same
+		// bytes.
+		preDeleteSHA256, reason, err := p.revalidateCandidate(ctx, req, *item, preVerifier)
 		if err != nil {
 			return reason, err
 		}
 		if preDeleteSHA256 != item.PayloadSHA256 {
 			return SkipSingleBlockPayloadMismatch, xerrors.Errorf("payload digest changed immediately before retirement: block_metadata_id=%d", item.BlockMetadataID)
 		}
-		if err := p.renewRetirementClaim(ctx, item.BlockMetadataID, claimToken); err != nil {
+		if err := p.maybeRenewRetirementClaim(ctx, item.BlockMetadataID, claim); err != nil {
 			return SkipRetirementClaimActive, err
 		}
-		if reason, err := p.verifyCSCBRetentionSafety(ctx, item); err != nil {
+		if reason, err := p.verifyCSCBRetentionSafetyCached(ctx, item, safetyCache); err != nil {
 			return reason, err
 		}
-		if reason, err := p.deletePinnedSingleBlockTopology(ctx, item, claimToken); err != nil {
+		if reason, err := p.deletePinnedSingleBlockTopology(ctx, item, claim); err != nil {
 			return reason, err
 		}
-		return p.completeObjectDeletion(ctx, req, item, claimToken, item.PayloadSHA256)
+		return p.completeObjectDeletion(ctx, req, item, claim, item.PayloadSHA256, postVerifier)
 	})
 }
 
@@ -551,16 +759,19 @@ func (p *Planner) reconcileManifest(
 	req PlanRequest,
 	item *Candidate,
 	manifest RetirementManifest,
+	preVerifier blockPayloadVerifier,
+	postVerifier blockPayloadVerifier,
+	safetyCache *retentionSafetyCache,
 ) (string, error) {
 	if manifest.State == RetirementStateDeletedPendingVerification {
 		if manifest.SingleBlockObjectKey != "" || manifest.SingleBlockObjectETag != "" || manifest.DeletedAt == nil || manifest.VerifiedAt != nil {
 			return SkipMetadataChanged, xerrors.Errorf("pending-verification retirement manifest is inconsistent: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
-		return p.withRetirementClaim(ctx, item, func(claimToken string) (string, error) {
-			if reason, err := p.verifyCSCBRetentionSafety(ctx, item); err != nil {
+		return p.withRetirementClaim(ctx, item, func(claim *retirementClaim) (string, error) {
+			if reason, err := p.verifyCSCBRetentionSafetyCached(ctx, item, safetyCache); err != nil {
 				return reason, err
 			}
-			return p.finalizeRecordedDeletion(ctx, req, item, claimToken, manifest.PayloadSHA256)
+			return p.finalizeRecordedDeletion(ctx, req, item, claim, manifest.PayloadSHA256, postVerifier)
 		})
 	}
 	if manifest.SingleBlockObjectKey == "" || keySHA256(manifest.SingleBlockObjectKey) != manifest.SingleBlockObjectKeySHA256 {
@@ -578,7 +789,7 @@ func (p *Planner) reconcileManifest(
 			return SkipUnsafeSingleBlockVersionTopology, xerrors.Errorf("eligible retirement topology changed: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
 	}
-	return p.withRetirementClaim(ctx, item, func(claimToken string) (string, error) {
+	return p.withRetirementClaim(ctx, item, func(claim *retirementClaim) (string, error) {
 		topology, err := p.store.ListObjectVersions(ctx, manifest.Bucket, manifest.SingleBlockObjectKey)
 		if err != nil {
 			return SkipObjectInspectionFailed, err
@@ -587,48 +798,43 @@ func (p *Planner) reconcileManifest(
 			if manifest.State != RetirementStateDeleting {
 				return SkipMetadataChanged, xerrors.Errorf("single-block object is absent while retirement state is %s", manifest.State)
 			}
-			if reason, err := p.verifyCSCBRetentionSafety(ctx, item); err != nil {
+			if reason, err := p.verifyCSCBRetentionSafetyCached(ctx, item, safetyCache); err != nil {
 				return reason, err
 			}
-			return p.completeObjectDeletion(ctx, req, item, claimToken, manifest.PayloadSHA256)
+			return p.completeObjectDeletion(ctx, req, item, claim, manifest.PayloadSHA256, postVerifier)
 		}
 		if manifest.State == RetirementStateEligible && !topologyMatchesManifest(topology, manifest) ||
 			manifest.State == RetirementStateDeleting && !topologyIsPinnedSubset(topology, manifest) {
 			return SkipUnsafeSingleBlockVersionTopology, xerrors.Errorf("pending retirement topology changed: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
-		verifier := p.verifierFactory()
 		verify := p.revalidateCandidate
 		if manifest.State == RetirementStateDeleting {
 			verify = p.revalidateConsolidatedCandidate
 		}
-		payloadSHA256, reason, err := verify(ctx, req, *item, verifier)
-		if err != nil {
-			return reason, err
-		}
-		if payloadSHA256 != manifest.PayloadSHA256 {
-			return SkipSingleBlockPayloadMismatch, xerrors.Errorf("pending retirement payload digest changed: block_metadata_id=%d", manifest.BlockMetadataID)
-		}
-		preDeleteSHA256, reason, err := verify(ctx, req, *item, verifier)
+		// One post-claim verification against the persisted manifest digest
+		// covers the crash-to-resume window; the pinned version is immutable,
+		// so an immediate second read would re-prove the same bytes.
+		preDeleteSHA256, reason, err := verify(ctx, req, *item, preVerifier)
 		if err != nil {
 			return reason, err
 		}
 		if preDeleteSHA256 != manifest.PayloadSHA256 {
 			return SkipSingleBlockPayloadMismatch, xerrors.Errorf("pending retirement payload digest changed immediately before deletion: block_metadata_id=%d", manifest.BlockMetadataID)
 		}
-		if err := p.renewRetirementClaim(ctx, item.BlockMetadataID, claimToken); err != nil {
+		if err := p.maybeRenewRetirementClaim(ctx, item.BlockMetadataID, claim); err != nil {
 			return SkipRetirementClaimActive, err
 		}
-		if reason, err := p.verifyCSCBRetentionSafety(ctx, item); err != nil {
+		if reason, err := p.verifyCSCBRetentionSafetyCached(ctx, item, safetyCache); err != nil {
 			return reason, err
 		}
-		if reason, err := p.deletePinnedSingleBlockTopology(ctx, item, claimToken); err != nil {
+		if reason, err := p.deletePinnedSingleBlockTopology(ctx, item, claim); err != nil {
 			return reason, err
 		}
-		return p.completeObjectDeletion(ctx, req, item, claimToken, manifest.PayloadSHA256)
+		return p.completeObjectDeletion(ctx, req, item, claim, manifest.PayloadSHA256, postVerifier)
 	})
 }
 
-func (p *Planner) verifyCSCBRetentionSafety(ctx context.Context, item *Candidate) (string, error) {
+func (p *Planner) verifyCSCBRetentionSafety(ctx context.Context, item *Candidate) (string, time.Duration, error) {
 	item.CSCBWriteOncePolicy = false
 	snapshot, inspectionErr := p.store.InspectObjectRetentionSafety(ctx, item.Bucket, item.ConsolidatedKey)
 	configurationSHA256 := snapshot.ConfigurationSHA256
@@ -642,14 +848,14 @@ func (p *Planner) verifyCSCBRetentionSafety(ctx context.Context, item *Candidate
 		configurationSHA256,
 	)
 	if observationErr != nil {
-		return SkipCSCBWriteOncePolicyUnverified, errors.Join(inspectionErr, observationErr)
+		return SkipCSCBWriteOncePolicyUnverified, 0, errors.Join(inspectionErr, observationErr)
 	}
 	if inspectionErr != nil {
-		return SkipCSCBWriteOncePolicyUnverified, inspectionErr
+		return SkipCSCBWriteOncePolicyUnverified, 0, inspectionErr
 	}
 	item.CSCBWriteOncePolicy = true
-	if observedAt.Sub(firstObservedAt) < RetentionSafetyQuiescencePeriod {
-		return SkipCSCBSafetyQuiescenceActive, xerrors.Errorf(
+	if elapsed := observedAt.Sub(firstObservedAt); elapsed < RetentionSafetyQuiescencePeriod {
+		return SkipCSCBSafetyQuiescenceActive, RetentionSafetyQuiescencePeriod - elapsed, xerrors.Errorf(
 			"CSCB retention safety configuration has not remained stable for %s: bucket=%s key=%s first_observed_at=%s observed_at=%s",
 			RetentionSafetyQuiescencePeriod,
 			item.Bucket,
@@ -658,7 +864,97 @@ func (p *Planner) verifyCSCBRetentionSafety(ctx context.Context, item *Candidate
 			observedAt.Format(time.RFC3339Nano),
 		)
 	}
-	return "", nil
+	return "", 0, nil
+}
+
+// verifyCSCBRetentionSafetyCached memoizes bucket-safety verification per CSCB
+// key. The verified configuration is bucket-level and the quiescence clock is
+// persisted in the database, so within retentionSafetyRevalidationInterval a
+// cached success (or failure) stands in for a fresh pair of S3 control-plane
+// calls. PrimeRetentionSafety and the Apply preflight seed the cache before any
+// destructive row runs.
+func (p *Planner) verifyCSCBRetentionSafetyCached(
+	ctx context.Context,
+	item *Candidate,
+	cache *retentionSafetyCache,
+) (string, error) {
+	if cache == nil {
+		reason, _, err := p.verifyCSCBRetentionSafety(ctx, item)
+		return reason, err
+	}
+	cache.mu.Lock()
+	outcome, ok := cache.outcomes[item.ConsolidatedKey]
+	if ok && cache.now().Sub(outcome.verifiedAt) < retentionSafetyRevalidationInterval {
+		cache.mu.Unlock()
+		if outcome.err == nil {
+			item.CSCBWriteOncePolicy = true
+		} else {
+			item.CSCBWriteOncePolicy = outcome.reason == SkipCSCBSafetyQuiescenceActive
+		}
+		return outcome.reason, outcome.err
+	}
+	cache.mu.Unlock()
+	reason, retryAfter, err := p.verifyCSCBRetentionSafety(ctx, item)
+	cache.mu.Lock()
+	cache.outcomes[item.ConsolidatedKey] = retentionSafetyOutcome{
+		reason:     reason,
+		retryAfter: retryAfter,
+		err:        err,
+		verifiedAt: cache.now(),
+	}
+	cache.mu.Unlock()
+	return reason, err
+}
+
+// PrimeRetentionSafety records safety observations for upcoming CSCB keys so
+// their quiescence clocks start before any execute attempt reaches them. The
+// verified configuration (bucket policy + lifecycle) is bucket-level, so one
+// inspection covers every key; recording the observation earlier only lengthens
+// the stability window the quiescence gate later requires. Destructive paths
+// still re-inspect live configuration through verifyCSCBRetentionSafety.
+func (p *Planner) PrimeRetentionSafety(ctx context.Context, bucket string, keys []string) (int, error) {
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	snapshot, err := p.store.InspectObjectRetentionSafety(ctx, bucket, keys[0])
+	if err != nil {
+		return 0, xerrors.Errorf("failed to inspect retention safety for priming: %w", err)
+	}
+	if !isSHA256Hex(snapshot.ConfigurationSHA256) {
+		return 0, xerrors.New("retention safety inspection returned an invalid configuration digest")
+	}
+	primed := 0
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		if err := ctx.Err(); err != nil {
+			return primed, xerrors.Errorf("retention safety priming canceled: %w", err)
+		}
+		p.recordHeartbeat(ctx, "retirement.prime.key", key)
+		if _, _, err := p.repo.ObserveRetentionSafety(ctx, bucket, key, snapshot.ConfigurationSHA256); err != nil {
+			return primed, xerrors.Errorf("failed to prime retention safety observation: %w", err)
+		}
+		primed++
+	}
+	return primed, nil
+}
+
+func (c *retentionSafetyCache) maxQuiescenceRetryAfter() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var max time.Duration
+	for _, outcome := range c.outcomes {
+		if outcome.reason == SkipCSCBSafetyQuiescenceActive && outcome.retryAfter > max {
+			max = outcome.retryAfter
+		}
+	}
+	return max
 }
 
 func (p *Planner) inspectCSCBRetentionSafety(ctx context.Context, item *Candidate) (string, error) {
@@ -670,33 +966,26 @@ func (p *Planner) inspectCSCBRetentionSafety(ctx context.Context, item *Candidat
 	return "", nil
 }
 
-func (p *Planner) preflightApplyRetentionSafety(ctx context.Context, report *Report) error {
-	type safetyResult struct {
-		reason string
-		err    error
-	}
-	results := make(map[string]safetyResult)
+func (p *Planner) preflightApplyRetentionSafety(
+	ctx context.Context,
+	report *Report,
+	cache *retentionSafetyCache,
+) error {
 	var firstErr error
 	for i := range report.Items {
 		item := &report.Items[i]
 		if item.Action != ActionDeleteObjectVersion {
 			continue
 		}
-		result, ok := results[item.ConsolidatedKey]
-		if !ok {
-			result.reason, result.err = p.verifyCSCBRetentionSafety(ctx, item)
-			results[item.ConsolidatedKey] = result
-		} else if result.err == nil {
-			item.CSCBWriteOncePolicy = true
-		}
-		if result.err == nil {
+		reason, err := p.verifyCSCBRetentionSafetyCached(ctx, item, cache)
+		if err == nil {
 			continue
 		}
 		item.Action = ActionSkip
-		item.SkipReason = result.reason
-		item.RetirementOutcome = result.reason
+		item.SkipReason = reason
+		item.RetirementOutcome = reason
 		if firstErr == nil {
-			firstErr = result.err
+			firstErr = err
 		}
 	}
 	return firstErr
@@ -705,7 +994,7 @@ func (p *Planner) preflightApplyRetentionSafety(ctx context.Context, report *Rep
 func (p *Planner) withRetirementClaim(
 	ctx context.Context,
 	item *Candidate,
-	operation func(claimToken string) (string, error),
+	operation func(claim *retirementClaim) (string, error),
 ) (reason string, err error) {
 	claimToken, err := newRetirementClaimToken()
 	if err != nil {
@@ -718,6 +1007,7 @@ func (p *Planner) withRetirementClaim(
 		}
 		return SkipMetadataChanged, err
 	}
+	claim := &retirementClaim{token: claimToken, lastRenewedAt: claimedAt}
 	if item.RetirementState == RetirementStateDeletedPendingVerification {
 		item.RetirementOutcome = "verification_started"
 	} else {
@@ -743,22 +1033,33 @@ func (p *Planner) withRetirementClaim(
 		}
 	}()
 
-	reason, err = operation(claimToken)
+	reason, err = operation(claim)
 	if err == nil {
 		claimOwned = false
 	}
 	return reason, err
 }
 
-func (p *Planner) renewRetirementClaim(ctx context.Context, blockMetadataID int64, claimToken string) error {
+// maybeRenewRetirementClaim renews once the claim has consumed half of its
+// lease. The claim cannot be taken over before the full lease expires, so a
+// half-life cadence keeps exclusive ownership provable while dropping the
+// per-operation renewal write.
+func (p *Planner) maybeRenewRetirementClaim(ctx context.Context, blockMetadataID int64, claim *retirementClaim) error {
 	renewedAt := time.Now().UTC()
-	return p.repo.RenewRetirementClaim(ctx, blockMetadataID, claimToken, renewedAt, renewedAt.Add(RetirementClaimLease))
+	if renewedAt.Sub(claim.lastRenewedAt) < RetirementClaimLease/retirementClaimRenewalFraction {
+		return nil
+	}
+	if err := p.repo.RenewRetirementClaim(ctx, blockMetadataID, claim.token, renewedAt, renewedAt.Add(RetirementClaimLease)); err != nil {
+		return err
+	}
+	claim.lastRenewedAt = renewedAt
+	return nil
 }
 
 func (p *Planner) deletePinnedSingleBlockTopology(
 	ctx context.Context,
 	item *Candidate,
-	claimToken string,
+	claim *retirementClaim,
 ) (string, error) {
 	topology, err := p.store.ListObjectVersions(ctx, item.Bucket, item.Key)
 	if err != nil {
@@ -788,7 +1089,7 @@ func (p *Planner) deletePinnedSingleBlockTopology(
 			)
 		}
 		p.recordHeartbeat(ctx, "retirement.delete.version", item.Height, versionID)
-		if err := p.renewRetirementClaim(ctx, item.BlockMetadataID, claimToken); err != nil {
+		if err := p.maybeRenewRetirementClaim(ctx, item.BlockMetadataID, claim); err != nil {
 			return SkipRetirementClaimActive, err
 		}
 		if err := p.store.DeleteObjectVersion(ctx, item.Bucket, item.Key, versionID); err != nil {
@@ -827,8 +1128,9 @@ func (p *Planner) completeObjectDeletion(
 	ctx context.Context,
 	req PlanRequest,
 	item *Candidate,
-	claimToken string,
+	claim *retirementClaim,
 	expectedPayloadSHA256 string,
+	postVerifier blockPayloadVerifier,
 ) (string, error) {
 	if err := p.verifySingleBlockDeleted(ctx, item.Bucket, item.Key); err != nil {
 		return SkipPostDeleteVerificationFailed, err
@@ -836,7 +1138,7 @@ func (p *Planner) completeObjectDeletion(
 	deletedAt, err := p.repo.RecordRetirementObjectDeleted(
 		ctx,
 		item.BlockMetadataID,
-		claimToken,
+		claim.token,
 		ActionDeletedObjectVersion,
 	)
 	if err != nil {
@@ -849,28 +1151,33 @@ func (p *Planner) completeObjectDeletion(
 	item.SingleBlockDeletedAt = &deletedAt
 	item.Key = ""
 	item.SingleBlockETag = ""
-	return p.finalizeRecordedDeletion(ctx, req, item, claimToken, expectedPayloadSHA256)
+	return p.finalizeRecordedDeletion(ctx, req, item, claim, expectedPayloadSHA256, postVerifier)
 }
 
 func (p *Planner) finalizeRecordedDeletion(
 	ctx context.Context,
 	req PlanRequest,
 	item *Candidate,
-	claimToken string,
+	claim *retirementClaim,
 	expectedPayloadSHA256 string,
+	postVerifier blockPayloadVerifier,
 ) (string, error) {
-	if err := p.renewRetirementClaim(ctx, item.BlockMetadataID, claimToken); err != nil {
+	if err := p.maybeRenewRetirementClaim(ctx, item.BlockMetadataID, claim); err != nil {
 		return SkipRetirementClaimActive, err
 	}
-	verifier := p.verifierFactory()
-	payloadSHA256, reason, err := p.revalidateConsolidatedCandidate(ctx, req, *item, verifier)
+	// postVerifier is scoped to the pass and used only after deletions, so its
+	// first read of each CSCB chunk happens post-delete and is then shared by
+	// height-adjacent rows in the same chunk. Every row still re-heads the
+	// pinned CSCB object freshly inside revalidateConsolidatedCandidate, so a
+	// vanished or changed CSCB fails this row even on a cached chunk.
+	payloadSHA256, reason, err := p.revalidateConsolidatedCandidate(ctx, req, *item, postVerifier)
 	if err != nil {
 		return reason, err
 	}
 	if payloadSHA256 != expectedPayloadSHA256 {
 		return SkipSingleBlockPayloadMismatch, xerrors.Errorf("pinned CSCB payload digest changed after single-block deletion: block_metadata_id=%d", item.BlockMetadataID)
 	}
-	verifiedAt, err := p.repo.FinalizeRetirement(ctx, item.BlockMetadataID, claimToken, ActionDeletedVerified)
+	verifiedAt, err := p.repo.FinalizeRetirement(ctx, item.BlockMetadataID, claim.token, ActionDeletedVerified)
 	if err != nil {
 		return SkipPostDeleteVerificationFailed, err
 	}

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -1557,9 +1557,10 @@ func TestPlannerApply_DoesNotFinalizeWhenCSCBChangesAfterSingleBlockDelete(t *te
 	row, repo, store, planner, _, req, report := newExecutableTestFixture(t)
 	store.headHook = func(key string, call int) ObjectHead {
 		head := store.heads[key]
-		// Call 1 is Plan, call 2 the post-claim revalidation; call 3 is the
-		// post-delete verification that must observe the replaced CSCB.
-		if key == row.PrimaryObjectKey && call >= 3 {
+		// Call 1 is Plan, call 2 the pre-fence revalidation, call 3 the
+		// post-claim revalidation; call 4 is the post-delete verification that
+		// must observe the replaced CSCB.
+		if key == row.PrimaryObjectKey && call >= 4 {
 			head.VersionID = "replacement-version"
 			head.ETag = "replacement-etag"
 		}
@@ -1940,9 +1941,10 @@ func TestPlannerApply_DoesNotDeleteWhenCSCBLifecycleExpirationAppears(t *testing
 	row, repo, store, planner, _, req, report := newExecutableTestFixture(t)
 	store.headHook = func(key string, call int) ObjectHead {
 		head := store.heads[key]
-		// Call 1 is Plan; call 2 is the post-claim revalidation that must
-		// observe the expiration before any version is deleted.
-		if key == row.PrimaryObjectKey && call >= 2 {
+		// Call 1 is Plan, call 2 the pre-fence revalidation; call 3 is the
+		// post-claim revalidation that must observe the expiration before any
+		// version is deleted.
+		if key == row.PrimaryObjectKey && call >= 3 {
 			head.Expiration = `expiry-date="Mon, 20 Jul 2026 00:00:00 GMT", rule-id="expire-current"`
 		}
 		return head
@@ -2311,6 +2313,21 @@ func TestPlannerPlanAndApply_RowParallelismMatchesSerial(t *testing.T) {
 	}
 }
 
+func TestPlannerApply_DoesNotFenceWhenCSCBVanishesAfterPlan(t *testing.T) {
+	require := require.New(t)
+	row, repo, store, planner, _, req, report := newExecutableTestFixture(t)
+	// The pinned CSCB disappears between Plan and Apply. The pre-fence
+	// revalidation must fail the row before PrepareRetirement stamps the
+	// irreversible single-block upload fence.
+	delete(store.heads, row.PrimaryObjectKey)
+
+	err := planner.Apply(context.Background(), req, report)
+	require.Error(err)
+	require.Empty(store.deleted)
+	require.Empty(repo.manifests)
+	require.Equal(SkipCSCBObjectChanged, report.Items[0].SkipReason)
+}
+
 func TestPlannerApply_ThrottlesClaimRenewalsWithinLease(t *testing.T) {
 	require := require.New(t)
 	_, repo, store, planner, _, req, report := newExecutableTestFixture(t)
@@ -2318,9 +2335,10 @@ func TestPlannerApply_ThrottlesClaimRenewalsWithinLease(t *testing.T) {
 	require.NoError(planner.Apply(context.Background(), req, report))
 	require.Len(store.deleted, 1)
 	require.Equal(ActionDeletedVerified, report.Items[0].Action)
-	// A freshly claimed row finishes well inside the lease half-life, so no
-	// renewal write is issued at all.
-	require.Zero(repo.renewCalls)
+	// A freshly claimed row skips every half-life renewal but still pays
+	// exactly one unconditional ownership fence before its destructive
+	// sequence.
+	require.Equal(1, repo.renewCalls)
 }
 
 func TestMaybeRenewRetirementClaimRenewsAfterHalfLife(t *testing.T) {

--- a/internal/storage/retirement/planner_test.go
+++ b/internal/storage/retirement/planner_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ type fakeRepo struct {
 	recordDeletedCalls int
 	finalizeErr        error
 	finalizeCalls      int
+	renewCalls         int
 }
 
 type fakeSafetyObservation struct {
@@ -154,6 +156,7 @@ func (r *fakeRepo) RenewRetirementClaim(
 	renewedAt time.Time,
 	claimExpiresAt time.Time,
 ) error {
+	r.renewCalls++
 	manifest, ok := r.manifests[blockMetadataID]
 	if !ok || manifest.State != RetirementStateDeleting && manifest.State != RetirementStateDeletedPendingVerification ||
 		manifest.ClaimToken != claimToken ||
@@ -1054,6 +1057,13 @@ func TestPlannerApply_RefetchesLiveCSCBWriteOncePolicyImmediatelyBeforeDelete(t 
 	_, repo, store, planner, _, req, report := newExecutableTestFixture(t)
 	key := report.Items[0].ConsolidatedKey
 	require.Equal(1, store.policyCalls[key])
+	// Step the safety-cache clock past the revalidation interval on every
+	// lookup so the row after preflight must re-verify against live S3.
+	cacheClock := req.Now
+	planner.retentionSafetyClock = func() time.Time {
+		cacheClock = cacheClock.Add(retentionSafetyRevalidationInterval + time.Second)
+		return cacheClock
+	}
 	store.policyHook = func(hookKey string, call int) (RetentionSafetySnapshot, error) {
 		snapshot := RetentionSafetySnapshot{ConfigurationSHA256: keySHA256("safe:" + hookKey)}
 		if call >= 3 {
@@ -1119,7 +1129,7 @@ func TestVerifyRetentionSafetyDoesNotCreditFailedInspectionTime(t *testing.T) {
 	store.policyErrors[key] = errors.New("GetBucketLifecycleConfiguration temporarily unavailable")
 	planner := testPlanner(repo, store)
 
-	reason, err := planner.verifyCSCBRetentionSafety(context.Background(), &item)
+	reason, _, err := planner.verifyCSCBRetentionSafety(context.Background(), &item)
 	require.Error(err)
 	require.Equal(SkipCSCBWriteOncePolicyUnverified, reason)
 	observation := repo.safetyObservations[observationKey]
@@ -1128,15 +1138,16 @@ func TestVerifyRetentionSafetyDoesNotCreditFailedInspectionTime(t *testing.T) {
 
 	repo.safetyNow = observedAt.Add(20 * time.Minute)
 	delete(store.policyErrors, key)
-	reason, err = planner.verifyCSCBRetentionSafety(context.Background(), &item)
+	reason, retryAfter, err := planner.verifyCSCBRetentionSafety(context.Background(), &item)
 	require.Error(err)
 	require.Equal(SkipCSCBSafetyQuiescenceActive, reason)
+	require.Equal(RetentionSafetyQuiescencePeriod, retryAfter)
 	observation = repo.safetyObservations[observationKey]
 	require.Equal(keySHA256("safe:"+key), observation.configurationSHA256)
 	require.Equal(repo.safetyNow, observation.firstObservedAt)
 }
 
-func TestPlannerApply_RefetchesLiveCSCBWriteOncePolicyForEveryDelete(t *testing.T) {
+func TestPlannerApply_VerifiesCSCBWriteOncePolicyOncePerPassWithinInterval(t *testing.T) {
 	require := require.New(t)
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	cscbKey := "consolidated/shared.cscb.zstd"
@@ -1158,9 +1169,11 @@ func TestPlannerApply_RefetchesLiveCSCBWriteOncePolicyForEveryDelete(t *testing.
 	require.NoError(err)
 	require.Equal(1, store.policyCalls[cscbKey])
 
+	// Rows within the revalidation interval reuse the preflight verification
+	// instead of re-issuing bucket control-plane calls per delete.
 	require.NoError(planner.Apply(context.Background(), req, report))
 	require.Len(store.deleted, 2)
-	require.Equal(4, store.policyCalls[cscbKey])
+	require.Equal(2, store.policyCalls[cscbKey])
 }
 
 func TestPlannerHeartbeatsFromRowAndVersionLoops(t *testing.T) {
@@ -1544,7 +1557,9 @@ func TestPlannerApply_DoesNotFinalizeWhenCSCBChangesAfterSingleBlockDelete(t *te
 	row, repo, store, planner, _, req, report := newExecutableTestFixture(t)
 	store.headHook = func(key string, call int) ObjectHead {
 		head := store.heads[key]
-		if key == row.PrimaryObjectKey && call >= 4 {
+		// Call 1 is Plan, call 2 the post-claim revalidation; call 3 is the
+		// post-delete verification that must observe the replaced CSCB.
+		if key == row.PrimaryObjectKey && call >= 3 {
 			head.VersionID = "replacement-version"
 			head.ETag = "replacement-etag"
 		}
@@ -1925,7 +1940,9 @@ func TestPlannerApply_DoesNotDeleteWhenCSCBLifecycleExpirationAppears(t *testing
 	row, repo, store, planner, _, req, report := newExecutableTestFixture(t)
 	store.headHook = func(key string, call int) ObjectHead {
 		head := store.heads[key]
-		if key == row.PrimaryObjectKey && call >= 3 {
+		// Call 1 is Plan; call 2 is the post-claim revalidation that must
+		// observe the expiration before any version is deleted.
+		if key == row.PrimaryObjectKey && call >= 2 {
 			head.Expiration = `expiry-date="Mon, 20 Jul 2026 00:00:00 GMT", rule-id="expire-current"`
 		}
 		return head
@@ -2090,6 +2107,297 @@ func cscbObjectMetadata(uncompressedLength string, format string, compressionSco
 		cscbCompressionScopeMetadataKey:   compressionScope,
 		cscbUncompressedLengthMetadataKey: uncompressedLength,
 	}
+}
+
+// lockedRepository and lockedObjectStore make the single-threaded fakes safe
+// for row-parallel planner tests without touching the serial fixtures.
+type lockedRepository struct {
+	mu    sync.Mutex
+	inner Repository
+}
+
+func (l *lockedRepository) ListMetadataRows(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, limit uint64) ([]MetadataRow, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ListMetadataRows(ctx, tag, startHeight, endHeight, limit)
+}
+
+func (l *lockedRepository) GetMetadataRow(ctx context.Context, blockMetadataID int64) (MetadataRow, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.GetMetadataRow(ctx, blockMetadataID)
+}
+
+func (l *lockedRepository) PrepareRetirement(ctx context.Context, manifest RetirementManifest, expectedStorageGeneration string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.PrepareRetirement(ctx, manifest, expectedStorageGeneration)
+}
+
+func (l *lockedRepository) ObserveRetentionSafety(ctx context.Context, bucket string, consolidatedObjectKey string, configurationSHA256 string) (time.Time, time.Time, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ObserveRetentionSafety(ctx, bucket, consolidatedObjectKey, configurationSHA256)
+}
+
+func (l *lockedRepository) ClaimRetirement(ctx context.Context, blockMetadataID int64, claimToken string, claimedAt time.Time, claimExpiresAt time.Time) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ClaimRetirement(ctx, blockMetadataID, claimToken, claimedAt, claimExpiresAt)
+}
+
+func (l *lockedRepository) RenewRetirementClaim(ctx context.Context, blockMetadataID int64, claimToken string, renewedAt time.Time, claimExpiresAt time.Time) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.RenewRetirementClaim(ctx, blockMetadataID, claimToken, renewedAt, claimExpiresAt)
+}
+
+func (l *lockedRepository) RecordRetirementOutcome(ctx context.Context, blockMetadataID int64, claimToken string, outcome string, attemptedAt time.Time) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.RecordRetirementOutcome(ctx, blockMetadataID, claimToken, outcome, attemptedAt)
+}
+
+func (l *lockedRepository) RecordRetirementObjectDeleted(ctx context.Context, blockMetadataID int64, claimToken string, outcome string) (time.Time, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.RecordRetirementObjectDeleted(ctx, blockMetadataID, claimToken, outcome)
+}
+
+func (l *lockedRepository) FinalizeRetirement(ctx context.Context, blockMetadataID int64, claimToken string, outcome string) (time.Time, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.FinalizeRetirement(ctx, blockMetadataID, claimToken, outcome)
+}
+
+func (l *lockedRepository) ListPendingRetirements(ctx context.Context, tag uint32, startHeight uint64, endHeight uint64, eligibilityCutoff time.Time, limit uint64) ([]RetirementManifest, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ListPendingRetirements(ctx, tag, startHeight, endHeight, eligibilityCutoff, limit)
+}
+
+type lockedObjectStore struct {
+	mu    sync.Mutex
+	inner ObjectStore
+}
+
+func (l *lockedObjectStore) InspectObjectRetentionSafety(ctx context.Context, bucket string, key string) (RetentionSafetySnapshot, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.InspectObjectRetentionSafety(ctx, bucket, key)
+}
+
+func (l *lockedObjectStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.HeadObject(ctx, bucket, key)
+}
+
+func (l *lockedObjectStore) HeadObjectVersion(ctx context.Context, bucket string, key string, versionID string) (ObjectHead, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.HeadObjectVersion(ctx, bucket, key, versionID)
+}
+
+func (l *lockedObjectStore) ListObjectVersions(ctx context.Context, bucket string, key string) (ObjectVersionTopology, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ListObjectVersions(ctx, bucket, key)
+}
+
+func (l *lockedObjectStore) ReadObjectVersion(ctx context.Context, bucket string, key string, versionID string) ([]byte, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ReadObjectVersion(ctx, bucket, key, versionID)
+}
+
+func (l *lockedObjectStore) ReadObjectVersionRange(ctx context.Context, bucket string, key string, versionID string, offset uint64, length uint64) ([]byte, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.ReadObjectVersionRange(ctx, bucket, key, versionID, offset, length)
+}
+
+func (l *lockedObjectStore) DeleteObjectVersion(ctx context.Context, bucket string, key string, versionID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.DeleteObjectVersion(ctx, bucket, key, versionID)
+}
+
+type lockedPayloadVerifier struct {
+	mu    sync.Mutex
+	inner blockPayloadVerifier
+}
+
+func (l *lockedPayloadVerifier) Verify(ctx context.Context, candidate Candidate) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.Verify(ctx, candidate)
+}
+
+func (l *lockedPayloadVerifier) VerifyConsolidated(ctx context.Context, candidate Candidate) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.VerifyConsolidated(ctx, candidate)
+}
+
+func newRowParallelismFixture(t *testing.T, parallelism int) (*fakeRepo, *fakeStore, *Planner, PlanRequest) {
+	t.Helper()
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	rows := make([]MetadataRow, 0, 6)
+	repo := &fakeRepo{}
+	store := newFakeStore()
+	store.deleteMutates = true
+	for i := range 6 {
+		height := uint64(428058000 + i)
+		cscbKey := "consolidated/first.cscb.zstd"
+		if i >= 3 {
+			cscbKey = "consolidated/second.cscb.zstd"
+		}
+		row := testRow(height, fmt.Sprintf("hash-%d", height), fmt.Sprintf("single-block/%d.zstd", height), cscbKey, now.Add(-8*24*time.Hour))
+		rows = append(rows, row)
+		store.topologies[row.SingleBlockObjectKey] = safeTopology(fmt.Sprintf("v-%d", height), "single-block-etag", 42)
+	}
+	repo.rows = rows
+	cscbHead := cscbObjectHead(1024, 1024)
+	for _, cscbKey := range []string{"consolidated/first.cscb.zstd", "consolidated/second.cscb.zstd"} {
+		store.heads[cscbKey] = cscbHead
+		store.versionHeads[versionObjectKey(cscbKey, cscbHead.VersionID)] = cscbHead
+	}
+	digest := strings.Repeat("a", sha256HexLength)
+	planner := NewPlanner(
+		&lockedRepository{inner: repo},
+		&lockedObjectStore{inner: store},
+		WithRowParallelism(parallelism),
+	)
+	sharedVerifier := &lockedPayloadVerifier{inner: &fakePayloadVerifier{digest: digest, consolidatedDigest: digest}}
+	planner.verifierFactory = func() blockPayloadVerifier { return sharedVerifier }
+	req := testRequest(now, true)
+	req.EndHeight = 428059000
+	req.ProductionDeleteEnabled = true
+	return repo, store, planner, req
+}
+
+func TestPlannerPlanAndApply_RowParallelismMatchesSerial(t *testing.T) {
+	require := require.New(t)
+	serialRepo, serialStore, serialPlanner, serialReq := newRowParallelismFixture(t, 1)
+	parallelRepo, parallelStore, parallelPlanner, parallelReq := newRowParallelismFixture(t, 4)
+
+	serialReport, err := serialPlanner.Plan(context.Background(), serialReq)
+	require.NoError(err)
+	parallelReport, err := parallelPlanner.Plan(context.Background(), parallelReq)
+	require.NoError(err)
+	require.Len(parallelReport.Items, len(serialReport.Items))
+	for i := range serialReport.Items {
+		require.Equal(serialReport.Items[i].Height, parallelReport.Items[i].Height)
+		require.Equal(serialReport.Items[i].Action, parallelReport.Items[i].Action)
+		require.Equal(serialReport.Items[i].SkipReason, parallelReport.Items[i].SkipReason)
+	}
+	require.Equal(serialReport.Summary, parallelReport.Summary)
+
+	require.NoError(serialPlanner.Apply(context.Background(), serialReq, serialReport))
+	require.NoError(parallelPlanner.Apply(context.Background(), parallelReq, parallelReport))
+	require.Len(parallelStore.deleted, len(serialStore.deleted))
+	require.Equal(serialReport.Summary, parallelReport.Summary)
+	require.Len(parallelRepo.manifests, len(serialRepo.manifests))
+	for blockMetadataID, serialManifest := range serialRepo.manifests {
+		parallelManifest, ok := parallelRepo.manifests[blockMetadataID]
+		require.True(ok)
+		require.Equal(serialManifest.State, parallelManifest.State)
+		require.Equal(RetirementStateDeletedVerified, parallelManifest.State)
+	}
+	for i := range serialReport.Items {
+		require.Equal(serialReport.Items[i].Action, parallelReport.Items[i].Action)
+		require.Equal(ActionDeletedVerified, parallelReport.Items[i].Action)
+	}
+}
+
+func TestPlannerApply_ThrottlesClaimRenewalsWithinLease(t *testing.T) {
+	require := require.New(t)
+	_, repo, store, planner, _, req, report := newExecutableTestFixture(t)
+
+	require.NoError(planner.Apply(context.Background(), req, report))
+	require.Len(store.deleted, 1)
+	require.Equal(ActionDeletedVerified, report.Items[0].Action)
+	// A freshly claimed row finishes well inside the lease half-life, so no
+	// renewal write is issued at all.
+	require.Zero(repo.renewCalls)
+}
+
+func TestMaybeRenewRetirementClaimRenewsAfterHalfLife(t *testing.T) {
+	require := require.New(t)
+	now := time.Now().UTC()
+	expiresAt := now.Add(RetirementClaimLease)
+	repo := &fakeRepo{
+		manifests: map[int64]RetirementManifest{
+			428058000: {
+				BlockMetadataID: 428058000,
+				State:           RetirementStateDeleting,
+				ClaimToken:      "claim-token",
+				ClaimExpiresAt:  &expiresAt,
+			},
+		},
+	}
+	planner := testPlanner(repo, newFakeStore())
+
+	fresh := &retirementClaim{token: "claim-token", lastRenewedAt: now}
+	require.NoError(planner.maybeRenewRetirementClaim(context.Background(), 428058000, fresh))
+	require.Zero(repo.renewCalls)
+	require.Equal(now, fresh.lastRenewedAt)
+
+	aged := &retirementClaim{token: "claim-token", lastRenewedAt: now.Add(-RetirementClaimLease/retirementClaimRenewalFraction - time.Second)}
+	require.NoError(planner.maybeRenewRetirementClaim(context.Background(), 428058000, aged))
+	require.Equal(1, repo.renewCalls)
+	require.True(aged.lastRenewedAt.After(now.Add(-time.Minute)))
+}
+
+func TestPlannerPrimeRetentionSafetyStartsQuiescenceClocks(t *testing.T) {
+	require := require.New(t)
+	repo := &fakeRepo{}
+	store := newFakeStore()
+	planner := testPlanner(repo, store)
+	keys := []string{
+		"BLOCKCHAIN_SOLANA/consolidated/a.cscb.zstd",
+		"BLOCKCHAIN_SOLANA/consolidated/b.cscb.zstd",
+		"BLOCKCHAIN_SOLANA/consolidated/a.cscb.zstd",
+	}
+
+	primed, err := planner.PrimeRetentionSafety(context.Background(), "priming-bucket", keys)
+	require.NoError(err)
+	require.Equal(2, primed)
+	// One bucket-level inspection covers every primed key.
+	require.Equal(1, store.policyCalls[keys[0]])
+	require.Zero(store.policyCalls[keys[1]])
+	expectedSHA256 := keySHA256("safe:" + keys[0])
+	for _, key := range keys[:2] {
+		observation, ok := repo.safetyObservations["priming-bucket\x00"+key]
+		require.True(ok)
+		require.Equal(expectedSHA256, observation.configurationSHA256)
+	}
+
+	store.policyErrors[keys[0]] = errors.New("bucket policy unreadable")
+	primed, err = planner.PrimeRetentionSafety(context.Background(), "priming-bucket", keys[:1])
+	require.Error(err)
+	require.Zero(primed)
+}
+
+func TestPlannerApply_SurfacesRemainingQuiescenceRetryAfter(t *testing.T) {
+	require := require.New(t)
+	_, repo, store, planner, _, req, report := newExecutableTestFixture(t)
+	key := report.Items[0].ConsolidatedKey
+	elapsed := 5 * time.Minute
+	repo.safetyNow = req.Now
+	repo.safetyObservations = map[string]fakeSafetyObservation{
+		req.Bucket + "\x00" + key: {
+			configurationSHA256: keySHA256("safe:" + key),
+			firstObservedAt:     req.Now.Add(-elapsed),
+		},
+	}
+
+	err := planner.Apply(context.Background(), req, report)
+	require.Error(err)
+	require.Empty(store.deleted)
+	require.Equal(SkipCSCBSafetyQuiescenceActive, report.Items[0].SkipReason)
+	require.Equal(RetentionSafetyQuiescencePeriod-elapsed, report.QuiescenceRetryAfter)
 }
 
 func activeSingleBlockTestRow(height uint64, hash string, singleBlockKey string, cscbKey string, validatedAt time.Time) MetadataRow {

--- a/internal/storage/retirement/selector.go
+++ b/internal/storage/retirement/selector.go
@@ -148,3 +148,69 @@ func (s *Selector) Select(
 	}
 	return result, hasMore, nil
 }
+
+// MaxRetentionPrimingLookahead bounds how many upcoming cohorts one Select pass
+// primes safety observations for. Two workflow batches of lookahead lets the
+// next continue-as-new run pass its quiescence gate on the first attempt.
+const MaxRetentionPrimingLookahead = 2 * MaxRetentionCohortsPerWorkflow
+
+// LookaheadKeys returns the distinct consolidated object keys of upcoming
+// retention cohorts, beyond the per-workflow selection cap, so their safety
+// quiescence clocks can be primed ahead of processing. It is advisory only:
+// selection and execution never trust its output.
+func (s *Selector) LookaheadKeys(
+	ctx context.Context,
+	bucket string,
+	storageGeneration string,
+	tag uint32,
+	startHeight uint64,
+	endHeight uint64,
+	eligibilityCutoff time.Time,
+	limit int,
+) ([]string, error) {
+	if s == nil || s.repo == nil {
+		return nil, xerrors.New("retention cohort repository is required")
+	}
+	if bucket == "" || eligibilityCutoff.IsZero() {
+		return nil, xerrors.New("retention priming lookahead requires a bucket and eligibility cutoff")
+	}
+	if !isValidStorageGeneration(storageGeneration) {
+		return nil, xerrors.Errorf("unsupported retention cohort storage generation %q", storageGeneration)
+	}
+	if limit <= 0 || limit > MaxRetentionPrimingLookahead {
+		return nil, xerrors.Errorf(
+			"retention priming lookahead limit must be between 1 and %d: %d",
+			MaxRetentionPrimingLookahead,
+			limit,
+		)
+	}
+	pending, due, err := s.repo.ListRetentionCohorts(
+		ctx,
+		bucket,
+		storageGeneration,
+		tag,
+		startHeight,
+		endHeight,
+		eligibilityCutoff,
+		limit,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list retention cohorts for priming: %w", err)
+	}
+	keys := make([]string, 0, len(pending)+len(due))
+	seen := make(map[string]struct{}, len(pending)+len(due))
+	for _, cohort := range append(pending, due...) {
+		if cohort.ConsolidatedObjectKey == "" {
+			continue
+		}
+		if _, duplicate := seen[cohort.ConsolidatedObjectKey]; duplicate {
+			continue
+		}
+		seen[cohort.ConsolidatedObjectKey] = struct{}{}
+		keys = append(keys, cohort.ConsolidatedObjectKey)
+		if len(keys) >= limit {
+			break
+		}
+	}
+	return keys, nil
+}

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -173,3 +173,42 @@ func TestDueRetentionCohortOrdering(t *testing.T) {
 	require.Equal(t, dueRetentionCohortOrderingByHeight, dueRetentionCohortOrdering(100))
 	require.Equal(t, dueRetentionCohortOrderingByDueTime, dueRetentionCohortOrdering(0))
 }
+
+func TestSelectorLookaheadKeysReturnsDistinctKeysBeyondWorkflowCap(t *testing.T) {
+	now := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
+	repo := &fakeCohortRepository{
+		pending: []RetentionCohort{{
+			ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+			StartHeight:           100,
+			EndHeight:             110,
+			RowCount:              10,
+			EligibleAt:            now,
+		}},
+		due: []RetentionCohort{
+			{
+				ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+				StartHeight:           110,
+				EndHeight:             120,
+				RowCount:              10,
+				EligibleAt:            now,
+			},
+			{
+				ConsolidatedObjectKey: "consolidated/b.cscb.zstd",
+				StartHeight:           200,
+				EndHeight:             210,
+				RowCount:              10,
+				EligibleAt:            now,
+			},
+		},
+	}
+	selector := NewSelector(repo)
+
+	keys, err := selector.LookaheadKeys(context.Background(), selectorTestBucket, "", 2, 0, 0, now, MaxRetentionPrimingLookahead)
+	require.NoError(t, err)
+	require.Equal(t, []string{"consolidated/a.cscb.zstd", "consolidated/b.cscb.zstd"}, keys)
+
+	_, err = selector.LookaheadKeys(context.Background(), selectorTestBucket, "", 2, 0, 0, now, MaxRetentionPrimingLookahead+1)
+	require.Error(t, err)
+	_, err = selector.LookaheadKeys(context.Background(), selectorTestBucket, "", 2, 0, 0, time.Time{}, 10)
+	require.Error(t, err)
+}

--- a/internal/storage/retirement/types.go
+++ b/internal/storage/retirement/types.go
@@ -190,7 +190,11 @@ type (
 		Approval    Approval    `json:"approval"`
 		SafetyGates SafetyGates `json:"safety_gates"`
 		Summary     Summary     `json:"summary"`
-		Items       []Candidate `json:"items"`
+		// QuiescenceRetryAfter is the longest remaining CSCB safety-quiescence
+		// wait observed by this pass, so a deferred run can retry when the
+		// quiescence window actually elapses instead of a full period later.
+		QuiescenceRetryAfter time.Duration `json:"quiescence_retry_after,omitempty"`
+		Items                []Candidate   `json:"items"`
 	}
 
 	SafetyGates struct {

--- a/internal/workflow/activity/single_block_retention.go
+++ b/internal/workflow/activity/single_block_retention.go
@@ -81,7 +81,11 @@ type (
 	}
 
 	SingleBlockRetentionRangeResult struct {
-		Cohort                   retirement.RetentionCohort        `json:"cohort"`
+		Cohort retirement.RetentionCohort `json:"cohort"`
+		// QuiescenceRetryAfter carries the longest remaining safety-quiescence
+		// wait the planner observed, so a deferred cohort retries when the
+		// window actually elapses instead of a full period later.
+		QuiescenceRetryAfter     time.Duration                     `json:"quiescence_retry_after,omitempty"`
 		ScannedRows              uint64                            `json:"scanned_rows"`
 		PlannedRows              uint64                            `json:"planned_rows"`
 		DeletedVerifiedRows      uint64                            `json:"deleted_verified_rows"`
@@ -139,7 +143,7 @@ func (a *SingleBlockRetention) executeSelect(
 	if err := a.selectActivity.validateRequest(request); err != nil {
 		return nil, err
 	}
-	selector, _, err := a.getComponents(ctx)
+	selector, planner, err := a.getComponents(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -182,11 +186,84 @@ func (a *SingleBlockRetention) executeSelect(
 		zap.Bool("has_more", hasMore),
 		zap.Int("limit", request.Limit),
 	)
+	a.primeRetentionSafety(ctx, selector, planner, primeRetentionSafetyRequest{
+		bucket:            bucket,
+		storageGeneration: storageGeneration,
+		tag:               tag,
+		startHeight:       request.StartHeight,
+		endHeight:         request.EndHeight,
+		eligibilityCutoff: eligibilityCutoff,
+		limit:             request.Limit,
+	})
 	sdkactivity.RecordHeartbeat(ctx, "single_block_retention.select.completed", tag, len(cohorts))
 	return &SingleBlockRetentionSelectResponse{
 		Cohorts: cohorts,
 		HasMore: hasMore,
 	}, nil
+}
+
+type primeRetentionSafetyRequest struct {
+	bucket            string
+	storageGeneration string
+	tag               uint32
+	startHeight       uint64
+	endHeight         uint64
+	eligibilityCutoff time.Time
+	limit             int
+}
+
+// retentionPrimingLookaheadWindow extends the priming cutoff beyond the frozen
+// selection cutoff so cohorts becoming due shortly after this run also have
+// their quiescence clocks running before they are first selected.
+const retentionPrimingLookaheadWindow = 2 * time.Hour
+
+// primeRetentionSafety starts the safety-quiescence clocks for the cohorts this
+// run and its successors will process. Priming is advisory: failures are logged
+// and never fail the selection, and execution still re-verifies live safety
+// configuration before deleting.
+func (a *SingleBlockRetention) primeRetentionSafety(
+	ctx context.Context,
+	selector *retirement.Selector,
+	planner *retirement.Planner,
+	request primeRetentionSafetyRequest,
+) {
+	logger := a.selectActivity.getLogger(ctx)
+	lookahead := request.limit * 2
+	if lookahead > retirement.MaxRetentionPrimingLookahead {
+		lookahead = retirement.MaxRetentionPrimingLookahead
+	}
+	if lookahead <= 0 {
+		return
+	}
+	keys, err := selector.LookaheadKeys(
+		ctx,
+		request.bucket,
+		request.storageGeneration,
+		request.tag,
+		request.startHeight,
+		request.endHeight,
+		request.eligibilityCutoff.Add(retentionPrimingLookaheadWindow),
+		lookahead,
+	)
+	if err != nil {
+		logger.Warn("failed to look ahead for retention safety priming", zap.Error(err))
+		return
+	}
+	primed, err := planner.PrimeRetentionSafety(ctx, request.bucket, keys)
+	if err != nil {
+		logger.Warn(
+			"failed to prime retention safety observations",
+			zap.Int("primed", primed),
+			zap.Int("keys", len(keys)),
+			zap.Error(err),
+		)
+		return
+	}
+	logger.Info(
+		"primed retention safety observations",
+		zap.Int("primed", primed),
+		zap.Int("keys", len(keys)),
+	)
 }
 
 func (a *SingleBlockRetention) executeProcess(
@@ -333,6 +410,7 @@ func (a *SingleBlockRetention) getComponents(
 		retirement.WithHeartbeat(func(ctx context.Context, details ...any) {
 			sdkactivity.RecordHeartbeat(ctx, details...)
 		}),
+		retirement.WithRowParallelism(a.config.Workflows.SingleBlockRetention.RowParallelism),
 	)
 	return a.selector, a.planner, nil
 }
@@ -490,6 +568,7 @@ func summarizeSingleBlockRetentionReport(
 	}
 	result := &SingleBlockRetentionRangeResult{
 		Cohort:                   cohort,
+		QuiescenceRetryAfter:     report.QuiescenceRetryAfter,
 		ScannedRows:              uint64(len(report.Items)),
 		VerifiedThroughExclusive: cohort.StartHeight,
 	}
@@ -658,6 +737,10 @@ func isDeferredRetentionReason(reason string) bool {
 	}
 }
 
+// retentionQuiescenceRetryGrace pads a remaining-quiescence retry so the retry
+// attempt lands after the window has actually closed.
+const retentionQuiescenceRetryGrace = 15 * time.Second
+
 func setSingleBlockRetentionRetry(result *SingleBlockRetentionRangeResult) bool {
 	if result == nil || result.FailedRows != 0 || result.DeferredRows == 0 || len(result.Blockers) != 1 {
 		return false
@@ -665,6 +748,10 @@ func setSingleBlockRetentionRetry(result *SingleBlockRetentionRangeResult) bool 
 	switch result.Blockers[0].Reason {
 	case retirement.SkipCSCBSafetyQuiescenceActive:
 		result.RetryAfter = retirement.RetentionSafetyQuiescencePeriod
+		if remaining := result.QuiescenceRetryAfter; remaining > 0 &&
+			remaining+retentionQuiescenceRetryGrace < result.RetryAfter {
+			result.RetryAfter = remaining + retentionQuiescenceRetryGrace
+		}
 	case retirement.SkipRetirementClaimActive:
 		result.RetryAfter = retirement.RetirementClaimLease
 	default:

--- a/internal/workflow/activity/single_block_retention_test.go
+++ b/internal/workflow/activity/single_block_retention_test.go
@@ -114,6 +114,33 @@ func TestSummarizeSingleBlockRetentionReportIdentifiesFirstIncompleteHeight(t *t
 	require.Equal(t, retirement.SkipCSCBSafetyQuiescenceActive, result.RetryReason)
 }
 
+func TestSetSingleBlockRetentionRetryUsesRemainingQuiescence(t *testing.T) {
+	result := &SingleBlockRetentionRangeResult{
+		QuiescenceRetryAfter: 10 * time.Minute,
+		DeferredRows:         1,
+		Blockers: []SingleBlockRetentionReasonCount{{
+			Reason: retirement.SkipCSCBSafetyQuiescenceActive,
+			Rows:   1,
+		}},
+	}
+
+	require.True(t, setSingleBlockRetentionRetry(result))
+	require.Equal(t, 10*time.Minute+retentionQuiescenceRetryGrace, result.RetryAfter)
+	require.Equal(t, retirement.SkipCSCBSafetyQuiescenceActive, result.RetryReason)
+
+	// Without a remaining hint (or when the padded hint would exceed the full
+	// period), the retry falls back to the full quiescence period.
+	fallback := &SingleBlockRetentionRangeResult{
+		DeferredRows: 1,
+		Blockers: []SingleBlockRetentionReasonCount{{
+			Reason: retirement.SkipCSCBSafetyQuiescenceActive,
+			Rows:   1,
+		}},
+	}
+	require.True(t, setSingleBlockRetentionRetry(fallback))
+	require.Equal(t, retirement.RetentionSafetyQuiescencePeriod, fallback.RetryAfter)
+}
+
 func TestSetSingleBlockRetentionRetryDefersActiveClaim(t *testing.T) {
 	result := &SingleBlockRetentionRangeResult{
 		DeferredRows: 1,


### PR DESCRIPTION
## Summary

Production measurement of the Aug 4-5 Solana retention shard (250k blocks in 21h at parallelism 10, 3.3 blocks/s, ~50 min per 1,000-block cohort) showed the per-cohort budget is roughly 30% mandatory quiescence sleep, 45% redundant I/O, and 25% necessary work. This PR removes the stall and the redundancy without weakening any fail-closed gate, and adds bounded row parallelism inside each cohort activity. Together these changes target roughly 10x cohort throughput on the existing retention fleet.

Linear: [INF-1327](https://linear.app/cipherowl/issue/INF-1327/cscb-speed-up-solana-single-block-retention-10-quiescence-priming) - investigation report attached to the ticket. An adversarial self-review ran against this branch; disposition of all 10 verified findings is in the PR comments, and the fixes landed in f15fff9.

## Changes

**Quiescence stall (was 15 min + a discarded Plan per fresh cohort)**
- The Select activity primes safety-quiescence observations for the selected cohorts plus a two-batch lookahead (`Selector.LookaheadKeys`, up to 500 keys, due within a 2h window). The inspected configuration (bucket policy + lifecycle) is bucket-level, but its pass/fail evaluation matches Resource ARNs and lifecycle prefixes against the specific key, so the keys[0] result is fanned out on the assumption that consolidated keys share one pattern. That assumption is an optimization only: the destructive path re-inspects every key, and a key whose own inspection disagrees records a different configuration digest there, which resets its quiescence clock and fails closed. Priming is advisory (failures are logged, never fail selection), and dry runs prime too, so the operator dry-run -> execute flow passes the gate on the first execute attempt.
- The planner reports the remaining quiescence wait (`Report.QuiescenceRetryAfter`, tracked monotonically so a later successful re-verification cannot erase it), and the activity uses it plus a 15s grace as the bounded retry delay instead of a full 15-minute period. Workflow code is untouched; replay histories still pass.

**Redundant I/O (per 1,000-row cohort)**
- `finalizeRecordedDeletion` used a fresh verifier per row, re-reading the CSCB index and a 10-block chunk ~1,000 times per cohort. Post-delete verification is now a pass-scoped verifier whose first read of each chunk happens after deletion; every row still freshly re-heads the pinned CSCB object. The accepted residual (an S3 event that keeps HEAD metadata intact while bytes become unreadable, within one chunk window) is documented at the reuse site.
- Apply's two full pre-delete revalidations (2 extra GETs + digests of the same immutable pinned version per row) collapse into one post-claim revalidation checked against Plan's persisted digest. Before `PrepareRetirement` stamps the irreversible single-block upload fence, the row re-proves its canonical metadata **and its live pinned CSCB object via fresh current + versioned HEADs** (`revalidateMetadataAndCSCB`) - a CSCB damaged between Plan and Apply fails the row without fencing it. Only the payload re-read moves after the claim.
- Bucket-safety verification (GetBucketPolicy + GetBucketLifecycleConfiguration + observation upsert per row, ~2,000 control-plane calls per cohort) is cached per pass with a one-minute revalidation interval. Preflight still verifies every cohort at pass start; a policy change is caught within one minute instead of one row. In Plan, the per-cohort head and policy loads are serialized under the shared cache lock so row parallelism cannot stampede the bucket control plane.
- Claim renewals move to lease half-life for non-destructive steps, but an **unconditional ownership fence (renewal) still runs immediately before each row's destructive delete sequence**, so a claim taken over after a long stall fails there instead of deleting unfenced.

**Row parallelism**
- Plan and Apply process independent rows with a bounded worker pool over contiguous height segments (`workflows.single_block_retention.row_parallelism`, default 0/1 = serial, **max 16**). The cap also bounds memory: each Apply worker pins up to two decompressed CSCB chunks (tens of MB each for Solana), so the ceiling must fit worker pod limits. Both Plan and Apply fan out via `errgroup`; the first error cancels the pass and unstarted rows are marked `not_attempted_after_failure`, matching the serial halt-on-failure contract. Row accounting invariants are unchanged.

## Safety

- All gates preserved: operator approval envelope, frozen eligibility cutoff, pinned version topology, write-once policy verification, post-delete CSCB payload verification, durable write-ahead manifests and claims.
- Rows are fenced only after their canonical metadata and live pinned CSCB are re-proven against S3.
- No workflow code changes: no new `GetVersion` marker needed; `single_block_retention_pre_parallelism_history.json` replay passes unchanged.
- Admin CLI paths keep serial defaults and existing behavior.

## Testing

- `make test` (fmt + lint + full unit suite) green; `go test -race` green on retirement + activity packages.
- Serial-vs-parallel equivalence test (6 rows, 2 CSCBs, parallelism 4) over locked fakes.
- New tests: fencing requires a live CSCB (`DoesNotFenceWhenCSCBVanishesAfterPlan`), priming (single inspection fan-out; inspect failure aborts priming), remaining-quiescence retry surfacing, claim-renewal throttling (exactly one destructive fence per fresh row; half-life renewal after aging), safety-cache TTL expiry re-verifies against live S3 and still fails closed on policy removal, lookahead key dedup + caps.
- Updated tests that encoded the old per-row contracts: policy verification asserted once per pass within the interval; the CSCB-change/lifecycle-expiration hooks moved to the new HEAD call ordinals (documented inline).

## Rollout

- Default behavior without config change: serial rows, priming + retry-remaining + I/O reductions active immediately.
- Prod enablement (follow-up helm change in the monorepo): set `workflows.single_block_retention.row_parallelism: 8` for solana-mainnet; retention pods may warrant 1-2 CPU (digest-bound) once parallel, and memory sizing should budget up to two decompressed chunks per worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
