### PR TITLE
feat(INF-1328): auto-launch single-block retention from cron

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,13 +441,14 @@ type (
 	}
 
 	CronConfig struct {
-		BlockRangeSize         uint64                      `mapstructure:"block_range_size" validate:"required"`
-		BatchConsolidator      BatchConsolidatorCronConfig `mapstructure:"batch_consolidator"`
-		DisableDLQProcessor    bool                        `mapstructure:"disable_dlq_processor"`
-		DisablePollingCanary   bool                        `mapstructure:"disable_polling_canary"`
-		DisableStreamingCanary bool                        `mapstructure:"disable_streaming_canary"`
-		DisableNodeCanary      bool                        `mapstructure:"disable_node_canary"`
-		DisableWorkflowStatus  bool                        `mapstructure:"disable_workflow_status"`
+		BlockRangeSize         uint64                         `mapstructure:"block_range_size" validate:"required"`
+		BatchConsolidator      BatchConsolidatorCronConfig    `mapstructure:"batch_consolidator"`
+		SingleBlockRetention   SingleBlockRetentionCronConfig `mapstructure:"single_block_retention"`
+		DisableDLQProcessor    bool                           `mapstructure:"disable_dlq_processor"`
+		DisablePollingCanary   bool                           `mapstructure:"disable_polling_canary"`
+		DisableStreamingCanary bool                           `mapstructure:"disable_streaming_canary"`
+		DisableNodeCanary      bool                           `mapstructure:"disable_node_canary"`
+		DisableWorkflowStatus  bool                           `mapstructure:"disable_workflow_status"`
 	}
 
 	BatchConsolidatorCronConfig struct {
@@ -457,6 +458,33 @@ type (
 		WorkflowParallelism int           `mapstructure:"workflow_parallelism"`
 		DelayStartDuration  time.Duration `mapstructure:"delay_start_duration"`
 		StartHeight         uint64        `mapstructure:"start_height"`
+	}
+
+	// SingleBlockRetentionCronConfig drives unattended single-block retention.
+	// Enabling it moves the operator's per-run deletion approval into reviewed
+	// configuration: the Approved* fields and the guard assertions are the
+	// standing operator input the cron passes through verbatim, and every
+	// in-workflow fail-closed gate still applies.
+	SingleBlockRetentionCronConfig struct {
+		Enabled             bool          `mapstructure:"enabled"`
+		Spec                string        `mapstructure:"spec"`
+		Parallelism         int64         `mapstructure:"parallelism"`
+		DelayStartDuration  time.Duration `mapstructure:"delay_start_duration"`
+		MaxObjectRanges     int           `mapstructure:"max_object_ranges" validate:"omitempty,gt=0,lte=250"`
+		WorkflowParallelism int           `mapstructure:"workflow_parallelism" validate:"omitempty,gt=0,lte=20"`
+		// WindowBlocks bounds each launched sweep so selection queries stay on
+		// the height index; the window is anchored at the oldest due work.
+		WindowBlocks uint64 `mapstructure:"window_blocks" validate:"omitempty,lte=2000000"`
+		// ApprovedEndHeight zero follows the consolidation frontier and
+		// requires AllowOpenEndedApproval as an explicit opt-in.
+		ApprovedChain               string `mapstructure:"approved_chain"`
+		ApprovedStartHeight         uint64 `mapstructure:"approved_start_height"`
+		ApprovedEndHeight           uint64 `mapstructure:"approved_end_height"`
+		AllowOpenEndedApproval      bool   `mapstructure:"allow_open_ended_approval"`
+		DirectStorageClientsGuarded bool   `mapstructure:"direct_storage_clients_guarded"`
+		SingleBlockWritersGuarded   bool   `mapstructure:"single_block_writers_guarded"`
+		FallbackReadsValidated      bool   `mapstructure:"fallback_reads_validated"`
+		ProductionDeleteEnabled     bool   `mapstructure:"production_delete_enabled"`
 	}
 
 	StorageConfig struct {

--- a/internal/cron/module.go
+++ b/internal/cron/module.go
@@ -29,4 +29,8 @@ var Module = fx.Options(
 		Group:  "task",
 		Target: NewBatchConsolidator,
 	}),
+	fx.Provide(fx.Annotated{
+		Group:  "task",
+		Target: NewSingleBlockRetention,
+	}),
 )

--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -40,8 +39,6 @@ type (
 		metaStorage          metastorage.MetaStorage
 		singleBlockRetention *workflow.SingleBlockRetention
 
-		selectorMu      sync.Mutex
-		selector        *retirement.Selector
 		selectorFactory func(ctx context.Context) (*retirement.Selector, error)
 	}
 )
@@ -106,6 +103,12 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 	}
 
 	workflowID := t.autoRetainWorkflowID()
+	// The open-workflow guard is best-effort dedup: workflow visibility is
+	// eventually consistent, so a manual run started moments before this tick
+	// can slip past it. Correctness never depends on exclusivity — per-row
+	// retirement claims and manifest conflict checks serialize destructive
+	// work — the guard only avoids wasted contention, and the fixed auto
+	// workflow ID makes duplicate auto launches impossible.
 	openWorkflowID, open, err := t.openSingleBlockRetentionWorkflow(ctx)
 	if err != nil {
 		return err
@@ -147,9 +150,12 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 		return err
 	}
 	eligibilityCutoff := time.Now().UTC()
