### PR TITLE
feat(INF-1288): safely rehome fenced CSCB metadata

### DIFF
--- a/cmd/admin/generation_rehome.go
+++ b/cmd/admin/generation_rehome.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/aws"
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/s3"
+	"github.com/coinbase/chainstorage/internal/storage/generationrehome"
+)
+
+type fencedGenerationRehomeFlags struct {
+	tag                     uint32
+	copyLedger              string
+	targetGeneration        string
+	execute                 bool
+	confirmProductionRehome bool
+	approveChain            string
+	approveObjects          uint64
+	approveRows             uint64
+	approveTransition       string
+	reportFile              string
+}
+
+var fencedRehomeFlags fencedGenerationRehomeFlags
+
+func newFencedGenerationRehomeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rehome-fenced-consolidated-generation",
+		Short: "audit or execute an exact legacy-null to v2 CSCB metadata rehome",
+		Long: `Verify copied, immutable source and destination S3 versions plus the exact Postgres
+placement and retirement cohort before changing consolidated metadata from legacy SQL NULL to v2.
+
+The command reads the append-only copy ledger and selects only audit objects with fenced rows. It is
+dry-run by default. Execution uses one object-scoped transaction at a time, holds the CSCB repair tag
+and object locks, writes an immutable database audit row, updates only primary and consolidated
+storage generation columns, and revalidates before commit. The deleted single-block generation is
+never changed. Production execution requires the explicit confirmation and exact cohort approvals.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFencedGenerationRehome(cmd.Context(), fencedRehomeFlags)
+		},
+	}
+	cmd.Flags().Uint32Var(&fencedRehomeFlags.tag, "tag", 0, "block tag; default zero resolves to the configured stable tag")
+	cmd.Flags().StringVar(&fencedRehomeFlags.copyLedger, "copy-ledger", "", "append-only legacy CSCB audit/copy progress JSONL")
+	cmd.Flags().StringVar(&fencedRehomeFlags.targetGeneration, "target-generation", "v2", "configured destination storage generation; this exception is restricted to v2")
+	cmd.Flags().BoolVar(&fencedRehomeFlags.execute, "execute", false, "execute guarded object-scoped metadata transitions")
+	cmd.Flags().BoolVar(&fencedRehomeFlags.confirmProductionRehome, "confirm-production-rehome", false, "second explicit gate required with --execute in production")
+	cmd.Flags().StringVar(&fencedRehomeFlags.approveChain, "approve-chain", "", "exact chain approval, e.g. solana-mainnet")
+	cmd.Flags().Uint64Var(&fencedRehomeFlags.approveObjects, "approve-objects", 0, "exact fenced object count approval")
+	cmd.Flags().Uint64Var(&fencedRehomeFlags.approveRows, "approve-rows", 0, "exact referenced row count approval")
+	cmd.Flags().StringVar(&fencedRehomeFlags.approveTransition, "approve-transition", "", "exact transition approval: legacy-null-to-v2")
+	cmd.Flags().StringVar(&fencedRehomeFlags.reportFile, "report-file", "", "write the final JSON report to this file instead of stdout")
+	_ = cmd.MarkFlagRequired("copy-ledger")
+	return cmd
+}
+
+func runFencedGenerationRehome(ctx context.Context, flags fencedGenerationRehomeFlags) error {
+	if flags.execute && isProductionEnvironment(commonFlags.env) && !flags.confirmProductionRehome {
+		return xerrors.New("production execution requires --execute and --confirm-production-rehome")
+	}
+	ledger, err := os.Open(flags.copyLedger)
+	if err != nil {
+		return xerrors.Errorf("failed to open copy ledger %s: %w", flags.copyLedger, err)
+	}
+	objects, err := generationrehome.LoadFencedCopyLedger(ledger)
+	_ = ledger.Close()
+	if err != nil {
+		return xerrors.Errorf("failed to load fenced copy ledger: %w", err)
+	}
+
+	var deps struct {
+		fx.In
+		S3Client s3.Client
+	}
+	app := startApp(aws.Module, s3.Module, fx.Populate(&deps))
+	defer app.Close()
+	cfg := app.Config()
+	if cfg.StorageType.MetaStorageType != config.MetaStorageType_POSTGRES || cfg.AWS.Postgres == nil {
+		return xerrors.New("fenced storage generation rehome requires Postgres meta storage")
+	}
+	if cfg.StorageType.BlobStorageType != config.BlobStorageType_UNSPECIFIED && cfg.StorageType.BlobStorageType != config.BlobStorageType_S3 {
+		return xerrors.Errorf("fenced storage generation rehome requires S3 blob storage, got %v", cfg.StorageType.BlobStorageType)
+	}
+
+	writeGeneration, err := cfg.WriteBlockStorageGeneration()
+	if err != nil {
+		return xerrors.Errorf("failed to resolve write block storage generation: %w", err)
+	}
+	if writeGeneration != flags.targetGeneration {
+		return xerrors.Errorf("target generation %q is not the active write generation %q", flags.targetGeneration, writeGeneration)
+	}
+	sourceBucket, err := cfg.ResolveBlockStorageBucket("")
+	if err != nil {
+		return xerrors.Errorf("failed to resolve legacy source bucket: %w", err)
+	}
+	destinationBucket, err := cfg.ResolveBlockStorageBucket(flags.targetGeneration)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve destination bucket: %w", err)
+	}
+	tag := cfg.GetEffectiveBlockTag(flags.tag)
+	chain := approvalChainFromFlags()
+
+	logger.Info("running fenced consolidated storage generation rehome",
+		zap.String("environment", string(cfg.Env())),
+		zap.String("chain", chain),
+		zap.Uint32("tag", tag),
+		zap.String("source_bucket", sourceBucket),
+		zap.String("destination_bucket", destinationBucket),
+		zap.String("target_generation", flags.targetGeneration),
+		zap.Int("objects", len(objects)),
+		zap.Bool("execute", flags.execute),
+	)
+
+	db, err := openRetirementPostgres(ctx, cfg.AWS.Postgres, !flags.execute)
+	if err != nil {
+		return xerrors.Errorf("failed to open generation rehome postgres connection: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	service := generationrehome.NewService(
+		generationrehome.NewPostgresRepository(db),
+		generationrehome.NewS3ObjectStore(deps.S3Client),
+	)
+	report, runErr := service.Run(ctx, generationrehome.Request{
+		Environment:       string(cfg.Env()),
+		Chain:             chain,
+		Tag:               tag,
+		SourceBucket:      sourceBucket,
+		DestinationBucket: destinationBucket,
+		TargetGeneration:  flags.targetGeneration,
+		Execute:           flags.execute,
+		Approval: generationrehome.Approval{
+			Chain:      flags.approveChain,
+			Objects:    flags.approveObjects,
+			Rows:       flags.approveRows,
+			Transition: flags.approveTransition,
+		},
+		Progress: func(completed int, total int, item generationrehome.ReportItem) {
+			logger.Info("fenced generation rehome progress",
+				zap.Int("completed", completed),
+				zap.Int("total", total),
+				zap.String("action", item.Action),
+				zap.String("object_key", item.ObjectKey),
+			)
+		},
+	}, objects)
+	if reportErr := writeGenerationRehomeReport(flags.reportFile, report); reportErr != nil {
+		if runErr != nil {
+			return xerrors.Errorf("generation rehome failed (%v) and report write failed: %w", runErr, reportErr)
+		}
+		return reportErr
+	}
+	if runErr != nil {
+		return runErr
+	}
+	return nil
+}
+
+func writeGenerationRehomeReport(path string, report *generationrehome.Report) error {
+	if path == "" {
+		return generationrehome.WriteReportJSON(os.Stdout, report)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return xerrors.Errorf("failed to create report file %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+	if err := generationrehome.WriteReportJSON(file, report); err != nil {
+		return xerrors.Errorf("failed to write report file %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/admin/retirement.go
+++ b/cmd/admin/retirement.go
@@ -48,6 +48,7 @@ func newRetirementCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newSingleBlockRetirementPlanCommand())
 	cmd.AddCommand(newSingleBlockRetirementReconcileCommand())
+	cmd.AddCommand(newFencedGenerationRehomeCommand())
 	return cmd
 }
 

--- a/internal/storage/generationrehome/ledger.go
+++ b/internal/storage/generationrehome/ledger.go
@@ -1,0 +1,181 @@
+package generationrehome
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+type ledgerRecord struct {
+	Type                 string `json:"type"`
+	ObjectKey            string `json:"object_key"`
+	MinHeight            uint64 `json:"min_height"`
+	EndHeightExclusive   uint64 `json:"end_height_exclusive"`
+	ReferencedRows       uint64 `json:"referenced_rows"`
+	CanonicalRows        uint64 `json:"canonical_rows"`
+	ValidPlacementRows   uint64 `json:"valid_placement_rows"`
+	ConsistentShadowRows uint64 `json:"consistent_shadow_rows"`
+	FencedRows           uint64 `json:"fenced_rows"`
+	DeletedRetentionRows uint64 `json:"deleted_retention_rows"`
+	CopyEligible         bool   `json:"copy_eligible"`
+	SourceSize           uint64 `json:"source_size"`
+	SourceETag           string `json:"source_etag"`
+	SourceVersionID      string `json:"source_version_id"`
+	DestinationSize      uint64 `json:"destination_size"`
+	DestinationETag      string `json:"destination_etag"`
+	DestinationVersionID string `json:"destination_version_id"`
+	Verification         string `json:"verification"`
+}
+
+// LoadFencedCopyLedger reads the append-only audit/copy ledger and returns only
+// objects whose consolidated placement includes retired, fenced rows.
+func LoadFencedCopyLedger(reader io.Reader) ([]Object, error) {
+	audits := make(map[string]ledgerRecord)
+	copies := make(map[string]ledgerRecord)
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for line := 1; scanner.Scan(); line++ {
+		var record ledgerRecord
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			return nil, xerrors.Errorf("invalid copy ledger line %d: %w", line, err)
+		}
+		switch record.Type {
+		case "audit_object":
+			if record.FencedRows == 0 {
+				continue
+			}
+			if _, exists := audits[record.ObjectKey]; exists {
+				return nil, xerrors.Errorf("duplicate fenced audit object %q", record.ObjectKey)
+			}
+			audits[record.ObjectKey] = record
+		case "copy_verified":
+			if existing, exists := copies[record.ObjectKey]; exists {
+				if existing.SourceVersionID != record.SourceVersionID || existing.DestinationVersionID != record.DestinationVersionID {
+					return nil, xerrors.Errorf("conflicting verified copies for object %q", record.ObjectKey)
+				}
+				continue
+			}
+			copies[record.ObjectKey] = record
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to read copy ledger: %w", err)
+	}
+	if len(audits) == 0 {
+		return nil, xerrors.New("copy ledger contains no fenced audit objects")
+	}
+
+	objects := make([]Object, 0, len(audits))
+	for key, audit := range audits {
+		if err := validateAuditRecord(audit); err != nil {
+			return nil, xerrors.Errorf("invalid fenced audit object %q: %w", key, err)
+		}
+		copyRecord, ok := copies[key]
+		if !ok {
+			return nil, xerrors.Errorf("fenced audit object %q has no verified copy", key)
+		}
+		if err := validateCopyRecord(copyRecord); err != nil {
+			return nil, xerrors.Errorf("invalid verified copy for object %q: %w", key, err)
+		}
+		object := Object{
+			ObjectKey:         key,
+			StartHeight:       audit.MinHeight,
+			EndHeight:         audit.EndHeightExclusive,
+			ExpectedRows:      audit.ReferencedRows,
+			ExpectedCanonical: audit.CanonicalRows,
+			ExpectedFenced:    audit.FencedRows,
+			ExpectedDeleted:   audit.DeletedRetentionRows,
+			Source: ObjectVersion{
+				VersionID: copyRecord.SourceVersionID,
+				ETag:      copyRecord.SourceETag,
+				Bytes:     copyRecord.SourceSize,
+			},
+			Destination: ObjectVersion{
+				VersionID: copyRecord.DestinationVersionID,
+				ETag:      copyRecord.DestinationETag,
+				Bytes:     copyRecord.DestinationSize,
+			},
+		}
+		object.EvidenceSHA256 = evidenceSHA256(object)
+		objects = append(objects, object)
+	}
+	sort.Slice(objects, func(i, j int) bool {
+		return objects[i].ObjectKey < objects[j].ObjectKey
+	})
+	return objects, nil
+}
+
+func validateAuditRecord(record ledgerRecord) error {
+	if strings.TrimSpace(record.ObjectKey) == "" {
+		return xerrors.New("object key is required")
+	}
+	if record.EndHeightExclusive <= record.MinHeight {
+		return xerrors.New("height range is invalid")
+	}
+	if record.ReferencedRows == 0 || record.FencedRows == 0 || record.FencedRows > record.ReferencedRows {
+		return xerrors.New("fenced row counts are invalid")
+	}
+	if record.CanonicalRows > record.ReferencedRows {
+		return xerrors.New("canonical row count exceeds referenced rows")
+	}
+	if record.ValidPlacementRows != record.ReferencedRows || record.ConsistentShadowRows != record.ReferencedRows {
+		return xerrors.New("not every referenced row has a valid, consistent placement")
+	}
+	if record.DeletedRetentionRows != record.FencedRows {
+		return xerrors.New("not every fenced row has deleted retention")
+	}
+	if !record.CopyEligible {
+		return xerrors.New("object is not copy eligible")
+	}
+	return nil
+}
+
+func validateCopyRecord(record ledgerRecord) error {
+	if !immutableVersionID(record.SourceVersionID) || !immutableVersionID(record.DestinationVersionID) {
+		return xerrors.New("source and destination immutable version ids are required")
+	}
+	if record.SourceETag == "" || record.DestinationETag == "" {
+		return xerrors.New("source and destination etags are required")
+	}
+	if record.SourceSize == 0 || record.SourceSize != record.DestinationSize {
+		return xerrors.New("source and destination sizes must match and be positive")
+	}
+	if record.Verification == "" {
+		return xerrors.New("copy verification evidence is required")
+	}
+	return nil
+}
+
+func evidenceSHA256(object Object) string {
+	digest := sha256.New()
+	_, _ = fmt.Fprintf(
+		digest,
+		"%d:%s\x1f%d\x1f%d\x1f%d\x1f%d\x1f%d\x1f%d\x1f%d:%s\x1f%d:%s\x1f%d\x1f%d:%s\x1f%d:%s\x1f%d\n",
+		len(object.ObjectKey), object.ObjectKey,
+		object.StartHeight,
+		object.EndHeight,
+		object.ExpectedRows,
+		object.ExpectedCanonical,
+		object.ExpectedFenced,
+		object.ExpectedDeleted,
+		len(object.Source.VersionID), object.Source.VersionID,
+		len(object.Source.ETag), object.Source.ETag,
+		object.Source.Bytes,
+		len(object.Destination.VersionID), object.Destination.VersionID,
+		len(object.Destination.ETag), object.Destination.ETag,
+		object.Destination.Bytes,
+	)
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func immutableVersionID(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && !strings.EqualFold(value, "null")
+}

--- a/internal/storage/generationrehome/ledger_test.go
+++ b/internal/storage/generationrehome/ledger_test.go
@@ -1,0 +1,44 @@
+package generationrehome
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFencedCopyLedger(t *testing.T) {
+	ledger := strings.Join([]string{
+		`{"type":"audit_object","object_key":"simple","min_height":1,"end_height_exclusive":2,"referenced_rows":1,"canonical_rows":1,"valid_placement_rows":1,"consistent_shadow_rows":1,"copy_eligible":true,"simple_cutover_eligible":true}`,
+		`{"type":"audit_object","object_key":"fenced","min_height":10,"end_height_exclusive":20,"referenced_rows":8,"canonical_rows":7,"valid_placement_rows":8,"consistent_shadow_rows":8,"fenced_rows":3,"deleted_retention_rows":3,"copy_eligible":true}`,
+		`{"type":"copy_verified","object_key":"fenced","source_size":100,"source_etag":"source-etag","source_version_id":"source-version","destination_size":100,"destination_etag":"destination-etag","destination_version_id":"destination-version","verification":"complete"}`,
+	}, "\n")
+
+	objects, err := LoadFencedCopyLedger(strings.NewReader(ledger))
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+	object := objects[0]
+	require.Equal(t, "fenced", object.ObjectKey)
+	require.Equal(t, uint64(8), object.ExpectedRows)
+	require.Equal(t, uint64(3), object.ExpectedFenced)
+	require.Equal(t, uint64(100), object.Destination.Bytes)
+	require.Len(t, object.EvidenceSHA256, 64)
+	require.Equal(t, evidenceSHA256(object), object.EvidenceSHA256)
+}
+
+func TestLoadFencedCopyLedgerRejectsMissingCopy(t *testing.T) {
+	ledger := `{"type":"audit_object","object_key":"fenced","min_height":10,"end_height_exclusive":20,"referenced_rows":8,"canonical_rows":8,"valid_placement_rows":8,"consistent_shadow_rows":8,"fenced_rows":8,"deleted_retention_rows":8,"copy_eligible":true}`
+
+	_, err := LoadFencedCopyLedger(strings.NewReader(ledger))
+	require.ErrorContains(t, err, "has no verified copy")
+}
+
+func TestLoadFencedCopyLedgerRejectsIncompleteRetirement(t *testing.T) {
+	ledger := strings.Join([]string{
+		`{"type":"audit_object","object_key":"fenced","min_height":10,"end_height_exclusive":20,"referenced_rows":8,"canonical_rows":8,"valid_placement_rows":8,"consistent_shadow_rows":8,"fenced_rows":8,"deleted_retention_rows":7,"copy_eligible":true}`,
+		`{"type":"copy_verified","object_key":"fenced","source_size":100,"source_etag":"source-etag","source_version_id":"source-version","destination_size":100,"destination_etag":"destination-etag","destination_version_id":"destination-version","verification":"complete"}`,
+	}, "\n")
+
+	_, err := LoadFencedCopyLedger(strings.NewReader(ledger))
+	require.ErrorContains(t, err, "not every fenced row has deleted retention")
+}

--- a/internal/storage/generationrehome/repository_postgres.go
+++ b/internal/storage/generationrehome/repository_postgres.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepairlock"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
@@ -57,6 +58,9 @@ func (r *PostgresRepository) Rehome(ctx context.Context, req RehomeRequest) (boo
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := cscbrepairlock.AcquireTag(ctx, tx, req.Tag); err != nil {
+		return false, err
+	}
 	if _, err := tx.ExecContext(
 		ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 1))`,

