### PR TITLE
feat(INF-1335): raise backfill parallelism limit

### DIFF
--- a/internal/workflow/batch_consolidator.go
+++ b/internal/workflow/batch_consolidator.go
@@ -72,7 +72,7 @@ const (
 	batchConsolidatorRepairParallelismChangeID     = "batch-consolidator-repair-parallelism"
 	batchConsolidatorRepairParallelismVersion      = 1
 	batchConsolidatorPreviousMaxParallelism        = 10
-	batchConsolidatorMaxParallelism                = 20
+	batchConsolidatorMaxParallelism                = 50
 	maxUint64                                      = ^uint64(0)
 )
 

--- a/internal/workflow/batch_consolidator_test.go
+++ b/internal/workflow/batch_consolidator_test.go
@@ -301,7 +301,7 @@ func (s *batchConsolidatorTestSuite) TestBatchConsolidatorRejectsExcessiveParall
 		Parallelism: batchConsolidatorMaxParallelism + 1,
 	})
 	require.Error(err)
-	require.Contains(err.Error(), "parallelism(21) exceeds max(20)")
+	require.Contains(err.Error(), "parallelism(51) exceeds max(50)")
 }
 
 func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParallelism() {
@@ -315,7 +315,7 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParalle
 	s.cfg.Workflows.BatchConsolidator.Storage.Consolidation.ShardSize = 10000
 	var requests []*activity.BatchConsolidatorRequest
 	var requestsMu sync.Mutex
-	s.mockAutoConsolidateLatestHeight(120010)
+	s.mockAutoConsolidateLatestHeight(150010)
 	s.mockEmptyShadowStats()
 	s.env.OnActivity(activity.ActivityBatchConsolidator, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, request *activity.BatchConsolidatorRequest) (*activity.BatchConsolidatorResponse, error) {
@@ -335,13 +335,13 @@ func (s *batchConsolidatorTestSuite) TestHistoricalBackfillAcceptsMaximumParalle
 		Mode:        config.ConsolidationModeHistoricalBackfill,
 		Tag:         2,
 		StartHeight: 100000,
-		EndHeight:   120000,
-		BatchSize:   20000,
+		EndHeight:   150000,
+		BatchSize:   50000,
 		MaxBlocks:   1000,
-		Parallelism: 20,
+		Parallelism: 50,
 	})
 	require.NoError(err)
-	require.Len(requests, 20)
+	require.Len(requests, 50)
 	sort.Slice(requests, func(i, j int) bool {
 		return requests[i].StartHeight < requests[j].StartHeight
 	})


### PR DESCRIPTION
## Summary

- raise the batch consolidator hard parallelism limit from 20 to 50
- extend the maximum-parallelism test to schedule fifty 1,000-height activities from a 50,000-height batch
- keep the boundary guard by rejecting parallelism 51

## Why 50-way parallelism

The Solana historical CSCB backfill has 417,679,000 heights remaining. Completed equal-size production runs show nearly linear scaling from ten to twenty active workers:

| Configuration | Throughput | Estimated full-backfill time |
|---|---:|---:|
| 10 pods / p10 | 140,847 heights/hour | 123.6 days |
| 20 pods / p20 | 279,113 heights/hour | 62.4 days |
| 50 pods / p50 projected | 689,346 heights/hour | 25.2 days |

P10 to p20 delivered 1.9817x throughput for a 2x concurrency increase. Applying that measured scaling efficiency to p50 projects 689k heights/hour; the planning sensitivity is 550k-700k, or 24.9-31.6 days.

The expected p50 benefit versus the current p20 configuration is about 37.1 days of elapsed time. A fair common-horizon AWS cost comparison, including worker EC2/EBS, v1 and v2 S3 byte-months, S3 requests, and an Aurora storage-growth allowance, is:

| Configuration | Marginal-node attribution | Full-node attribution |
|---|---:|---:|
| 10/10 | $23.1k | $27.0k |
| 20/20 | $22.1k | $26.0k |
| 50/50 | $21.5k | $25.5k |

At central throughput, p50 is approximately $0.54k-$0.59k cheaper than p20 while finishing five weeks earlier. It saves about $2.96k of gross v1 storage versus p20; earlier creation of permanent v2 data offsets most of that, leaving about $0.72k of net transformed-storage savings.

P50 must sustain approximately 622k-652k heights/hour to break even with p20, depending on node attribution. If a canary only reaches the 550k sensitivity case, p50 is expected to cost about $1.85k more than p20 and should not be continued.

Cost notes:

- Aurora is I/O-Optimized, so read/write IOPS add no request charge.
- Remaining S3 request cost is approximately $169 and is independent of parallelism.
- Both S3 buckets use SSE-S3 and a VPC gateway endpoint, so there is no KMS, NAT, or same-region S3 transfer charge.
- Existing Aurora compute, Temporal, and the EKS control plane are shared fixed infrastructure and do not disappear when the backfill completes.

## Validation

- make test TARGET=internal/workflow
- repository-wide go vet, errcheck, and ineffassign through the canonical Make target

## Operational note

This PR only raises the workflow validation ceiling. It does not scale workers, deploy production, or start a historical backfill. A production p50 run still requires the reviewed worker/config deployment and a staged 1M-height canary using BatchSize 50000, CheckpointSize 100000, MaxBlocks 1000, and Parallelism 50.

The canary should continue only if it sustains at least 650k heights/hour, retries remain negligible, all 50 pods remain healthy, and Aurora CPU, connections, and free memory remain within safe bounds. The isolated p50 worker pool should be reduced from min 5 / max 25 connections per pod to approximately min 1 / max 5 before the run.

Linear: https://linear.app/cipherowl/issue/INF-1335/raise-chainstorage-historical-backfill-parallelism-limit-to-50