-	// One height-ordered cohort probes the due set; its cost is bounded by the
-	// undeleted backlog through the partial retention-due index, never by the
-	// width of the approved range.
+	// The probe's cost is bounded by the undeleted backlog through the partial
+	// retention-due index, never by the width of the approved range. It asks
+	// for a full workflow batch because the selector sorts pending (in-flight)
+	// cohorts by prepared_at ahead of height-ordered due cohorts: anchoring on
+	// the first cohort alone could hide older due work behind a stuck pending
+	// cohort indefinitely.
 	cohorts, hasMore, err := selector.Select(
 		ctx,
 		bucket,
@@ -158,13 +164,14 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 		cronConfig.ApprovedStartHeight,
 		approvedEnd,
 		eligibilityCutoff,
-		1,
+		retirement.MaxRetentionCohortsPerWorkflow,
 	)
 	if err != nil {
 		return xerrors.Errorf("failed to probe due retention cohorts: %w", err)
 	}
 	if len(cohorts) == 0 {
 		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
+		t.metrics.Gauge("probe_backlog_truncated").Update(0)
 		t.logger.Info(
 			"single_block_retention cron found no due cohorts",
 			zap.Uint32("tag", tag),
@@ -176,9 +183,27 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 		)
 		return nil
 	}
+	// Anchor at the minimum start height and age the gauge from the oldest
+	// eligibility across the whole probe set, so neither is masked by
+	// pending-cohort ordering. Stuck pending cohorts are themselves overdue,
+	// so they keep the age alarm honest rather than silencing it.
 	anchor := cohorts[0]
-	oldestDueAge := eligibilityCutoff.Sub(anchor.EligibleAt)
+	oldestEligibleAt := cohorts[0].EligibleAt
+	for _, cohort := range cohorts[1:] {
+		if cohort.StartHeight < anchor.StartHeight {
+			anchor = cohort
+		}
+		if cohort.EligibleAt.Before(oldestEligibleAt) {
+			oldestEligibleAt = cohort.EligibleAt
+		}
+	}
+	oldestDueAge := eligibilityCutoff.Sub(oldestEligibleAt)
 	t.metrics.Gauge("oldest_due_age_seconds").Update(oldestDueAge.Seconds())