--- a/internal/storage/generationrehome/repository_postgres.go
+++ b/internal/storage/generationrehome/repository_postgres.go
@@ -1,0 +1,375 @@
+package generationrehome
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
+)
+
+const legacyGeneration = "legacy"
+
+type (
+	PostgresRepository struct {
+		db *sql.DB
+	}
+
+	rowQueryer interface {
+		QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	}
+)
+
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) Inspect(
+	ctx context.Context,
+	tag uint32,
+	objectKey string,
+	targetGeneration string,
+	evidenceSHA256 string,
+) (Inspection, error) {
+	if r.db == nil {
+		return Inspection{}, xerrors.New("postgres db is required")
+	}
+	if err := validateInspectionKey(objectKey, targetGeneration, evidenceSHA256); err != nil {
+		return Inspection{}, err
+	}
+	return inspectCohort(ctx, r.db, tag, objectKey, targetGeneration, evidenceSHA256)
+}
+
+func (r *PostgresRepository) Rehome(ctx context.Context, req RehomeRequest) (bool, error) {
+	if r.db == nil {
+		return false, xerrors.New("postgres db is required")
+	}
+	if err := validateRehomeRequest(req); err != nil {
+		return false, err
+	}
+
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return false, xerrors.Errorf("failed to begin storage generation rehome: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 1))`,
+		req.Object.ObjectKey,
+	); err != nil {
+		return false, xerrors.Errorf("failed to lock storage generation rehome object %q: %w", req.Object.ObjectKey, err)
+	}
+
+	inspection, err := inspectCohort(
+		ctx,
+		tx,
+		req.Tag,
+		req.Object.ObjectKey,
+		req.TargetGeneration,
+		req.Object.EvidenceSHA256,
+	)
+	if err != nil {
+		return false, err
+	}
+	alreadyTarget, err := validateInspection(req.Object, inspection)
+	if err != nil {
+		return false, err
+	}
+	if alreadyTarget {
+		return true, nil
+	}
+
+	const insertAudit = `
+		INSERT INTO block_storage_generation_rehome (
+			evidence_sha256, tag, object_key_main, source_generation, target_generation,
+			source_bucket, source_version_id, source_etag,
+			destination_bucket, destination_version_id, destination_etag, object_bytes,
+			start_height, end_height, expected_block_count, expected_canonical_count,
+			expected_fenced_count, expected_deleted_verified_count, state
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7, $8,
+			$9, $10, $11, $12,
+			$13, $14, $15, $16,
+			$17, $18, 'executing'
+		)
+		RETURNING id`
+	var auditID int64
+	if err := tx.QueryRowContext(
+		ctx,
+		insertAudit,
+		req.Object.EvidenceSHA256,
+		req.Tag,
+		req.Object.ObjectKey,
+		legacyGeneration,
+		req.TargetGeneration,
+		req.SourceBucket,
+		req.Object.Source.VersionID,
+		req.Object.Source.ETag,
+		req.DestinationBucket,
+		req.Object.Destination.VersionID,
+		req.Object.Destination.ETag,
+		req.Object.Destination.Bytes,
+		req.Object.StartHeight,
+		req.Object.EndHeight,
+		req.Object.ExpectedRows,
+		req.Object.ExpectedCanonical,
+		req.Object.ExpectedFenced,
+		req.Object.ExpectedDeleted,
+	).Scan(&auditID); err != nil {
+		return false, xerrors.Errorf("failed to insert storage generation rehome audit for %q: %w", req.Object.ObjectKey, err)
+	}
+
+	const updateShadow = `
+		UPDATE block_consolidation_shadow shadow
+		SET consolidated_storage_generation = $3
+		FROM block_metadata bm
+		WHERE shadow.block_metadata_id = bm.id
+			AND bm.tag = $1
+			AND bm.object_key_main = $2
+			AND bm.storage_generation IS NULL
+			AND shadow.consolidated_object_key_main = bm.object_key_main
+			AND shadow.consolidated_storage_generation IS NULL`
+	result, err := tx.ExecContext(ctx, updateShadow, req.Tag, req.Object.ObjectKey, req.TargetGeneration)
+	if err != nil {
+		return false, xerrors.Errorf("failed to rehome shadow placement for %q: %w", req.Object.ObjectKey, err)
+	}
+	if err := requireRowsAffected(result, req.Object.ExpectedRows, "shadow placement", req.Object.ObjectKey); err != nil {
+		return false, err
+	}
+
+	const updatePrimary = `
+		UPDATE block_metadata
+		SET storage_generation = $3
+		WHERE tag = $1
+			AND object_key_main = $2
+			AND storage_generation IS NULL`
+	result, err = tx.ExecContext(ctx, updatePrimary, req.Tag, req.Object.ObjectKey, req.TargetGeneration)
+	if err != nil {
+		return false, xerrors.Errorf("failed to rehome primary placement for %q: %w", req.Object.ObjectKey, err)
+	}
+	if err := requireRowsAffected(result, req.Object.ExpectedRows, "primary placement", req.Object.ObjectKey); err != nil {
+		return false, err
+	}
+
+	const completeAudit = `
+		UPDATE block_storage_generation_rehome
+		SET state = 'completed', completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+		WHERE id = $1 AND state = 'executing'`
+	result, err = tx.ExecContext(ctx, completeAudit, auditID)
+	if err != nil {
+		return false, xerrors.Errorf("failed to complete storage generation rehome audit for %q: %w", req.Object.ObjectKey, err)
+	}
+	if err := requireRowsAffected(result, 1, "rehome audit", req.Object.ObjectKey); err != nil {
+		return false, err
+	}
+
+	completed, err := inspectCohort(
+		ctx,
+		tx,
+		req.Tag,
+		req.Object.ObjectKey,
+		req.TargetGeneration,
+		req.Object.EvidenceSHA256,
+	)
+	if err != nil {
+		return false, err
+	}
+	completedTarget, err := validateInspection(req.Object, completed)
+	if err != nil {
+		return false, xerrors.Errorf("post-rehome validation failed for %q: %w", req.Object.ObjectKey, err)
+	}
+	if !completedTarget {
+		return false, xerrors.Errorf("post-rehome validation did not reach target generation for %q", req.Object.ObjectKey)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, xerrors.Errorf("failed to commit storage generation rehome for %q: %w", req.Object.ObjectKey, err)
+	}
+	return false, nil
+}
+
+func inspectCohort(
+	ctx context.Context,
+	q rowQueryer,
+	tag uint32,
+	objectKey string,
+	targetGeneration string,
+	evidenceSHA256 string,
+) (Inspection, error) {
+	const query = `
+		WITH cohort AS (
+			SELECT
+				bm.height,
+				cb.block_metadata_id IS NOT NULL AS canonical,
+				bm.single_block_retention_fenced_at IS NOT NULL AS fenced,
+				bm.storage_generation AS primary_generation,
+				shadow.block_metadata_id IS NULL AS missing_shadow,
+				CASE
+					WHEN shadow.block_metadata_id IS NULL THEN FALSE
+					ELSE NOT (
+						bm.object_format = $5
+						AND bm.byte_offset IS NOT NULL AND bm.byte_offset >= 0
+						AND bm.byte_length IS NOT NULL AND bm.byte_length > 0
+						AND bm.uncompressed_length IS NOT NULL AND bm.uncompressed_length > 0
+						AND shadow.tag = bm.tag
+						AND shadow.height = bm.height
+						AND shadow.hash IS NOT DISTINCT FROM bm.hash
+						AND shadow.consolidated_object_key_main = bm.object_key_main
+						AND shadow.object_format = bm.object_format
+						AND shadow.byte_offset = bm.byte_offset
+						AND shadow.byte_length = bm.byte_length
+						AND shadow.uncompressed_length IS NOT DISTINCT FROM bm.uncompressed_length
+					)
+				END AS invalid_placement,
+				shadow.consolidated_storage_generation,
+				retirement.block_metadata_id IS NOT NULL
+					AND retirement.state = 'deleted_verified'
+					AND retirement.deleted_at IS NOT NULL
+					AND retirement.verified_at IS NOT NULL
+					AND retirement.consolidated_object_key_main = bm.object_key_main
+					AND shadow.single_block_object_deleted_at IS NOT NULL AS deleted_verified,
+				retirement.block_metadata_id IS NOT NULL
+					AND NOT (
+						retirement.state = 'deleted_verified'
+						AND retirement.deleted_at IS NOT NULL
+						AND retirement.verified_at IS NOT NULL
+						AND retirement.consolidated_object_key_main = bm.object_key_main
+						AND shadow.single_block_object_deleted_at IS NOT NULL
+					) AS active_retention,
+				EXISTS (
+					SELECT 1
+					FROM cscb_repair_manifest repair
+					WHERE repair.old_consolidated_object_key_main = bm.object_key_main
+						AND NOT (
+							repair.state = 'completed'
+							AND repair.outcome = 'already_clean_storage_neutral'
+						)
+				) AS pinned_repair
+			FROM block_metadata bm
+			LEFT JOIN canonical_blocks cb
+				ON cb.block_metadata_id = bm.id AND cb.tag = bm.tag AND cb.height = bm.height
+			LEFT JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+			LEFT JOIN block_single_block_retention retirement ON retirement.block_metadata_id = bm.id
+			WHERE bm.tag = $1 AND bm.object_key_main = $2
+		)
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE canonical),
+			COALESCE(MIN(height), 0),
+			COALESCE(MAX(height) + 1, 0),
+			COUNT(*) FILTER (WHERE missing_shadow),
+			COUNT(*) FILTER (WHERE invalid_placement),
+			COUNT(*) FILTER (WHERE fenced),
+			COUNT(*) FILTER (WHERE deleted_verified),
+			COUNT(*) FILTER (WHERE active_retention),
+			COUNT(*) FILTER (WHERE pinned_repair),
+			COUNT(*) FILTER (WHERE primary_generation IS NULL),
+			COUNT(*) FILTER (WHERE primary_generation = $3),
+			COUNT(*) FILTER (WHERE primary_generation IS NOT NULL AND primary_generation <> $3),
+			COUNT(*) FILTER (WHERE consolidated_storage_generation IS NULL),
+			COUNT(*) FILTER (WHERE consolidated_storage_generation = $3),
+			COUNT(*) FILTER (WHERE consolidated_storage_generation IS NOT NULL AND consolidated_storage_generation <> $3),
+			EXISTS (
+				SELECT 1
+				FROM block_storage_generation_rehome audit
+				WHERE audit.tag = $1
+					AND audit.object_key_main = $2
+					AND audit.source_generation = 'legacy'
+					AND audit.target_generation = $3
+					AND audit.evidence_sha256 = $4
+					AND audit.state = 'completed'
+			)
+		FROM cohort`
+
+	var inspection Inspection
+	if err := q.QueryRowContext(
+		ctx,
+		query,
+		tag,
+		objectKey,
+		targetGeneration,
+		evidenceSHA256,
+		int32(api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH),
+	).Scan(
+		&inspection.TotalRows,
+		&inspection.CanonicalRows,
+		&inspection.StartHeight,
+		&inspection.EndHeight,
+		&inspection.MissingShadowRows,
+		&inspection.InvalidPlacementRows,
+		&inspection.FencedRows,
+		&inspection.DeletedVerifiedRows,
+		&inspection.ActiveRetentionRows,
+		&inspection.PinnedRepairRows,
+		&inspection.PrimaryLegacyRows,
+		&inspection.PrimaryTargetRows,
+		&inspection.PrimaryOtherRows,
+		&inspection.ConsolidatedLegacyRows,
+		&inspection.ConsolidatedTargetRows,
+		&inspection.ConsolidatedOtherRows,
+		&inspection.CompletedAudit,
+	); err != nil {
+		return Inspection{}, xerrors.Errorf("failed to inspect storage generation cohort for %q: %w", objectKey, err)
+	}
+	return inspection, nil
+}
+
+func validateInspectionKey(objectKey string, targetGeneration string, evidenceSHA256 string) error {
+	if strings.TrimSpace(objectKey) == "" {
+		return xerrors.New("storage generation rehome object key is required")
+	}
+	if !generationPattern.MatchString(targetGeneration) || targetGeneration != "v2" {
+		return xerrors.Errorf("unsupported storage generation rehome target %q", targetGeneration)
+	}
+	if len(evidenceSHA256) != 64 {
+		return xerrors.New("valid storage generation rehome evidence digest is required")
+	}
+	if _, err := hex.DecodeString(evidenceSHA256); err != nil || strings.ToLower(evidenceSHA256) != evidenceSHA256 {
+		return xerrors.New("valid storage generation rehome evidence digest is required")
+	}
+	return nil
+}
+
+func validateRehomeRequest(req RehomeRequest) error {
+	if err := validateInspectionKey(req.Object.ObjectKey, req.TargetGeneration, req.Object.EvidenceSHA256); err != nil {
+		return err
+	}
+	if req.SourceBucket == "" || req.DestinationBucket == "" || req.SourceBucket == req.DestinationBucket {
+		return xerrors.New("distinct source and destination buckets are required")
+	}
+	if req.Object.EndHeight <= req.Object.StartHeight || req.Object.ExpectedRows == 0 {
+		return xerrors.New("valid storage generation rehome object range and row count are required")
+	}
+	if req.Object.ExpectedCanonical > req.Object.ExpectedRows ||
+		req.Object.ExpectedFenced == 0 ||
+		req.Object.ExpectedFenced > req.Object.ExpectedRows ||
+		req.Object.ExpectedDeleted != req.Object.ExpectedFenced {
+		return xerrors.New("valid storage generation rehome cohort counts are required")
+	}
+	if !immutableVersionID(req.Object.Source.VersionID) || !immutableVersionID(req.Object.Destination.VersionID) ||
+		req.Object.Source.ETag == "" || req.Object.Destination.ETag == "" ||
+		req.Object.Source.Bytes == 0 || req.Object.Source.Bytes != req.Object.Destination.Bytes {
+		return xerrors.New("valid immutable storage generation rehome object versions are required")
+	}
+	if req.Object.EvidenceSHA256 != evidenceSHA256(req.Object) {
+		return xerrors.New("storage generation rehome evidence digest mismatch")
+	}
+	return nil
+}
+
+func requireRowsAffected(result sql.Result, expected uint64, name string, objectKey string) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return xerrors.Errorf("failed to count %s rows for %q: %w", name, objectKey, err)
+	}
+	if rows < 0 || uint64(rows) != expected {
+		return xerrors.Errorf("%s guard failed for %q: rows=%d expected=%d", name, objectKey, rows, expected)
+	}
+	return nil
+}

--- a/internal/storage/generationrehome/s3_store.go
+++ b/internal/storage/generationrehome/s3_store.go
@@ -1,0 +1,83 @@
+package generationrehome
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	awss3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"golang.org/x/xerrors"
+
+	"github.com/coinbase/chainstorage/internal/s3"
+)
+
+type S3ObjectStore struct {
+	client s3.Client
+}
+
+func NewS3ObjectStore(client s3.Client) *S3ObjectStore {
+	return &S3ObjectStore{client: client}
+}
+
+func (s *S3ObjectStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {
+	return s.headObject(ctx, bucket, key, "")
+}
+
+func (s *S3ObjectStore) HeadObjectVersion(ctx context.Context, bucket string, key string, versionID string) (ObjectHead, error) {
+	if !immutableVersionID(versionID) {
+		return ObjectHead{}, xerrors.New("an immutable non-null version id is required")
+	}
+	return s.headObject(ctx, bucket, key, versionID)
+}
+
+func (s *S3ObjectStore) headObject(ctx context.Context, bucket string, key string, versionID string) (ObjectHead, error) {
+	if s.client == nil {
+		return ObjectHead{}, xerrors.New("s3 client is required")
+	}
+	input := &awss3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+	if versionID != "" {
+		input.VersionId = aws.String(versionID)
+	}
+	output, err := s.client.HeadObject(ctx, input)
+	if err != nil {
+		if isNotFound(err) {
+			return ObjectHead{}, nil
+		}
+		return ObjectHead{}, xerrors.Errorf("failed to head object (bucket=%s key=%s version_id=%s): %w", bucket, key, versionID, err)
+	}
+	head := ObjectHead{
+		Exists:    true,
+		VersionID: aws.ToString(output.VersionId),
+		ETag:      aws.ToString(output.ETag),
+	}
+	if output.ContentLength != nil && *output.ContentLength > 0 {
+		head.Bytes = uint64(*output.ContentLength)
+	}
+	return head, nil
+}
+
+func isNotFound(err error) bool {
+	var notFound *awss3types.NotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var noSuchKey *awss3types.NoSuchKey
+	if errors.As(err, &noSuchKey) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NotFound", "NoSuchKey", "404":
+			return true
+		}
+	}
+	return false
+}
+
+var _ ObjectStore = (*S3ObjectStore)(nil)