+	backlogTruncated := float64(0)
+	if hasMore {
+		backlogTruncated = 1
+	}
+	t.metrics.Gauge("probe_backlog_truncated").Update(backlogTruncated)
 
 	windowBlocks := cronConfig.WindowBlocks
 	if windowBlocks == 0 {
@@ -200,7 +225,10 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 	}
 
 	request := &workflow.SingleBlockRetentionRequest{
-		Tag:                         0,
+		// Pass the resolved tag so the sweep executes under the same tag the
+		// probe and window derivation used, even if a rolling deploy bumps the
+		// stable tag between launch and activity execution.
+		Tag:                         tag,
 		StartHeight:                 windowStart,
 		EndHeight:                   windowEnd,
 		EligibilityCutoff:           eligibilityCutoff,
@@ -338,18 +366,11 @@ func (t *singleBlockRetentionTask) openSingleBlockRetentionWorkflow(ctx context.
 	return "", false, nil
 }
 
+// getSelector resolves per tick instead of caching: the postgres factory rides
+// the process-global connection-pool cache, and re-resolving keeps the cron
+// healthy if the pool is ever closed or recycled underneath it.
 func (t *singleBlockRetentionTask) getSelector(ctx context.Context) (*retirement.Selector, error) {
-	t.selectorMu.Lock()
-	defer t.selectorMu.Unlock()
-	if t.selector != nil {
-		return t.selector, nil
-	}
-	selector, err := t.selectorFactory(ctx)
-	if err != nil {
-		return nil, err
-	}
-	t.selector = selector
-	return t.selector, nil
+	return t.selectorFactory(ctx)
 }
 
 func (t *singleBlockRetentionTask) newPostgresSelector(ctx context.Context) (*retirement.Selector, error) {

--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -1,0 +1,370 @@
+package cron
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally/v4"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/cadence"
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	metapostgres "github.com/coinbase/chainstorage/internal/storage/metastorage/postgres"
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
+	"github.com/coinbase/chainstorage/internal/utils/fxparams"
+	"github.com/coinbase/chainstorage/internal/utils/log"
+	"github.com/coinbase/chainstorage/internal/workflow"
+)
+
+type (
+	SingleBlockRetentionTaskParams struct {
+		fx.In
+		fxparams.Params
+		Config               *config.Config
+		Runtime              cadence.Runtime
+		MetaStorage          metastorage.MetaStorage
+		SingleBlockRetention *workflow.SingleBlockRetention
+	}
+
+	singleBlockRetentionTask struct {
+		config               *config.Config
+		logger               *zap.Logger
+		metrics              tally.Scope
+		runtime              cadence.Runtime
+		metaStorage          metastorage.MetaStorage
+		singleBlockRetention *workflow.SingleBlockRetention
+
+		selectorMu      sync.Mutex
+		selector        *retirement.Selector
+		selectorFactory func(ctx context.Context) (*retirement.Selector, error)
+	}
+)
+
+const (
+	autoRetainSuffix                        = "auto_retain"
+	defaultSingleBlockRetentionCronSpec     = "@every 1h"
+	defaultSingleBlockRetentionWindowBlocks = uint64(250_000)
+	singleBlockRetentionOpenPageSize        = 1000
+)
+
+func NewSingleBlockRetention(params SingleBlockRetentionTaskParams) (Task, error) {
+	task := &singleBlockRetentionTask{
+		config:               params.Config,
+		logger:               log.WithPackage(params.Logger),
+		metrics:              params.Metrics.SubScope("cron").SubScope("single_block_retention"),
+		runtime:              params.Runtime,
+		metaStorage:          params.MetaStorage,
+		singleBlockRetention: params.SingleBlockRetention,
+	}
+	task.selectorFactory = task.newPostgresSelector
+	return task, nil
+}
+
+func (t *singleBlockRetentionTask) Name() string {
+	return "single_block_retention"
+}
+
+func (t *singleBlockRetentionTask) Spec() string {
+	spec := t.config.Cron.SingleBlockRetention.Spec
+	if spec == "" {
+		return defaultSingleBlockRetentionCronSpec
+	}
+	return spec
+}
+
+func (t *singleBlockRetentionTask) Parallelism() int64 {
+	parallelism := t.config.Cron.SingleBlockRetention.Parallelism
+	if parallelism <= 0 {
+		return 1
+	}
+	return parallelism
+}
+
+func (t *singleBlockRetentionTask) Enabled() bool {
+	return t.config.Cron.SingleBlockRetention.Enabled
+}
+
+func (t *singleBlockRetentionTask) DelayStartDuration() time.Duration {
+	return t.config.Cron.SingleBlockRetention.DelayStartDuration
+}
+
+// Run launches at most one bounded execute sweep anchored at the oldest due
+// retention work. Eligibility is database state (a row leaves the due set only
+// when its retirement is finalized as deleted-and-verified), so anchoring every
+// window at the due minimum guarantees deferred, failed, or repair-re-created
+// rows are re-selected by a later tick instead of skipped past.
+func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
+	cronConfig := t.config.Cron.SingleBlockRetention
+	if err := t.validateStandingApproval(cronConfig); err != nil {
+		return err
+	}
+
+	workflowID := t.autoRetainWorkflowID()
+	openWorkflowID, open, err := t.openSingleBlockRetentionWorkflow(ctx)
+	if err != nil {
+		return err
+	}
+	if open {
+		t.logger.Info(
+			"single_block_retention cron skipped because a retention workflow is already open",
+			zap.String("open_workflow_id", openWorkflowID),
+			zap.String("auto_workflow_id", workflowID),
+		)
+		return nil
+	}
+
+	tag := t.config.GetEffectiveBlockTag(0)
+	approvedEnd, err := t.resolveApprovedEndHeight(ctx, cronConfig, tag)
+	if err != nil {
+		return err
+	}
+	if approvedEnd <= cronConfig.ApprovedStartHeight {
+		t.logger.Info(
+			"single_block_retention cron has no approved range yet",
+			zap.Uint32("tag", tag),
+			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
+			zap.Uint64("approved_end_height", approvedEnd),
+		)
+		return nil
+	}
+
+	bucket, err := t.config.WriteBlockStorageBucket()
+	if err != nil {
+		return xerrors.Errorf("failed to resolve write block storage bucket: %w", err)
+	}
+	storageGeneration, err := t.config.WriteBlockStorageGeneration()
+	if err != nil {
+		return xerrors.Errorf("failed to resolve write block storage generation: %w", err)
+	}
+	selector, err := t.getSelector(ctx)
+	if err != nil {
+		return err
+	}
+	eligibilityCutoff := time.Now().UTC()
+	// One height-ordered cohort probes the due set; its cost is bounded by the
+	// undeleted backlog through the partial retention-due index, never by the
+	// width of the approved range.
+	cohorts, hasMore, err := selector.Select(
+		ctx,
+		bucket,
+		storageGeneration,
+		tag,
+		cronConfig.ApprovedStartHeight,
+		approvedEnd,
+		eligibilityCutoff,
+		1,
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to probe due retention cohorts: %w", err)
+	}
+	if len(cohorts) == 0 {
+		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
+		t.logger.Info(
+			"single_block_retention cron found no due cohorts",
+			zap.Uint32("tag", tag),
+			zap.String("bucket", bucket),
+			zap.String("storage_generation", storageGeneration),
+			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
+			zap.Uint64("approved_end_height", approvedEnd),
+			zap.Bool("has_more", hasMore),
+		)
+		return nil
+	}
+	anchor := cohorts[0]
+	oldestDueAge := eligibilityCutoff.Sub(anchor.EligibleAt)
+	t.metrics.Gauge("oldest_due_age_seconds").Update(oldestDueAge.Seconds())
+
+	windowBlocks := cronConfig.WindowBlocks
+	if windowBlocks == 0 {
+		windowBlocks = defaultSingleBlockRetentionWindowBlocks
+	}
+	// The selected cohort lies inside the approved range, so the window is
+	// always non-empty; it is clipped to keep each sweep bounded.
+	windowStart := anchor.StartHeight
+	windowEnd := approvedEnd
+	if windowEnd-windowStart > windowBlocks {
+		windowEnd = windowStart + windowBlocks
+	}
+	if windowEnd <= windowStart {
+		return xerrors.Errorf(
+			"single_block_retention cron derived an invalid window [%d, %d)",
+			windowStart,
+			windowEnd,
+		)
+	}
+
+	request := &workflow.SingleBlockRetentionRequest{
+		Tag:                         0,
+		StartHeight:                 windowStart,
+		EndHeight:                   windowEnd,
+		EligibilityCutoff:           eligibilityCutoff,
+		MaxObjectRanges:             cronConfig.MaxObjectRanges,
+		Parallelism:                 cronConfig.WorkflowParallelism,
+		Execute:                     true,
+		ProductionDeleteEnabled:     cronConfig.ProductionDeleteEnabled,
+		DirectStorageClientsGuarded: cronConfig.DirectStorageClientsGuarded,
+		SingleBlockWritersGuarded:   cronConfig.SingleBlockWritersGuarded,
+		FallbackReadsValidated:      cronConfig.FallbackReadsValidated,
+		FallbackErrorCount:          0,
+		ApprovedChain:               cronConfig.ApprovedChain,
+		ApprovedStartHeight:         cronConfig.ApprovedStartHeight,
+		ApprovedEndHeight:           approvedEnd,
+	}
+	workflowCtx := workflow.WithWorkflowID(ctx, workflowID)
+	run, err := t.singleBlockRetention.Execute(workflowCtx, request)
+	if err != nil {
+		if isWorkflowAlreadyStarted(err) {
+			t.logger.Info(
+				"single_block_retention cron skipped because a retention workflow was already started",
+				zap.String("workflow_id", workflowID),
+			)
+			return nil
+		}
+		return xerrors.Errorf("failed to start single_block_retention cron workflow: %w", err)
+	}
+	t.metrics.Counter("launched").Inc(1)
+	t.logger.Info(
+		"started single_block_retention cron workflow",
+		zap.String("workflow_id", workflowID),
+		zap.String("run_id", run.GetRunID()),
+		zap.Uint32("tag", tag),
+		zap.String("bucket", bucket),
+		zap.String("storage_generation", storageGeneration),
+		zap.Uint64("window_start_height", windowStart),
+		zap.Uint64("window_end_height", windowEnd),
+		zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
+		zap.Uint64("approved_end_height", approvedEnd),
+		zap.Time("eligibility_cutoff", eligibilityCutoff),
+		zap.Duration("oldest_due_age", oldestDueAge),
+		zap.Int("max_object_ranges", cronConfig.MaxObjectRanges),
+		zap.Int("workflow_parallelism", cronConfig.WorkflowParallelism),
+	)
+	return nil
+}
+
+// validateStandingApproval fails closed unless the reviewed configuration
+// carries the complete operator approval a manual launch would have supplied.
+func (t *singleBlockRetentionTask) validateStandingApproval(cronConfig config.SingleBlockRetentionCronConfig) error {
+	if t.config.StorageType.MetaStorageType != config.MetaStorageType_POSTGRES || t.config.AWS.Postgres == nil {
+		return xerrors.New("single_block_retention cron requires Postgres meta storage")
+	}
+	if cronConfig.ApprovedChain == "" {
+		return xerrors.New("single_block_retention cron requires cron.single_block_retention.approved_chain")
+	}
+	if cronConfig.ApprovedEndHeight == 0 && !cronConfig.AllowOpenEndedApproval {
+		return xerrors.New("single_block_retention cron requires approved_end_height or the explicit allow_open_ended_approval opt-in")
+	}
+	if cronConfig.ApprovedEndHeight != 0 && cronConfig.ApprovedEndHeight <= cronConfig.ApprovedStartHeight {
+		return xerrors.Errorf(
+			"single_block_retention cron approved range [%d, %d) is invalid",
+			cronConfig.ApprovedStartHeight,
+			cronConfig.ApprovedEndHeight,
+		)
+	}
+	if !cronConfig.DirectStorageClientsGuarded {
+		return xerrors.New("single_block_retention cron requires direct_storage_clients_guarded")
+	}
+	if !cronConfig.SingleBlockWritersGuarded {
+		return xerrors.New("single_block_retention cron requires single_block_writers_guarded")
+	}
+	if !cronConfig.FallbackReadsValidated {
+		return xerrors.New("single_block_retention cron requires fallback_reads_validated")
+	}
+	if isProductionRetentionCronEnvironment(t.config.Env()) && !cronConfig.ProductionDeleteEnabled {
+		return xerrors.New("single_block_retention cron requires production_delete_enabled in production")
+	}
+	return nil
+}
+
+// resolveApprovedEndHeight resolves an open-ended standing approval to the
+// consolidation frontier: everything below the auto-consolidate cursor is
+// consolidated, and rows only become due after promotion stamps their
+// retention deadline, so the cursor is a safe, monotonic envelope end.
+func (t *singleBlockRetentionTask) resolveApprovedEndHeight(
+	ctx context.Context,
+	cronConfig config.SingleBlockRetentionCronConfig,
+	tag uint32,
+) (uint64, error) {
+	if cronConfig.ApprovedEndHeight != 0 {
+		return cronConfig.ApprovedEndHeight, nil
+	}
+	cursorHeight, cursorFound, err := t.metaStorage.GetBlockConsolidationCursor(
+		ctx,
+		metastorage.BatchConsolidatorAutoConsolidateCursor,
+		tag,
+	)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to resolve consolidation cursor for open-ended retention approval: %w", err)
+	}
+	if !cursorFound {
+		t.logger.Info(
+			"single_block_retention cron found no consolidation cursor for open-ended approval",
+			zap.Uint32("tag", tag),
+		)
+		return 0, nil
+	}
+	return cursorHeight, nil
+}
+
+func (t *singleBlockRetentionTask) autoRetainWorkflowID() string {
+	return fmt.Sprintf("%s/%s", t.config.Workflows.SingleBlockRetention.WorkflowIdentity, autoRetainSuffix)
+}
+
+func (t *singleBlockRetentionTask) openSingleBlockRetentionWorkflow(ctx context.Context) (string, bool, error) {
+	workflowIdentity := t.config.Workflows.SingleBlockRetention.WorkflowIdentity
+	openWorkflows, err := t.runtime.ListOpenWorkflows(
+		ctx,
+		t.config.Cadence.Domain,
+		singleBlockRetentionOpenPageSize,
+		workflowIdentity,
+	)
+	if err != nil {
+		return "", false, xerrors.Errorf("failed to list open workflows for single_block_retention cron: %w", err)
+	}
+	if openWorkflows == nil {
+		return "", false, nil
+	}
+	for _, wf := range openWorkflows.Executions {
+		if wf.GetType().GetName() == workflowIdentity {
+			return wf.GetExecution().GetWorkflowId(), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func (t *singleBlockRetentionTask) getSelector(ctx context.Context) (*retirement.Selector, error) {
+	t.selectorMu.Lock()
+	defer t.selectorMu.Unlock()
+	if t.selector != nil {
+		return t.selector, nil
+	}
+	selector, err := t.selectorFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	t.selector = selector
+	return t.selector, nil
+}
+
+func (t *singleBlockRetentionTask) newPostgresSelector(ctx context.Context) (*retirement.Selector, error) {
+	pool, err := metapostgres.GetConnectionPool(ctx, t.config.AWS.Postgres)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get single_block_retention cron Postgres pool: %w", err)
+	}
+	db := pool.DB()
+	if db == nil {
+		return nil, xerrors.New("single_block_retention cron Postgres pool returned a nil database")
+	}
+	return retirement.NewSelector(retirement.NewPostgresRepository(db)), nil
+}
+
+func isProductionRetentionCronEnvironment(env config.Env) bool {
+	value := strings.ToLower(string(env))
+	return value == "production" || value == "prod"
+}

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -154,9 +154,41 @@ func TestSingleBlockRetentionCronLaunchesWindowAnchoredAtOldestDueCohort(t *test
 	require.False(t, request.EligibilityCutoff.IsZero())
 	require.WithinDuration(t, time.Now().UTC(), request.EligibilityCutoff, time.Minute)
 	require.Nil(t, request.Checkpoint)
-	// The probe walks the approved envelope, not an unbounded range.
+	require.Equal(t, cfg.GetEffectiveBlockTag(0), request.Tag)
+	// The probe walks the approved envelope, not an unbounded range, and asks
+	// for a full workflow batch so pending-cohort ordering cannot mask the
+	// oldest due work.
 	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
 	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, cohortRepository.requestedEndHeight)
+	require.Equal(t, retirement.MaxRetentionCohortsPerWorkflow+1, cohortRepository.requestedLimit)
+}
+
+func TestSingleBlockRetentionCronAnchorsBelowPendingCohorts(t *testing.T) {
+	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	// A stuck in-flight cohort near the envelope tail sorts ahead of due
+	// cohorts in the selector merge; the window must still anchor at the
+	// lowest height in the probe set.
+	cohortRepository.pending = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/stuck.cscb.zstd",
+		StartHeight:           436_900_000,
+		EndHeight:             436_901_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-30 * time.Minute),
+	}}
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/oldest.cscb.zstd",
+		StartHeight:           424_000_000,
+		EndHeight:             424_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-48 * time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.Equal(t, uint64(424_000_000), request.StartHeight)
+	require.Equal(t, uint64(425_000_000), request.EndHeight)
 }
 
 func TestSingleBlockRetentionCronClipsWindowToApprovedEnd(t *testing.T) {

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -50,7 +50,7 @@ func (r *retentionCronCohortRepository) ListRetentionCohorts(
 	return r.pending, r.due, nil
 }
 
-func newSingleBlockRetentionCronTask(t *testing.T) (
+func newSingleBlockRetentionCronTask(t *testing.T, configOpts ...config.ConfigOption) (
 	*singleBlockRetentionTask,
 	*batchConsolidatorCronRuntime,
 	*retentionCronCohortRepository,
@@ -59,7 +59,7 @@ func newSingleBlockRetentionCronTask(t *testing.T) (
 	*gomock.Controller,
 ) {
 	t.Helper()
-	cfg, err := config.New()
+	cfg, err := config.New(configOpts...)
 	require.NoError(t, err)
 	cfg.Chain.BlockTag.Stable = 2
 	cfg.Chain.BlockTag.Latest = 2
@@ -335,6 +335,17 @@ func TestSingleBlockRetentionCronFailsClosedOnIncompleteStandingApproval(t *test
 			require.Empty(t, runtime.executions)
 		})
 	}
+}
+
+func TestSingleBlockRetentionCronRequiresProductionDeleteEnablementInProduction(t *testing.T) {
+	task, runtime, _, _, cfg, ctrl := newSingleBlockRetentionCronTask(t, config.WithEnvironment(config.EnvProduction))
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.ProductionDeleteEnabled = false
+
+	err := task.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "production_delete_enabled")
+	require.Empty(t, runtime.executions)
 }
 
 func TestSingleBlockRetentionCronPropagatesProbeErrors(t *testing.T) {

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -1,0 +1,329 @@
+package cron
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally/v4"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/coinbase/chainstorage/internal/cadence"
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/metastorage"
+	metastoragemocks "github.com/coinbase/chainstorage/internal/storage/metastorage/mocks"
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
+	"github.com/coinbase/chainstorage/internal/utils/fxparams"
+	workflowpkg "github.com/coinbase/chainstorage/internal/workflow"
+	workflowactivity "github.com/coinbase/chainstorage/internal/workflow/activity"
+)
+
+type retentionCronCohortRepository struct {
+	pending []retirement.RetentionCohort
+	due     []retirement.RetentionCohort
+	err     error
+
+	requestedStartHeight uint64
+	requestedEndHeight   uint64
+	requestedLimit       int
+}
+
+func (r *retentionCronCohortRepository) ListRetentionCohorts(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ uint32,
+	startHeight uint64,
+	endHeight uint64,
+	_ time.Time,
+	limit int,
+) ([]retirement.RetentionCohort, []retirement.RetentionCohort, error) {
+	r.requestedStartHeight = startHeight
+	r.requestedEndHeight = endHeight
+	r.requestedLimit = limit
+	if r.err != nil {
+		return nil, nil, r.err
+	}
+	return r.pending, r.due, nil
+}
+
+func newSingleBlockRetentionCronTask(t *testing.T) (
+	*singleBlockRetentionTask,
+	*batchConsolidatorCronRuntime,
+	*retentionCronCohortRepository,
+	*metastoragemocks.MockMetaStorage,
+	*config.Config,
+	*gomock.Controller,
+) {
+	t.Helper()
+	cfg, err := config.New()
+	require.NoError(t, err)
+	cfg.Chain.BlockTag.Stable = 2
+	cfg.Chain.BlockTag.Latest = 2
+	cfg.StorageType.MetaStorageType = config.MetaStorageType_POSTGRES
+	cfg.AWS.Postgres = &config.PostgresConfig{}
+	cfg.Cron.SingleBlockRetention = config.SingleBlockRetentionCronConfig{
+		Enabled:                     true,
+		MaxObjectRanges:             250,
+		WorkflowParallelism:         10,
+		WindowBlocks:                1_000_000,
+		ApprovedChain:               "solana-mainnet",
+		ApprovedStartHeight:         423_300_000,
+		ApprovedEndHeight:           437_068_000,
+		DirectStorageClientsGuarded: true,
+		SingleBlockWritersGuarded:   true,
+		FallbackReadsValidated:      true,
+		ProductionDeleteEnabled:     true,
+	}
+
+	logger := zaptest.NewLogger(t)
+	runtime := &batchConsolidatorCronRuntime{logger: logger}
+	activity := workflowactivity.NewSingleBlockRetention(workflowactivity.SingleBlockRetentionParams{
+		Params: fxparams.Params{
+			Config:  cfg,
+			Logger:  logger,
+			Metrics: tally.NoopScope,
+		},
+		Runtime: runtime,
+	})
+	retentionWorkflow := workflowpkg.NewSingleBlockRetention(workflowpkg.SingleBlockRetentionParams{
+		Params: fxparams.Params{
+			Config:  cfg,
+			Logger:  logger,
+			Metrics: tally.NoopScope,
+		},
+		Runtime:  runtime,
+		Activity: activity,
+	})
+	ctrl := gomock.NewController(t)
+	metaStorage := metastoragemocks.NewMockMetaStorage(ctrl)
+	task, err := NewSingleBlockRetention(SingleBlockRetentionTaskParams{
+		Params: fxparams.Params{
+			Config:  cfg,
+			Logger:  logger,
+			Metrics: tally.NoopScope,
+		},
+		Config:               cfg,
+		Runtime:              runtime,
+		MetaStorage:          metaStorage,
+		SingleBlockRetention: retentionWorkflow,
+	})
+	require.NoError(t, err)
+	retentionTask := task.(*singleBlockRetentionTask)
+	cohortRepository := &retentionCronCohortRepository{}
+	retentionTask.selectorFactory = func(ctx context.Context) (*retirement.Selector, error) {
+		return retirement.NewSelector(cohortRepository), nil
+	}
+	return retentionTask, runtime, cohortRepository, metaStorage, cfg, ctrl
+}
+
+var _ cadence.Runtime = (*batchConsolidatorCronRuntime)(nil)
+
+func TestSingleBlockRetentionCronLaunchesWindowAnchoredAtOldestDueCohort(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+		StartHeight:           430_000_000,
+		EndHeight:             430_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	require.Equal(t, "workflow.single_block_retention/auto_retain", runtime.executions[0].options.ID)
+	request, ok := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.True(t, ok)
+	require.True(t, request.Execute)
+	require.Equal(t, uint64(430_000_000), request.StartHeight)
+	require.Equal(t, uint64(431_000_000), request.EndHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedChain, request.ApprovedChain)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, request.ApprovedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, request.ApprovedEndHeight)
+	require.Equal(t, 250, request.MaxObjectRanges)
+	require.Equal(t, 10, request.Parallelism)
+	require.True(t, request.ProductionDeleteEnabled)
+	require.True(t, request.DirectStorageClientsGuarded)
+	require.True(t, request.SingleBlockWritersGuarded)
+	require.True(t, request.FallbackReadsValidated)
+	require.Zero(t, request.FallbackErrorCount)
+	require.False(t, request.EligibilityCutoff.IsZero())
+	require.WithinDuration(t, time.Now().UTC(), request.EligibilityCutoff, time.Minute)
+	require.Nil(t, request.Checkpoint)
+	// The probe walks the approved envelope, not an unbounded range.
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, cohortRepository.requestedEndHeight)
+}
+
+func TestSingleBlockRetentionCronClipsWindowToApprovedEnd(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 1_000_000
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/tail.cscb.zstd",
+		StartHeight:           437_000_000,
+		EndHeight:             437_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.Equal(t, uint64(437_000_000), request.StartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, request.EndHeight)
+}
+
+func TestSingleBlockRetentionCronIdlesWhenNothingIsDue(t *testing.T) {
+	task, runtime, _, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestSingleBlockRetentionCronSkipsWhenRetentionWorkflowIsOpen(t *testing.T) {
+	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	runtime.openWorkflowID = []string{"workflow.single_block_retention/manual_run"}
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+		StartHeight:           430_000_000,
+		EndHeight:             430_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+	require.Equal(t, "workflow.single_block_retention", runtime.requestedWorkflowType)
+}
+
+func TestSingleBlockRetentionCronResolvesOpenEndedApprovalFromConsolidationCursor(t *testing.T) {
+	task, runtime, cohortRepository, metaStorage, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.ApprovedEndHeight = 0
+	cfg.Cron.SingleBlockRetention.AllowOpenEndedApproval = true
+	tag := cfg.GetEffectiveBlockTag(0)
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), metastorage.BatchConsolidatorAutoConsolidateCursor, tag).
+		Return(uint64(438_000_000), true, nil)
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+		StartHeight:           430_000_000,
+		EndHeight:             430_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.Equal(t, uint64(438_000_000), request.ApprovedEndHeight)
+	require.Equal(t, uint64(430_000_000), request.StartHeight)
+	require.Equal(t, uint64(431_000_000), request.EndHeight)
+}
+
+func TestSingleBlockRetentionCronIdlesWithoutConsolidationCursor(t *testing.T) {
+	task, runtime, _, metaStorage, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.ApprovedEndHeight = 0
+	cfg.Cron.SingleBlockRetention.AllowOpenEndedApproval = true
+	metaStorage.EXPECT().
+		GetBlockConsolidationCursor(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(uint64(0), false, nil)
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+}
+
+func TestSingleBlockRetentionCronFailsClosedOnIncompleteStandingApproval(t *testing.T) {
+	testCases := []struct {
+		name     string
+		mutate   func(cronConfig *config.SingleBlockRetentionCronConfig)
+		expected string
+	}{
+		{
+			name: "missing approved chain",
+			mutate: func(cronConfig *config.SingleBlockRetentionCronConfig) {
+				cronConfig.ApprovedChain = ""
+			},
+			expected: "approved_chain",
+		},
+		{
+			name: "open-ended without opt-in",
+			mutate: func(cronConfig *config.SingleBlockRetentionCronConfig) {
+				cronConfig.ApprovedEndHeight = 0
+				cronConfig.AllowOpenEndedApproval = false
+			},
+			expected: "allow_open_ended_approval",
+		},
+		{
+			name: "inverted approved range",
+			mutate: func(cronConfig *config.SingleBlockRetentionCronConfig) {
+				cronConfig.ApprovedEndHeight = cronConfig.ApprovedStartHeight
+			},
+			expected: "is invalid",
+		},
+		{
+			name: "direct storage clients unguarded",
+			mutate: func(cronConfig *config.SingleBlockRetentionCronConfig) {
+				cronConfig.DirectStorageClientsGuarded = false
+			},
+			expected: "direct_storage_clients_guarded",
+		},
+		{
+			name: "single-block writers unguarded",
+			mutate: func(cronConfig *config.SingleBlockRetentionCronConfig) {
+				cronConfig.SingleBlockWritersGuarded = false
+			},
+			expected: "single_block_writers_guarded",
+		},
+		{
+			name: "fallback reads unvalidated",
+			mutate: func(cronConfig *config.SingleBlockRetentionCronConfig) {
+				cronConfig.FallbackReadsValidated = false
+			},
+			expected: "fallback_reads_validated",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			task, runtime, _, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+			defer ctrl.Finish()
+			testCase.mutate(&cfg.Cron.SingleBlockRetention)
+
+			err := task.Run(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), testCase.expected)
+			require.Empty(t, runtime.executions)
+		})
+	}
+}
+
+func TestSingleBlockRetentionCronPropagatesProbeErrors(t *testing.T) {
+	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.err = errors.New("connection reset")
+
+	err := task.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to probe due retention cohorts")
+	require.Empty(t, runtime.executions)
+}
+
+func TestSingleBlockRetentionCronDefaults(t *testing.T) {
+	task, _, _, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+
+	require.Equal(t, "single_block_retention", task.Name())
+	require.Equal(t, defaultSingleBlockRetentionCronSpec, task.Spec())
+	require.Equal(t, int64(1), task.Parallelism())
+	require.True(t, task.Enabled())
+	cfg.Cron.SingleBlockRetention.Enabled = false
+	require.False(t, task.Enabled())
+}