--- a/internal/storage/generationrehome/s3_store.go
+++ b/internal/storage/generationrehome/s3_store.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/s3"
+	"github.com/coinbase/chainstorage/internal/storage/retirement"
 )
 
 type S3ObjectStore struct {
@@ -19,6 +20,14 @@ type S3ObjectStore struct {
 
 func NewS3ObjectStore(client s3.Client) *S3ObjectStore {
 	return &S3ObjectStore{client: client}
+}
+
+func (s *S3ObjectStore) InspectObjectRetentionSafety(ctx context.Context, bucket string, key string) error {
+	if s == nil {
+		return xerrors.New("s3 client is required to verify destination retention safety")
+	}
+	_, err := retirement.NewS3ObjectStore(s.client).InspectObjectRetentionSafety(ctx, bucket, key)
+	return err
 }
 
 func (s *S3ObjectStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {

--- a/internal/storage/generationrehome/service.go
+++ b/internal/storage/generationrehome/service.go
@@ -1,0 +1,296 @@
+package generationrehome
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+var generationPattern = regexp.MustCompile(`^v[1-9][0-9]*$`)
+
+type Service struct {
+	repository Repository
+	store      ObjectStore
+	now        func() time.Time
+}
+
+func NewService(repository Repository, store ObjectStore) *Service {
+	return &Service{
+		repository: repository,
+		store:      store,
+		now:        time.Now,
+	}
+}
+
+func (s *Service) Run(ctx context.Context, req Request, objects []Object) (*Report, error) {
+	report := newReport(req, objects, s.now().UTC())
+	if err := validateRequest(req, objects); err != nil {
+		return report, err
+	}
+
+	for _, object := range objects {
+		item := ReportItem{
+			ObjectKey:      object.ObjectKey,
+			EvidenceSHA256: object.EvidenceSHA256,
+			StartHeight:    object.StartHeight,
+			EndHeight:      object.EndHeight,
+			Rows:           object.ExpectedRows,
+			FencedRows:     object.ExpectedFenced,
+		}
+		if err := s.verifyObjectCopy(ctx, req, object); err != nil {
+			item.Action = ActionFailed
+			item.Error = err.Error()
+			report.Items = append(report.Items, item)
+			report.Summary.FailedObjects++
+			reportProgress(req, report, item, len(objects))
+			return report, xerrors.Errorf("object copy verification failed for %q: %w", object.ObjectKey, err)
+		}
+
+		inspection, err := s.repository.Inspect(ctx, req.Tag, object.ObjectKey, req.TargetGeneration, object.EvidenceSHA256)
+		if err != nil {
+			item.Action = ActionFailed
+			item.Error = err.Error()
+			report.Items = append(report.Items, item)
+			report.Summary.FailedObjects++
+			reportProgress(req, report, item, len(objects))
+			return report, xerrors.Errorf("metadata inspection failed for %q: %w", object.ObjectKey, err)
+		}
+		alreadyTarget, err := validateInspection(object, inspection)
+		if err != nil {
+			item.Action = ActionFailed
+			item.Error = err.Error()
+			report.Items = append(report.Items, item)
+			report.Summary.FailedObjects++
+			reportProgress(req, report, item, len(objects))
+			return report, xerrors.Errorf("metadata inspection rejected object %q: %w", object.ObjectKey, err)
+		}
+		if alreadyTarget {
+			item.Action = ActionAlreadyTarget
+			report.Summary.AlreadyTarget++
+			report.Items = append(report.Items, item)
+			reportProgress(req, report, item, len(objects))
+			continue
+		}
+
+		item.Action = ActionReady
+		report.Summary.ReadyObjects++
+		if !req.Execute {
+			report.Items = append(report.Items, item)
+			reportProgress(req, report, item, len(objects))
+			continue
+		}
+
+		item.Action = ActionRehome
+		alreadyTarget, err = s.repository.Rehome(ctx, RehomeRequest{
+			Tag:               req.Tag,
+			SourceBucket:      req.SourceBucket,
+			DestinationBucket: req.DestinationBucket,
+			TargetGeneration:  req.TargetGeneration,
+			Object:            object,
+		})
+		if err != nil {
+			item.Action = ActionFailed
+			item.Error = err.Error()
+			report.Items = append(report.Items, item)
+			report.Summary.FailedObjects++
+			reportProgress(req, report, item, len(objects))
+			return report, xerrors.Errorf("metadata rehome failed for %q: %w", object.ObjectKey, err)
+		}
+		if alreadyTarget {
+			item.Action = ActionAlreadyTarget
+			report.Summary.AlreadyTarget++
+		} else {
+			item.Action = ActionRehomed
+			report.Summary.CompletedObjects++
+		}
+		report.Items = append(report.Items, item)
+		reportProgress(req, report, item, len(objects))
+	}
+	return report, nil
+}
+
+func reportProgress(req Request, report *Report, item ReportItem, total int) {
+	if req.Progress != nil {
+		req.Progress(len(report.Items), total, item)
+	}
+}
+
+func validateRequest(req Request, objects []Object) error {
+	if req.Chain == "" || req.SourceBucket == "" || req.DestinationBucket == "" {
+		return xerrors.New("chain, source bucket, and destination bucket are required")
+	}
+	if req.SourceBucket == req.DestinationBucket {
+		return xerrors.New("source and destination buckets must be different")
+	}
+	if !generationPattern.MatchString(req.TargetGeneration) {
+		return xerrors.Errorf("unsupported target generation %q", req.TargetGeneration)
+	}
+	if req.TargetGeneration != "v2" {
+		return xerrors.Errorf("fenced legacy rehome is restricted to target generation v2, got %q", req.TargetGeneration)
+	}
+	if len(objects) == 0 {
+		return xerrors.New("at least one fenced object is required")
+	}
+
+	var rows uint64
+	seen := make(map[string]struct{}, len(objects))
+	for _, object := range objects {
+		if object.ObjectKey == "" || object.EvidenceSHA256 == "" {
+			return xerrors.New("every object requires a key and evidence digest")
+		}
+		if _, ok := seen[object.ObjectKey]; ok {
+			return xerrors.Errorf("duplicate object %q", object.ObjectKey)
+		}
+		seen[object.ObjectKey] = struct{}{}
+		if object.EvidenceSHA256 != evidenceSHA256(object) {
+			return xerrors.Errorf("evidence digest mismatch for object %q", object.ObjectKey)
+		}
+		if ^uint64(0)-rows < object.ExpectedRows {
+			return xerrors.New("approved row count overflow")
+		}
+		rows += object.ExpectedRows
+	}
+	if req.Execute {
+		if req.Approval.Chain != req.Chain {
+			return xerrors.Errorf("approval chain mismatch: approved=%q actual=%q", req.Approval.Chain, req.Chain)
+		}
+		if req.Approval.Objects != uint64(len(objects)) {
+			return xerrors.Errorf("approval object count mismatch: approved=%d actual=%d", req.Approval.Objects, len(objects))
+		}
+		if req.Approval.Rows != rows {
+			return xerrors.Errorf("approval row count mismatch: approved=%d actual=%d", req.Approval.Rows, rows)
+		}
+		if req.Approval.Transition != TransitionLegacyNullToV2 {
+			return xerrors.Errorf("approval transition mismatch: approved=%q required=%q", req.Approval.Transition, TransitionLegacyNullToV2)
+		}
+	}
+	return nil
+}
+
+func validateInspection(object Object, inspection Inspection) (bool, error) {
+	if inspection.TotalRows != object.ExpectedRows ||
+		inspection.CanonicalRows != object.ExpectedCanonical ||
+		inspection.StartHeight != object.StartHeight ||
+		inspection.EndHeight != object.EndHeight {
+		return false, xerrors.Errorf(
+			"row cohort changed: rows=%d/%d canonical=%d/%d range=[%d,%d)/[%d,%d)",
+			inspection.TotalRows, object.ExpectedRows,
+			inspection.CanonicalRows, object.ExpectedCanonical,
+			inspection.StartHeight, inspection.EndHeight,
+			object.StartHeight, object.EndHeight,
+		)
+	}
+	if inspection.MissingShadowRows != 0 || inspection.InvalidPlacementRows != 0 {
+		return false, xerrors.Errorf("invalid placement cohort: missing_shadow=%d invalid_placement=%d", inspection.MissingShadowRows, inspection.InvalidPlacementRows)
+	}
+	if inspection.FencedRows != object.ExpectedFenced || inspection.DeletedVerifiedRows != object.ExpectedDeleted {
+		return false, xerrors.Errorf(
+			"retirement cohort changed: fenced=%d/%d deleted_verified=%d/%d",
+			inspection.FencedRows, object.ExpectedFenced,
+			inspection.DeletedVerifiedRows, object.ExpectedDeleted,
+		)
+	}
+	if inspection.ActiveRetentionRows != 0 || inspection.PinnedRepairRows != 0 {
+		return false, xerrors.Errorf("active safety work exists: retention_rows=%d pinned_repair_rows=%d", inspection.ActiveRetentionRows, inspection.PinnedRepairRows)
+	}
+
+	allLegacy := inspection.PrimaryLegacyRows == inspection.TotalRows &&
+		inspection.ConsolidatedLegacyRows == inspection.TotalRows &&
+		inspection.PrimaryTargetRows == 0 && inspection.ConsolidatedTargetRows == 0 &&
+		inspection.PrimaryOtherRows == 0 && inspection.ConsolidatedOtherRows == 0
+	allTarget := inspection.PrimaryTargetRows == inspection.TotalRows &&
+		inspection.ConsolidatedTargetRows == inspection.TotalRows &&
+		inspection.PrimaryLegacyRows == 0 && inspection.ConsolidatedLegacyRows == 0 &&
+		inspection.PrimaryOtherRows == 0 && inspection.ConsolidatedOtherRows == 0
+	if allLegacy {
+		return false, nil
+	}
+	if allTarget {
+		if !inspection.CompletedAudit {
+			return false, xerrors.New("target generation metadata has no matching completed rehome audit")
+		}
+		return true, nil
+	}
+	return false, xerrors.Errorf(
+		"storage generation cohort is mixed: primary_legacy=%d primary_target=%d primary_other=%d shadow_legacy=%d shadow_target=%d shadow_other=%d",
+		inspection.PrimaryLegacyRows,
+		inspection.PrimaryTargetRows,
+		inspection.PrimaryOtherRows,
+		inspection.ConsolidatedLegacyRows,
+		inspection.ConsolidatedTargetRows,
+		inspection.ConsolidatedOtherRows,
+	)
+}
+
+func (s *Service) verifyObjectCopy(ctx context.Context, req Request, object Object) error {
+	checks := []struct {
+		name    string
+		bucket  string
+		version ObjectVersion
+		current bool
+	}{
+		{name: "source current", bucket: req.SourceBucket, version: object.Source, current: true},
+		{name: "source pinned", bucket: req.SourceBucket, version: object.Source},
+		{name: "destination current", bucket: req.DestinationBucket, version: object.Destination, current: true},
+		{name: "destination pinned", bucket: req.DestinationBucket, version: object.Destination},
+	}
+	for _, check := range checks {
+		var head ObjectHead
+		var err error
+		if check.current {
+			head, err = s.store.HeadObject(ctx, check.bucket, object.ObjectKey)
+		} else {
+			head, err = s.store.HeadObjectVersion(ctx, check.bucket, object.ObjectKey, check.version.VersionID)
+		}
+		if err != nil {
+			return xerrors.Errorf("%s head failed: %w", check.name, err)
+		}
+		if !head.Exists {
+			return xerrors.Errorf("%s object is missing", check.name)
+		}
+		if head.VersionID != check.version.VersionID || head.ETag != check.version.ETag || head.Bytes != check.version.Bytes {
+			return xerrors.Errorf(
+				"%s evidence mismatch: version=%q/%q etag=%q/%q bytes=%d/%d",
+				check.name,
+				head.VersionID, check.version.VersionID,
+				head.ETag, check.version.ETag,
+				head.Bytes, check.version.Bytes,
+			)
+		}
+	}
+	return nil
+}
+
+func newReport(req Request, objects []Object, generatedAt time.Time) *Report {
+	report := &Report{
+		GeneratedAt:       generatedAt,
+		DryRun:            !req.Execute,
+		Environment:       req.Environment,
+		Chain:             req.Chain,
+		Tag:               req.Tag,
+		SourceBucket:      req.SourceBucket,
+		DestinationBucket: req.DestinationBucket,
+		Transition:        TransitionLegacyNullToV2,
+		Items:             make([]ReportItem, 0, len(objects)),
+	}
+	for _, object := range objects {
+		report.Summary.Objects++
+		report.Summary.Rows += object.ExpectedRows
+		report.Summary.FencedRows += object.ExpectedFenced
+	}
+	return report
+}
+
+func WriteReportJSON(writer io.Writer, report *Report) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("failed to encode generation rehome report: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/generationrehome/service.go
+++ b/internal/storage/generationrehome/service.go
@@ -263,6 +263,9 @@ func (s *Service) verifyObjectCopy(ctx context.Context, req Request, object Obje
 			)
 		}
 	}
+	if err := s.store.InspectObjectRetentionSafety(ctx, req.DestinationBucket, object.ObjectKey); err != nil {
+		return xerrors.Errorf("destination retention safety verification failed: %w", err)
+	}
 	return nil
 }
 

--- a/internal/storage/generationrehome/service_test.go
+++ b/internal/storage/generationrehome/service_test.go
@@ -2,6 +2,7 @@ package generationrehome
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -13,10 +14,12 @@ type fakeRepository struct {
 	inspectErr    error
 	rehomeErr     error
 	alreadyTarget bool
+	inspectCalls  int
 	rehomeCalls   []RehomeRequest
 }
 
 func (r *fakeRepository) Inspect(ctx context.Context, tag uint32, objectKey string, targetGeneration string, evidenceSHA256 string) (Inspection, error) {
+	r.inspectCalls++
 	return r.inspection, r.inspectErr
 }
 
@@ -26,7 +29,12 @@ func (r *fakeRepository) Rehome(ctx context.Context, req RehomeRequest) (bool, e
 }
 
 type fakeObjectStore struct {
-	heads map[string]ObjectHead
+	heads              map[string]ObjectHead
+	retentionSafetyErr error
+}
+
+func (s *fakeObjectStore) InspectObjectRetentionSafety(ctx context.Context, bucket string, key string) error {
+	return s.retentionSafetyErr
 }
 
 func (s *fakeObjectStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {
@@ -71,6 +79,21 @@ func TestServiceRunRejectsApprovalMismatchBeforeExternalInspection(t *testing.T)
 	_, err := service.Run(context.Background(), req, []Object{object})
 	require.ErrorContains(t, err, "approval row count mismatch")
 	require.Empty(t, repository.rehomeCalls)
+}
+
+func TestServiceRunRejectsUnsafeDestinationBeforeMetadataInspection(t *testing.T) {
+	object := testObject()
+	repository := &fakeRepository{inspection: legacyInspection(object)}
+	store := testObjectStore(object)
+	store.retentionSafetyErr = errors.New("destination bucket is mutable")
+	service := NewService(repository, store)
+
+	report, err := service.Run(context.Background(), testRequest(object, true), []Object{object})
+	require.ErrorContains(t, err, "destination retention safety verification failed")
+	require.ErrorContains(t, err, "destination bucket is mutable")
+	require.Zero(t, repository.inspectCalls)
+	require.Empty(t, repository.rehomeCalls)
+	require.Equal(t, ActionFailed, report.Items[0].Action)
 }
 
 func TestServiceRunRejectsMixedGenerationCohort(t *testing.T) {

--- a/internal/storage/generationrehome/service_test.go
+++ b/internal/storage/generationrehome/service_test.go
@@ -1,0 +1,180 @@
+package generationrehome
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRepository struct {
+	inspection    Inspection
+	inspectErr    error
+	rehomeErr     error
+	alreadyTarget bool
+	rehomeCalls   []RehomeRequest
+}
+
+func (r *fakeRepository) Inspect(ctx context.Context, tag uint32, objectKey string, targetGeneration string, evidenceSHA256 string) (Inspection, error) {
+	return r.inspection, r.inspectErr
+}
+
+func (r *fakeRepository) Rehome(ctx context.Context, req RehomeRequest) (bool, error) {
+	r.rehomeCalls = append(r.rehomeCalls, req)
+	return r.alreadyTarget, r.rehomeErr
+}
+
+type fakeObjectStore struct {
+	heads map[string]ObjectHead
+}
+
+func (s *fakeObjectStore) HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error) {
+	return s.heads[fmt.Sprintf("current/%s/%s", bucket, key)], nil
+}
+
+func (s *fakeObjectStore) HeadObjectVersion(ctx context.Context, bucket string, key string, versionID string) (ObjectHead, error) {
+	return s.heads[fmt.Sprintf("version/%s/%s/%s", bucket, key, versionID)], nil
+}
+
+func TestServiceRunDryRunAndExecute(t *testing.T) {
+	object := testObject()
+	for _, execute := range []bool{false, true} {
+		t.Run(fmt.Sprintf("execute=%t", execute), func(t *testing.T) {
+			repository := &fakeRepository{inspection: legacyInspection(object)}
+			service := NewService(repository, testObjectStore(object))
+			req := testRequest(object, execute)
+
+			report, err := service.Run(context.Background(), req, []Object{object})
+			require.NoError(t, err)
+			require.Len(t, report.Items, 1)
+			if execute {
+				require.Equal(t, ActionRehomed, report.Items[0].Action)
+				require.Equal(t, uint64(1), report.Summary.CompletedObjects)
+				require.Len(t, repository.rehomeCalls, 1)
+			} else {
+				require.Equal(t, ActionReady, report.Items[0].Action)
+				require.Equal(t, uint64(1), report.Summary.ReadyObjects)
+				require.Empty(t, repository.rehomeCalls)
+			}
+		})
+	}
+}
+
+func TestServiceRunRejectsApprovalMismatchBeforeExternalInspection(t *testing.T) {
+	object := testObject()
+	repository := &fakeRepository{inspection: legacyInspection(object)}
+	service := NewService(repository, testObjectStore(object))
+	req := testRequest(object, true)
+	req.Approval.Rows++
+
+	_, err := service.Run(context.Background(), req, []Object{object})
+	require.ErrorContains(t, err, "approval row count mismatch")
+	require.Empty(t, repository.rehomeCalls)
+}
+
+func TestServiceRunRejectsMixedGenerationCohort(t *testing.T) {
+	object := testObject()
+	inspection := legacyInspection(object)
+	inspection.PrimaryLegacyRows--
+	inspection.PrimaryTargetRows++
+	repository := &fakeRepository{inspection: inspection}
+	service := NewService(repository, testObjectStore(object))
+
+	report, err := service.Run(context.Background(), testRequest(object, false), []Object{object})
+	require.ErrorContains(t, err, "storage generation cohort is mixed")
+	require.Equal(t, ActionFailed, report.Items[0].Action)
+}
+
+func TestServiceRunRecognizesAlreadyTarget(t *testing.T) {
+	object := testObject()
+	inspection := legacyInspection(object)
+	inspection.PrimaryLegacyRows = 0
+	inspection.ConsolidatedLegacyRows = 0
+	inspection.PrimaryTargetRows = object.ExpectedRows
+	inspection.ConsolidatedTargetRows = object.ExpectedRows
+	inspection.CompletedAudit = true
+	repository := &fakeRepository{inspection: inspection}
+	service := NewService(repository, testObjectStore(object))
+
+	report, err := service.Run(context.Background(), testRequest(object, true), []Object{object})
+	require.NoError(t, err)
+	require.Equal(t, ActionAlreadyTarget, report.Items[0].Action)
+	require.Empty(t, repository.rehomeCalls)
+}
+
+func testObject() Object {
+	object := Object{
+		ObjectKey:         "consolidated/object.cscb.zstd",
+		StartHeight:       100,
+		EndHeight:         110,
+		ExpectedRows:      8,
+		ExpectedCanonical: 7,
+		ExpectedFenced:    3,
+		ExpectedDeleted:   3,
+		Source: ObjectVersion{
+			VersionID: "source-version",
+			ETag:      "source-etag",
+			Bytes:     100,
+		},
+		Destination: ObjectVersion{
+			VersionID: "destination-version",
+			ETag:      "destination-etag",
+			Bytes:     100,
+		},
+	}
+	object.EvidenceSHA256 = evidenceSHA256(object)
+	return object
+}
+
+func legacyInspection(object Object) Inspection {
+	return Inspection{
+		TotalRows:              object.ExpectedRows,
+		CanonicalRows:          object.ExpectedCanonical,
+		StartHeight:            object.StartHeight,
+		EndHeight:              object.EndHeight,
+		FencedRows:             object.ExpectedFenced,
+		DeletedVerifiedRows:    object.ExpectedDeleted,
+		PrimaryLegacyRows:      object.ExpectedRows,
+		ConsolidatedLegacyRows: object.ExpectedRows,
+	}
+}
+
+func testRequest(object Object, execute bool) Request {
+	return Request{
+		Environment:       "production",
+		Chain:             "solana-mainnet",
+		Tag:               2,
+		SourceBucket:      "legacy",
+		DestinationBucket: "v2",
+		TargetGeneration:  "v2",
+		Execute:           execute,
+		Approval: Approval{
+			Chain:      "solana-mainnet",
+			Objects:    1,
+			Rows:       object.ExpectedRows,
+			Transition: TransitionLegacyNullToV2,
+		},
+	}
+}
+
+func testObjectStore(object Object) *fakeObjectStore {
+	store := &fakeObjectStore{heads: make(map[string]ObjectHead)}
+	for _, entry := range []struct {
+		bucket  string
+		version ObjectVersion
+	}{
+		{bucket: "legacy", version: object.Source},
+		{bucket: "v2", version: object.Destination},
+	} {
+		head := ObjectHead{
+			Exists:    true,
+			VersionID: entry.version.VersionID,
+			ETag:      entry.version.ETag,
+			Bytes:     entry.version.Bytes,
+		}
+		store.heads[fmt.Sprintf("current/%s/%s", entry.bucket, object.ObjectKey)] = head
+		store.heads[fmt.Sprintf("version/%s/%s/%s", entry.bucket, object.ObjectKey, entry.version.VersionID)] = head
+	}
+	return store
+}

--- a/internal/storage/generationrehome/types.go
+++ b/internal/storage/generationrehome/types.go
@@ -1,0 +1,134 @@
+package generationrehome
+
+import (
+	"context"
+	"time"
+)
+
+type (
+	ObjectVersion struct {
+		VersionID string `json:"version_id"`
+		ETag      string `json:"etag"`
+		Bytes     uint64 `json:"bytes"`
+	}
+
+	Object struct {
+		ObjectKey         string        `json:"object_key"`
+		StartHeight       uint64        `json:"start_height"`
+		EndHeight         uint64        `json:"end_height"`
+		ExpectedRows      uint64        `json:"expected_rows"`
+		ExpectedCanonical uint64        `json:"expected_canonical_rows"`
+		ExpectedFenced    uint64        `json:"expected_fenced_rows"`
+		ExpectedDeleted   uint64        `json:"expected_deleted_verified_rows"`
+		Source            ObjectVersion `json:"source"`
+		Destination       ObjectVersion `json:"destination"`
+		EvidenceSHA256    string        `json:"evidence_sha256"`
+	}
+
+	Inspection struct {
+		TotalRows              uint64
+		CanonicalRows          uint64
+		StartHeight            uint64
+		EndHeight              uint64
+		MissingShadowRows      uint64
+		InvalidPlacementRows   uint64
+		FencedRows             uint64
+		DeletedVerifiedRows    uint64
+		ActiveRetentionRows    uint64
+		PinnedRepairRows       uint64
+		PrimaryLegacyRows      uint64
+		PrimaryTargetRows      uint64
+		PrimaryOtherRows       uint64
+		ConsolidatedLegacyRows uint64
+		ConsolidatedTargetRows uint64
+		ConsolidatedOtherRows  uint64
+		CompletedAudit         bool
+	}
+
+	ObjectHead struct {
+		Exists    bool
+		VersionID string
+		ETag      string
+		Bytes     uint64
+	}
+
+	Request struct {
+		Environment       string
+		Chain             string
+		Tag               uint32
+		SourceBucket      string
+		DestinationBucket string
+		TargetGeneration  string
+		Execute           bool
+		Approval          Approval
+		Progress          func(completed int, total int, item ReportItem)
+	}
+
+	Approval struct {
+		Chain      string
+		Objects    uint64
+		Rows       uint64
+		Transition string
+	}
+
+	Report struct {
+		GeneratedAt       time.Time    `json:"generated_at"`
+		DryRun            bool         `json:"dry_run"`
+		Environment       string       `json:"environment"`
+		Chain             string       `json:"chain"`
+		Tag               uint32       `json:"tag"`
+		SourceBucket      string       `json:"source_bucket"`
+		DestinationBucket string       `json:"destination_bucket"`
+		Transition        string       `json:"transition"`
+		Summary           Summary      `json:"summary"`
+		Items             []ReportItem `json:"items"`
+	}
+
+	Summary struct {
+		Objects          uint64 `json:"objects"`
+		Rows             uint64 `json:"rows"`
+		FencedRows       uint64 `json:"fenced_rows"`
+		ReadyObjects     uint64 `json:"ready_objects"`
+		CompletedObjects uint64 `json:"completed_objects"`
+		AlreadyTarget    uint64 `json:"already_target_objects"`
+		FailedObjects    uint64 `json:"failed_objects"`
+	}
+
+	ReportItem struct {
+		ObjectKey      string `json:"object_key"`
+		EvidenceSHA256 string `json:"evidence_sha256"`
+		StartHeight    uint64 `json:"start_height"`
+		EndHeight      uint64 `json:"end_height"`
+		Rows           uint64 `json:"rows"`
+		FencedRows     uint64 `json:"fenced_rows"`
+		Action         string `json:"action"`
+		Error          string `json:"error,omitempty"`
+	}
+
+	Repository interface {
+		Inspect(ctx context.Context, tag uint32, objectKey string, targetGeneration string, evidenceSHA256 string) (Inspection, error)
+		Rehome(ctx context.Context, req RehomeRequest) (alreadyTarget bool, err error)
+	}
+
+	ObjectStore interface {
+		HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error)
+		HeadObjectVersion(ctx context.Context, bucket string, key string, versionID string) (ObjectHead, error)
+	}
+
+	RehomeRequest struct {
+		Tag               uint32
+		SourceBucket      string
+		DestinationBucket string
+		TargetGeneration  string
+		Object            Object
+	}
+)
+
+const (
+	TransitionLegacyNullToV2 = "legacy-null-to-v2"
+	ActionReady              = "ready"
+	ActionRehome             = "rehome"
+	ActionRehomed            = "rehomed"
+	ActionAlreadyTarget      = "already_target"
+	ActionFailed             = "failed"
+)

--- a/internal/storage/generationrehome/types.go
+++ b/internal/storage/generationrehome/types.go
@@ -111,6 +111,7 @@ type (
 	}
 
 	ObjectStore interface {
+		InspectObjectRetentionSafety(ctx context.Context, bucket string, key string) error
 		HeadObject(ctx context.Context, bucket string, key string) (ObjectHead, error)
 		HeadObjectVersion(ctx context.Context, bucket string, key string, versionID string) (ObjectHead, error)
 	}

--- a/internal/storage/metastorage/postgres/db/migrations/20260816000001_add_fenced_storage_generation_rehome.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260816000001_add_fenced_storage_generation_rehome.sql
@@ -1,0 +1,313 @@
+-- +goose Up
+-- A completed single-block retirement deliberately freezes the consolidated
+-- placement. Legacy CSCB objects copied byte-for-byte into a configured storage
+-- generation therefore need an explicit, object-scoped exception rather than a
+-- disabled trigger or an unrestricted UPDATE.
+CREATE TABLE block_storage_generation_rehome (
+    id BIGSERIAL PRIMARY KEY,
+    evidence_sha256 CHAR(64) NOT NULL UNIQUE CHECK (evidence_sha256 ~ '^[0-9a-f]{64}$'),
+    tag INTEGER NOT NULL,
+    object_key_main TEXT NOT NULL CHECK (object_key_main <> ''),
+    source_generation TEXT NOT NULL CHECK (source_generation = 'legacy'),
+    target_generation TEXT NOT NULL CHECK (target_generation ~ '^v[1-9][0-9]*$'),
+    source_bucket TEXT NOT NULL CHECK (source_bucket <> ''),
+    source_version_id TEXT NOT NULL CHECK (
+        BTRIM(source_version_id) <> '' AND LOWER(BTRIM(source_version_id)) <> 'null'
+    ),
+    source_etag TEXT NOT NULL CHECK (source_etag <> ''),
+    destination_bucket TEXT NOT NULL CHECK (destination_bucket <> ''),
+    destination_version_id TEXT NOT NULL CHECK (
+        BTRIM(destination_version_id) <> '' AND LOWER(BTRIM(destination_version_id)) <> 'null'
+    ),
+    destination_etag TEXT NOT NULL CHECK (destination_etag <> ''),
+    object_bytes BIGINT NOT NULL CHECK (object_bytes > 0),
+    start_height BIGINT NOT NULL CHECK (start_height >= 0),
+    end_height BIGINT NOT NULL CHECK (end_height > start_height),
+    expected_block_count BIGINT NOT NULL CHECK (expected_block_count > 0),
+    expected_canonical_count BIGINT NOT NULL CHECK (
+        expected_canonical_count >= 0 AND expected_canonical_count <= expected_block_count
+    ),
+    expected_fenced_count BIGINT NOT NULL CHECK (
+        expected_fenced_count > 0 AND expected_fenced_count <= expected_block_count
+    ),
+    expected_deleted_verified_count BIGINT NOT NULL CHECK (
+        expected_deleted_verified_count = expected_fenced_count
+    ),
+    state TEXT NOT NULL CHECK (state IN ('executing', 'completed')),
+    executed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tag, object_key_main, source_generation, target_generation),
+    CHECK (source_bucket <> destination_bucket),
+    CHECK (
+        (state = 'executing' AND completed_at IS NULL)
+        OR (state = 'completed' AND completed_at IS NOT NULL AND completed_at >= executed_at)
+    )
+);
+
+-- The evidence is immutable. The only permitted mutation completes the exact
+-- transaction that inserted the executing row and changed both placements.
+-- +goose StatementBegin
+CREATE FUNCTION enforce_block_storage_generation_rehome_audit_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'block storage generation rehome audit rows are immutable';
+    END IF;
+
+    IF OLD.state = 'executing'
+        AND NEW.state = 'completed'
+        AND OLD.id IS NOT DISTINCT FROM NEW.id
+        AND OLD.evidence_sha256 IS NOT DISTINCT FROM NEW.evidence_sha256
+        AND OLD.tag IS NOT DISTINCT FROM NEW.tag
+        AND OLD.object_key_main IS NOT DISTINCT FROM NEW.object_key_main
+        AND OLD.source_generation IS NOT DISTINCT FROM NEW.source_generation
+        AND OLD.target_generation IS NOT DISTINCT FROM NEW.target_generation
+        AND OLD.source_bucket IS NOT DISTINCT FROM NEW.source_bucket
+        AND OLD.source_version_id IS NOT DISTINCT FROM NEW.source_version_id
+        AND OLD.source_etag IS NOT DISTINCT FROM NEW.source_etag
+        AND OLD.destination_bucket IS NOT DISTINCT FROM NEW.destination_bucket
+        AND OLD.destination_version_id IS NOT DISTINCT FROM NEW.destination_version_id
+        AND OLD.destination_etag IS NOT DISTINCT FROM NEW.destination_etag
+        AND OLD.object_bytes IS NOT DISTINCT FROM NEW.object_bytes
+        AND OLD.start_height IS NOT DISTINCT FROM NEW.start_height
+        AND OLD.end_height IS NOT DISTINCT FROM NEW.end_height
+        AND OLD.expected_block_count IS NOT DISTINCT FROM NEW.expected_block_count
+        AND OLD.expected_canonical_count IS NOT DISTINCT FROM NEW.expected_canonical_count
+        AND OLD.expected_fenced_count IS NOT DISTINCT FROM NEW.expected_fenced_count
+        AND OLD.expected_deleted_verified_count IS NOT DISTINCT FROM NEW.expected_deleted_verified_count
+        AND OLD.executed_at IS NOT DISTINCT FROM NEW.executed_at
+        AND OLD.completed_at IS NULL
+        AND NEW.completed_at IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION 'cannot mutate block storage generation rehome audit id %', OLD.id;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER block_storage_generation_rehome_update_trigger
+BEFORE UPDATE ON block_storage_generation_rehome
+FOR EACH ROW
+EXECUTE FUNCTION enforce_block_storage_generation_rehome_audit_mutation();
+
+CREATE TRIGGER block_storage_generation_rehome_delete_trigger
+BEFORE DELETE ON block_storage_generation_rehome
+FOR EACH ROW
+EXECUTE FUNCTION enforce_block_storage_generation_rehome_audit_mutation();
+
+-- Replace the primary-placement trigger with a narrowly scoped exception. The
+-- executing manifest is visible only inside the transaction performing the
+-- rehome, and every fenced block must already have a verified retirement.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION enforce_block_metadata_storage_generation_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+    pinned_old BOOLEAN;
+    approved_rehome BOOLEAN;
+    retirement_verified BOOLEAN;
+BEGIN
+    IF OLD.single_block_retention_fenced_at IS NOT NULL
+        AND NEW.storage_generation IS DISTINCT FROM OLD.storage_generation THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM block_storage_generation_rehome rehome
+            WHERE rehome.state = 'executing'
+                AND rehome.tag = OLD.tag
+                AND rehome.object_key_main = OLD.object_key_main
+                AND rehome.source_generation = 'legacy'
+                AND OLD.storage_generation IS NULL
+                AND rehome.target_generation = NEW.storage_generation
+        ) INTO approved_rehome;
+        IF NOT approved_rehome THEN
+            RAISE EXCEPTION 'cannot change storage generation after single-block object retirement is fenced for block_metadata id %', OLD.id;
+        END IF;
+
+        SELECT EXISTS (
+            SELECT 1
+            FROM block_single_block_retention retirement
+            JOIN block_consolidation_shadow shadow
+                ON shadow.block_metadata_id = retirement.block_metadata_id
+            WHERE retirement.block_metadata_id = OLD.id
+                AND retirement.state = 'deleted_verified'
+                AND retirement.deleted_at IS NOT NULL
+                AND retirement.verified_at IS NOT NULL
+                AND retirement.consolidated_object_key_main = OLD.object_key_main
+                AND shadow.single_block_object_deleted_at IS NOT NULL
+                AND shadow.consolidated_object_key_main = OLD.object_key_main
+        ) INTO retirement_verified;
+        IF NOT retirement_verified THEN
+            RAISE EXCEPTION 'cannot rehome fenced storage generation without verified single-block retirement for block_metadata id %', OLD.id;
+        END IF;
+    END IF;
+
+    IF NEW.storage_generation IS DISTINCT FROM OLD.storage_generation
+        AND NEW.object_key_main IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.object_key_main, 1));
+        SELECT EXISTS (
+            SELECT 1
+            FROM cscb_repair_manifest repair
+            WHERE repair.old_consolidated_object_key_main = NEW.object_key_main
+                AND NOT (
+                    repair.state = 'completed'
+                    AND repair.outcome = 'already_clean_storage_neutral'
+                )
+        ) INTO pinned_old;
+        IF pinned_old THEN
+            RAISE EXCEPTION 'cannot change storage generation for a pinned old CSCB object from block_metadata id %', OLD.id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Apply the same manifest requirement to retired shadow placements. The
+-- deleted single-block generation itself remains immutable and is not rehomed.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION enforce_block_consolidation_shadow_storage_generation_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+    pinned_old BOOLEAN;
+    approved_rehome BOOLEAN;
+    retirement_verified BOOLEAN;
+BEGIN
+    IF OLD.single_block_object_deleted_at IS NOT NULL
+        AND NEW.single_block_storage_generation IS DISTINCT FROM OLD.single_block_storage_generation THEN
+        RAISE EXCEPTION 'cannot change deleted single-block object storage generation for block_metadata id %', OLD.block_metadata_id;
+    END IF;
+
+    IF OLD.single_block_object_deleted_at IS NOT NULL
+        AND NEW.consolidated_storage_generation IS DISTINCT FROM OLD.consolidated_storage_generation THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM block_storage_generation_rehome rehome
+            WHERE rehome.state = 'executing'
+                AND rehome.tag = OLD.tag
+                AND rehome.object_key_main = OLD.consolidated_object_key_main
+                AND rehome.source_generation = 'legacy'
+                AND OLD.consolidated_storage_generation IS NULL
+                AND rehome.target_generation = NEW.consolidated_storage_generation
+        ) INTO approved_rehome;
+        IF NOT approved_rehome THEN
+            RAISE EXCEPTION 'cannot change retired consolidated storage generation without an executing rehome manifest for block_metadata id %', OLD.block_metadata_id;
+        END IF;
+
+        SELECT EXISTS (
+            SELECT 1
+            FROM block_single_block_retention retirement
+            WHERE retirement.block_metadata_id = OLD.block_metadata_id
+                AND retirement.state = 'deleted_verified'
+                AND retirement.deleted_at IS NOT NULL
+                AND retirement.verified_at IS NOT NULL
+                AND retirement.consolidated_object_key_main = OLD.consolidated_object_key_main
+        ) INTO retirement_verified;
+        IF NOT retirement_verified THEN
+            RAISE EXCEPTION 'cannot rehome retired consolidated storage generation without verified single-block retirement for block_metadata id %', OLD.block_metadata_id;
+        END IF;
+    END IF;
+
+    IF NEW.consolidated_storage_generation IS DISTINCT FROM OLD.consolidated_storage_generation
+        AND NEW.consolidated_object_key_main IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.consolidated_object_key_main, 1));
+        SELECT EXISTS (
+            SELECT 1
+            FROM cscb_repair_manifest repair
+            WHERE repair.old_consolidated_object_key_main = NEW.consolidated_object_key_main
+                AND NOT (
+                    repair.state = 'completed'
+                    AND repair.outcome = 'already_clean_storage_neutral'
+                )
+        ) INTO pinned_old;
+        IF pinned_old THEN
+            RAISE EXCEPTION 'cannot change storage generation for a pinned old CSCB object from consolidation shadow for block_metadata id %', OLD.block_metadata_id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Completed rows are permanent evidence for a placement transition. Refuse to
+-- remove the exception schema after it has been used.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    LOCK TABLE block_storage_generation_rehome IN ACCESS EXCLUSIVE MODE;
+    IF EXISTS (SELECT 1 FROM block_storage_generation_rehome) THEN
+        RAISE EXCEPTION 'cannot roll back fenced storage generation rehome migration after execution';
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- Restore the original storage-generation guards.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION enforce_block_metadata_storage_generation_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+    pinned_old BOOLEAN;
+BEGIN
+    IF OLD.single_block_retention_fenced_at IS NOT NULL
+        AND NEW.storage_generation IS DISTINCT FROM OLD.storage_generation THEN
+        RAISE EXCEPTION 'cannot change storage generation after single-block object retirement is fenced for block_metadata id %', OLD.id;
+    END IF;
+
+    IF NEW.storage_generation IS DISTINCT FROM OLD.storage_generation
+        AND NEW.object_key_main IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.object_key_main, 1));
+        SELECT EXISTS (
+            SELECT 1
+            FROM cscb_repair_manifest repair
+            WHERE repair.old_consolidated_object_key_main = NEW.object_key_main
+                AND NOT (
+                    repair.state = 'completed'
+                    AND repair.outcome = 'already_clean_storage_neutral'
+                )
+        ) INTO pinned_old;
+        IF pinned_old THEN
+            RAISE EXCEPTION 'cannot change storage generation for a pinned old CSCB object from block_metadata id %', OLD.id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION enforce_block_consolidation_shadow_storage_generation_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+    pinned_old BOOLEAN;
+BEGIN
+    IF OLD.single_block_object_deleted_at IS NOT NULL
+        AND NEW.single_block_storage_generation IS DISTINCT FROM OLD.single_block_storage_generation THEN
+        RAISE EXCEPTION 'cannot change deleted single-block object storage generation for block_metadata id %', OLD.block_metadata_id;
+    END IF;
+
+    IF NEW.consolidated_storage_generation IS DISTINCT FROM OLD.consolidated_storage_generation
+        AND NEW.consolidated_object_key_main IS NOT NULL THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(NEW.consolidated_object_key_main, 1));
+        SELECT EXISTS (
+            SELECT 1
+            FROM cscb_repair_manifest repair
+            WHERE repair.old_consolidated_object_key_main = NEW.consolidated_object_key_main
+                AND NOT (
+                    repair.state = 'completed'
+                    AND repair.outcome = 'already_clean_storage_neutral'
+                )
+        ) INTO pinned_old;
+        IF pinned_old THEN
+            RAISE EXCEPTION 'cannot change storage generation for a pinned old CSCB object from consolidation shadow for block_metadata id %', OLD.block_metadata_id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS block_storage_generation_rehome_delete_trigger ON block_storage_generation_rehome;
+DROP TRIGGER IF EXISTS block_storage_generation_rehome_update_trigger ON block_storage_generation_rehome;
+DROP FUNCTION IF EXISTS enforce_block_storage_generation_rehome_audit_mutation();
+DROP TABLE IF EXISTS block_storage_generation_rehome;