### PR DESCRIPTION
## Summary

Retention execute sweeps are launched manually per shard today (compute range, dry run, capture cutoff, execute with an approval envelope, monitor). This PR adds an app-level cron task - modeled on the `auto_consolidate` launcher in `internal/cron/batch_consolidator.go` - that keeps v2 single-block retention running unattended: each tick finds the oldest eligible work and drives one bounded execute sweep over it.

Linear: [INF-1328](https://linear.app/cipherowl/issue/INF-1328/cscb-auto-launch-single-block-retention-from-cron-continuous-sweep-of). An adversarial self-review ran against this branch; disposition of all 5 verified findings is in the PR comments, with fixes in 68ab922 and the production-gate test in c2fc4c3.

## How it works

Each tick of `cron.single_block_retention`:

1. **Fails closed on incomplete standing approval** - the reviewed config must carry `approved_chain`, a valid approved range (or the explicit `allow_open_ended_approval` opt-in), all three guard assertions, and `production_delete_enabled` in production.
2. **Open-workflow guard** - skips the tick if any `workflow.single_block_retention` execution is visible. This is best-effort dedup: workflow visibility is eventually consistent, so a manual run started moments before a tick can slip past it. Correctness never depends on exclusivity - per-row retirement claims (leased, token-fenced) and manifest conflict checks serialize destructive work - the guard only avoids wasted contention, and the fixed `workflow.single_block_retention/auto_retain` ID makes duplicate auto launches impossible.
3. **Probes the due set with a full workflow batch** (`MaxRetentionCohortsPerWorkflow` cohorts) over the approved envelope. Selection cost is bounded by the undeleted backlog through the partial `idx_block_consolidation_shadow_retention_due` index, never by the width of the range. The full batch matters because the selector sorts pending (in-flight) cohorts by `prepared_at` ahead of height-ordered due cohorts: a limit-1 probe could starve older due work behind a stuck pending cohort.
4. **Anchors a bounded window at the minimum start height across the probe set** - `[min_start, min_start + window_blocks)` clipped to the envelope (default 250k blocks) - and launches one execute sweep with the resolved effective tag and `EligibilityCutoff = now`, which freezes that tick's destructive set exactly like the manual dry-run-then-execute flow does.
5. The workflow continues-as-new to `sweep_completed`; the next tick re-probes.

## Why nothing gets left behind

Eligibility is database state, not a cursor: a row leaves the due set only when its retirement is finalized as deleted-and-verified. Deferrals, failures, crashes, expired claims, and repair-re-created rows all stay in (or return to) the due set, and because every window is anchored at the minimum height across a full probe batch, a later tick always re-selects them - a stuck in-flight cohort cannot mask older due work. A stuck row pins the anchor, stalls the window, and surfaces through the `cron.single_block_retention.oldest_due_age_seconds` gauge, which ages from the oldest eligibility across the whole probe set (stuck pending cohorts are themselves overdue, so they raise the alarm instead of silencing it); `probe_backlog_truncated` exports whether the probe hit its batch limit. Target deletion lag: 72h retention + one cron interval.

## Approval model

Enabling the cron moves the per-run operator approval into reviewed configuration (`approved_chain`, `approved_start_height`, `approved_end_height`, guard assertions). An open-ended envelope (`approved_end_height: 0`) requires the explicit `allow_open_ended_approval: true` opt-in and resolves each tick to the auto-consolidate cursor. Every in-workflow fail-closed gate - per-cohort envelope containment, chain match, frozen cutoff, pinned version topology, write-once policy verification, post-delete CSCB payload verification - is untouched; the cron only replaces who types the numbers.

## Testing

- `make test` (fmt + lint + full unit suite) green; cron package green under `-race`.
- Tests mirror the batch-consolidator harness: window anchoring below pending cohorts (starvation regression), window clipping, envelope-bounded full-batch probe, resolved-tag passthrough, idle tick, open-workflow skip, open-ended approval resolution from the consolidation cursor (and idle without one), fail-closed table over every incomplete-approval case **including the production `production_delete_enabled` gate under a production config**, probe error propagation, and task defaults.

## Rollout

Disabled by default everywhere. Enabling for solana-mainnet prod is a follow-up reviewed helm change in the monorepo (`config.cron.single_block_retention` + the standing approval + the oldest-due-age alert). Best landed together with INF-1327 (chainstorage #191): without quiescence priming, every fresh cohort in auto mode still pays the 15-minute stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