--- a/internal/storage/metastorage/postgres/generation_rehome_migration_integration_test.go
+++ b/internal/storage/metastorage/postgres/generation_rehome_migration_integration_test.go
@@ -1,0 +1,212 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/generationrehome"
+)
+
+func TestIntegrationFencedStorageGenerationRehomeGuard(t *testing.T) {
+	if os.Getenv("TEST_TYPE") != "integration" {
+		t.Skip("integration test")
+	}
+	ctx := context.Background()
+	cfg, err := config.New()
+	require.NoError(t, err)
+	if cfg.AWS.Postgres == nil {
+		t.Skip("Postgres is not configured")
+	}
+	if cfg.Env() == config.EnvProduction {
+		t.Skip("fenced generation rehome integration tests never write to production")
+	}
+	db, err := newDBConnection(ctx, cfg.AWS.Postgres)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	require.NoError(t, runMigrations(ctx, db))
+
+	t.Run("fenced update requires executing manifest", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback() }()
+		blockMetadataID, _, _, _ := insertFencedRehomeFixture(t, ctx, tx, uint64(time.Now().UnixNano()))
+
+		_, err = tx.ExecContext(ctx, `UPDATE block_metadata SET storage_generation = 'v2' WHERE id = $1`, blockMetadataID)
+		require.ErrorContains(t, err, "cannot change storage generation after single-block object retirement is fenced")
+	})
+
+	t.Run("exact manifest permits only consolidated generation rehome", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback() }()
+		blockMetadataID, tag, _, objectKey := insertFencedRehomeFixture(t, ctx, tx, uint64(time.Now().UnixNano())+1)
+
+		var auditID int64
+		err = tx.QueryRowContext(ctx, `
+			INSERT INTO block_storage_generation_rehome (
+				evidence_sha256, tag, object_key_main, source_generation, target_generation,
+				source_bucket, source_version_id, source_etag,
+				destination_bucket, destination_version_id, destination_etag, object_bytes,
+				start_height, end_height, expected_block_count, expected_canonical_count,
+				expected_fenced_count, expected_deleted_verified_count, state
+			) SELECT
+				$1, bm.tag, bm.object_key_main, 'legacy', 'v2',
+				'legacy-bucket', 'legacy-version', 'legacy-etag',
+				'v2-bucket', 'v2-version', 'v2-etag', 128,
+				bm.height, bm.height + 1, 1, 1, 1, 1, 'executing'
+			FROM block_metadata bm
+			WHERE bm.id = $2
+			RETURNING id`, fmt.Sprintf("%064x", blockMetadataID), blockMetadataID).Scan(&auditID)
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(ctx, `
+			UPDATE block_consolidation_shadow
+			SET consolidated_storage_generation = 'v2'
+			WHERE block_metadata_id = $1`, blockMetadataID)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(ctx, `UPDATE block_metadata SET storage_generation = 'v2' WHERE id = $1`, blockMetadataID)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(ctx, `
+			UPDATE block_storage_generation_rehome
+			SET state = 'completed', completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1`, auditID)
+		require.NoError(t, err)
+
+		var primaryGeneration, consolidatedGeneration sql.NullString
+		var singleBlockGeneration sql.NullString
+		err = tx.QueryRowContext(ctx, `
+			SELECT bm.storage_generation, shadow.consolidated_storage_generation, shadow.single_block_storage_generation
+			FROM block_metadata bm
+			JOIN block_consolidation_shadow shadow ON shadow.block_metadata_id = bm.id
+			WHERE bm.id = $1 AND bm.tag = $2 AND bm.object_key_main = $3`, blockMetadataID, tag, objectKey).Scan(
+			&primaryGeneration,
+			&consolidatedGeneration,
+			&singleBlockGeneration,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "v2", primaryGeneration.String)
+		require.Equal(t, "v2", consolidatedGeneration.String)
+		require.False(t, singleBlockGeneration.Valid)
+	})
+
+	t.Run("repository transaction is verified and idempotent", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		_, tag, height, objectKey := insertFencedRehomeFixture(t, ctx, tx, uint64(time.Now().UnixNano())+2)
+		require.NoError(t, tx.Commit())
+
+		ledger := fmt.Sprintf(`{"type":"audit_object","object_key":%q,"min_height":%d,"end_height_exclusive":%d,"referenced_rows":1,"canonical_rows":1,"valid_placement_rows":1,"consistent_shadow_rows":1,"fenced_rows":1,"deleted_retention_rows":1,"copy_eligible":true}
+{"type":"copy_verified","object_key":%q,"source_size":128,"source_etag":"source-etag","source_version_id":"source-version","destination_size":128,"destination_etag":"destination-etag","destination_version_id":"destination-version","verification":"complete"}
+`, objectKey, height, height+1, objectKey)
+		objects, err := generationrehome.LoadFencedCopyLedger(strings.NewReader(ledger))
+		require.NoError(t, err)
+		require.Len(t, objects, 1)
+		object := objects[0]
+		repository := generationrehome.NewPostgresRepository(db)
+
+		before, err := repository.Inspect(ctx, tag, objectKey, "v2", object.EvidenceSHA256)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), before.PrimaryLegacyRows)
+		require.False(t, before.CompletedAudit)
+
+		alreadyTarget, err := repository.Rehome(ctx, generationrehome.RehomeRequest{
+			Tag:               tag,
+			SourceBucket:      "legacy-bucket",
+			DestinationBucket: "v2-bucket",
+			TargetGeneration:  "v2",
+			Object:            object,
+		})
+		require.NoError(t, err)
+		require.False(t, alreadyTarget)
+
+		after, err := repository.Inspect(ctx, tag, objectKey, "v2", object.EvidenceSHA256)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), after.PrimaryTargetRows)
+		require.Equal(t, uint64(1), after.ConsolidatedTargetRows)
+		require.True(t, after.CompletedAudit)
+
+		alreadyTarget, err = repository.Rehome(ctx, generationrehome.RehomeRequest{
+			Tag:               tag,
+			SourceBucket:      "legacy-bucket",
+			DestinationBucket: "v2-bucket",
+			TargetGeneration:  "v2",
+			Object:            object,
+		})
+		require.NoError(t, err)
+		require.True(t, alreadyTarget)
+	})
+}
+
+func insertFencedRehomeFixture(t *testing.T, ctx context.Context, tx *sql.Tx, unique uint64) (int64, uint32, uint64, string) {
+	t.Helper()
+	tag := uint32(1_700_000_000 + unique%100_000_000)
+	height := uint64(8_000_000_000) + unique%100_000_000
+	hash := fmt.Sprintf("0x%064x", unique)
+	objectKey := fmt.Sprintf("2/consolidated/%d-%d.cscb.zstd", height, unique)
+	now := time.Now().UTC()
+
+	var blockMetadataID int64
+	err := tx.QueryRowContext(ctx, `
+		INSERT INTO block_metadata (
+			height, tag, hash, parent_height, object_key_main, timestamp, skipped,
+			object_format, byte_offset, byte_length, uncompressed_length,
+			single_block_retention_fenced_at
+		) VALUES ($1, $2, $3, $4, $5, $6, FALSE, 1, 0, 64, 128, $7)
+		RETURNING id`, height, tag, hash, height-1, objectKey, now.Unix(), now).Scan(&blockMetadataID)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO canonical_blocks (height, block_metadata_id, tag)
+		VALUES ($1, $2, $3)`, height, blockMetadataID, tag)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO block_consolidation_shadow (
+			block_metadata_id, tag, height, hash, legacy_object_key_main,
+			single_block_object_key_main, consolidated_object_key_main, object_format,
+			byte_offset, byte_length, uncompressed_length, validated_at,
+			single_block_object_deleted_at
+		) VALUES ($1, $2, $3, $4, NULL, NULL, $5, 1, 0, 64, 128, $6, $7)`,
+		blockMetadataID, tag, height, hash, objectKey, now, now,
+	)
+	require.NoError(t, err)
+
+	// The fixture starts after the normal retirement state machine has completed;
+	// disable only its insert gate while retaining every generation rehome guard.
+	_, err = tx.ExecContext(ctx, `ALTER TABLE block_single_block_retention DISABLE TRIGGER block_single_block_retention_insert_trigger`)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO block_single_block_retention (
+			block_metadata_id, tag, height, hash, state, bucket,
+			single_block_object_key_main, single_block_object_key_sha256,
+			single_block_object_version_ids, single_block_object_etag, single_block_object_bytes,
+			consolidated_object_key_main, consolidated_object_version_id, consolidated_object_etag,
+			consolidated_byte_offset, consolidated_byte_length, consolidated_uncompressed_length,
+			payload_sha256, outcome, attempt_count, prepared_at, delete_started_at,
+			last_attempt_at, deleted_at, verified_at
+		) VALUES (
+			$1, $2, $3, $4, 'deleted_verified', 'legacy-bucket',
+			NULL, $5, ARRAY['single-version'], '', 128,
+			$6, 'consolidated-version', 'consolidated-etag', 0, 64, 128,
+			$7, 'deleted_and_verified', 1, $8, $8, $8, $8, $8
+		)`,
+		blockMetadataID,
+		tag,
+		height,
+		hash,
+		fmt.Sprintf("%064x", unique+1),
+		objectKey,
+		fmt.Sprintf("%064x", unique+2),
+		now,
+	)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, `ALTER TABLE block_single_block_retention ENABLE TRIGGER block_single_block_retention_insert_trigger`)
+	require.NoError(t, err)
+	return blockMetadataID, tag, height, objectKey
+}

--- a/internal/storage/metastorage/postgres/generation_rehome_migration_integration_test.go
+++ b/internal/storage/metastorage/postgres/generation_rehome_migration_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coinbase/chainstorage/internal/config"
+	"github.com/coinbase/chainstorage/internal/storage/cscbrepairlock"
 	"github.com/coinbase/chainstorage/internal/storage/generationrehome"
 )
 
@@ -142,6 +143,42 @@ func TestIntegrationFencedStorageGenerationRehomeGuard(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.True(t, alreadyTarget)
+	})
+
+	t.Run("repository waits for repair tag lock before object lock", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		_, tag, height, objectKey := insertFencedRehomeFixture(t, ctx, tx, uint64(time.Now().UnixNano())+3)
+		require.NoError(t, tx.Commit())
+
+		ledger := fmt.Sprintf(`{"type":"audit_object","object_key":%q,"min_height":%d,"end_height_exclusive":%d,"referenced_rows":1,"canonical_rows":1,"valid_placement_rows":1,"consistent_shadow_rows":1,"fenced_rows":1,"deleted_retention_rows":1,"copy_eligible":true}
+{"type":"copy_verified","object_key":%q,"source_size":128,"source_etag":"source-etag","source_version_id":"source-version","destination_size":128,"destination_etag":"destination-etag","destination_version_id":"destination-version","verification":"complete"}
+`, objectKey, height, height+1, objectKey)
+		objects, err := generationrehome.LoadFencedCopyLedger(strings.NewReader(ledger))
+		require.NoError(t, err)
+		require.Len(t, objects, 1)
+		req := generationrehome.RehomeRequest{
+			Tag:               tag,
+			SourceBucket:      "legacy-bucket",
+			DestinationBucket: "v2-bucket",
+			TargetGeneration:  "v2",
+			Object:            objects[0],
+		}
+
+		lockTx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = lockTx.Rollback() }()
+		require.NoError(t, cscbrepairlock.AcquireTag(ctx, lockTx, tag))
+
+		blockedCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+		defer cancel()
+		_, err = generationrehome.NewPostgresRepository(db).Rehome(blockedCtx, req)
+		require.ErrorContains(t, err, "failed to acquire CSCB repair tag lock")
+		require.NoError(t, lockTx.Rollback())
+
+		alreadyTarget, err := generationrehome.NewPostgresRepository(db).Rehome(ctx, req)
+		require.NoError(t, err)
+		require.False(t, alreadyTarget)
 	})
 }
 


### PR DESCRIPTION
## Summary
- add an object-scoped, immutable audit exception for fenced legacy-null CSCB placements copied to v2
- add a dry-run-by-default admin command that consumes the existing copy ledger and verifies exact S3 versions, row counts, placements, retired rows, and repair/retention safety
- update only primary and consolidated storage generations in one locked transaction; deleted single-block generation remains legacy
- make execution exact-count approved, production double-confirmed, resumable, and idempotent

## Production cohort evidence
- 522 fenced objects
- 520,666 referenced/canonical rows
- 519,667 fenced rows, all deleted_verified
- 0 invalid audits, missing verified copies, size mismatches, active retention rows, or active repair objects in the source audit

## Validation
- TEST_TYPE=unit go test ./...
- go vet ./... plus errcheck and ineffassign
- local Postgres integration: ordinary fenced update rejected; exact manifest transition succeeds; repository transaction verified and idempotent

Linear: https://linear.app/cipherowl/issue/INF-1288