### PR TITLE
fix(INF-1330): make the retention generation filter indexable

### DIFF
--- a/internal/storage/metastorage/postgres/db/migrations/20260817000001_add_generation_aware_retention_due_index.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260817000001_add_generation_aware_retention_due_index.sql
@@ -1,0 +1,41 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- The due-cohort probe filters storage generation as well as tag, due time and
+-- height, but idx_block_consolidation_shadow_retention_due leads with
+-- (tag, single_block_delete_after, height) only. Every legacy-generation row
+-- therefore has to be examined and discarded on each probe. On solana-mainnet
+-- prod that is ~20.9M rows against ~768k v2 rows, which pushed the hourly
+-- retention probe past its 60s statement timeout and stalled retention
+-- entirely (INF-1330).
+--
+-- Leading with the generation lets the planner seek straight to the rows of the
+-- active write generation, so probe cost tracks live work rather than the
+-- accumulated history of superseded generations.
+--
+-- This index is only reachable because the queries now match generation with
+-- plain equality (or IS NULL for the legacy generation). The previous
+-- `IS NOT DISTINCT FROM NULLIF($n, '')` form cannot use a btree index at all,
+-- so this migration is inert without that code change.
+--
+-- The predicate is kept identical to the existing due index so both describe
+-- the same row set. The older index is deliberately left in place: it still
+-- serves probes that do not constrain generation, and dropping it belongs in a
+-- follow-up once production plans confirm the new one is chosen.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_due_generation
+    ON block_consolidation_shadow (
+        tag,
+        single_block_storage_generation,
+        single_block_delete_after,
+        height
+    )
+    WHERE validated_at IS NOT NULL
+        AND single_block_delete_after IS NOT NULL
+        AND single_block_object_deleted_at IS NULL
+        AND single_block_object_key_main IS NOT NULL
+        AND single_block_object_key_main <> ''
+        AND consolidated_object_key_main IS NOT NULL
+        AND consolidated_object_key_main <> '';
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_retention_due_generation;

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -13,6 +14,39 @@ import (
 
 type retentionCohortQuerier interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// storageGenerationMatch renders an indexable generation match for each column.
+//
+// The null-safe IS NOT DISTINCT FROM form these queries used, against a
+// NULLIF of the generation parameter, cannot use a btree index at all —
+// verified with EXPLAIN against production:
+// `height = 439200000` plans an Index Only Scan while
+// `height IS NOT DISTINCT FROM 439200000` falls back to a parallel sequential
+// scan. Because the generation value is known when the query is built, the
+// same semantics are expressible as plain equality (concrete generation) or an
+// IS NULL test (the legacy generation, stored as NULL), both of which the
+// planner can seek on. Adding a generation column to an index is worthless
+// until the query is written this way (INF-1330).
+//
+// placeholder is referenced only for a concrete generation; callers must bind
+// the generation argument exactly when storageGenerationIsBound reports true.
+func storageGenerationMatch(generation string, placeholder string, columns ...string) string {
+	predicates := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if generation == "" {
+			predicates = append(predicates, column+" IS NULL")
+			continue
+		}
+		predicates = append(predicates, column+" = "+placeholder)
+	}
+	return strings.Join(predicates, "\n\t\t\tAND ")
+}
+
+// storageGenerationIsBound reports whether storageGenerationMatch referenced
+// its placeholder, so callers append the argument only when the query uses it.
+func storageGenerationIsBound(generation string) bool {
+	return generation != ""
 }
 
 // ListRetentionCohorts reads pending and newly due work from one repeatable-read
@@ -137,23 +171,21 @@ func listPendingRetentionCohorts(
 			AND ($3::BIGINT = 0 OR (retention.height >= $2 AND retention.height < $3))
 			AND shadow.single_block_delete_after <= $4
 			AND retention.bucket = $6
-			AND metadata.storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
-			AND shadow.single_block_storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
-			AND shadow.consolidated_storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
+			AND ` + storageGenerationMatch(
+		storageGeneration,
+		"$7",
+		"metadata.storage_generation",
+		"shadow.single_block_storage_generation",
+		"shadow.consolidated_storage_generation",
+	) + `
 		GROUP BY retention.consolidated_object_key_main
 		ORDER BY MIN(retention.prepared_at), MIN(retention.height), retention.consolidated_object_key_main
 		LIMIT $5`
-	rows, err := db.QueryContext(
-		ctx,
-		query,
-		tag,
-		startHeight,
-		endHeight,
-		eligibilityCutoff,
-		limit,
-		bucket,
-		storageGeneration,
-	)
+	args := []any{tag, startHeight, endHeight, eligibilityCutoff, limit, bucket}
+	if storageGenerationIsBound(storageGeneration) {
+		args = append(args, storageGeneration)
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query pending retention cohorts: %w", err)
 	}
@@ -255,9 +287,7 @@ func listDueRetentionCohorts(
 				AND due_metadata.skipped = FALSE
 				AND due_metadata.object_format = $4
 				AND due_metadata.object_key_main = shadow.consolidated_object_key_main
-				AND due_metadata.storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
-				AND shadow.single_block_storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
-				AND shadow.consolidated_storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
+				AND %s
 				AND ($3::BIGINT = 0 OR (shadow.height >= $2 AND shadow.height < $3))
 				AND NOT EXISTS (
 					SELECT 1
@@ -293,9 +323,7 @@ func listDueRetentionCohorts(
 			AND shadow.single_block_object_key_main <> ''
 			AND metadata.skipped = FALSE
 			AND metadata.object_format = $4
-			AND metadata.storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
-			AND shadow.single_block_storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
-			AND shadow.consolidated_storage_generation IS NOT DISTINCT FROM NULLIF($7, '')
+			AND %s
 			AND ($3::BIGINT = 0 OR (shadow.height >= $2 AND shadow.height < $3))
 			AND metadata.object_key_main = shadow.consolidated_object_key_main
 			AND NOT EXISTS (
@@ -319,18 +347,36 @@ func listDueRetentionCohorts(
 		HAVING MAX(shadow.single_block_delete_after) <= $6
 		ORDER BY %s
 		LIMIT $5`
-	query := fmt.Sprintf(queryTemplate, dueRetentionCohortOrdering(endHeight))
-	rows, err := db.QueryContext(
-		ctx,
-		query,
+	query := fmt.Sprintf(
+		queryTemplate,
+		storageGenerationMatch(
+			storageGeneration,
+			"$7",
+			"due_metadata.storage_generation",
+			"shadow.single_block_storage_generation",
+			"shadow.consolidated_storage_generation",
+		),
+		storageGenerationMatch(
+			storageGeneration,
+			"$7",
+			"metadata.storage_generation",
+			"shadow.single_block_storage_generation",
+			"shadow.consolidated_storage_generation",
+		),
+		dueRetentionCohortOrdering(endHeight),
+	)
+	args := []any{
 		tag,
 		startHeight,
 		endHeight,
 		api.BlockObjectFormat_BLOCK_OBJECT_FORMAT_CSCB_BATCH,
 		limit,
 		eligibilityCutoff,
-		storageGeneration,
-	)
+	}
+	if storageGenerationIsBound(storageGeneration) {
+		args = append(args, storageGeneration)
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query due retention cohorts: %w", err)
 	}

--- a/internal/storage/retirement/storage_generation_sql_test.go
+++ b/internal/storage/retirement/storage_generation_sql_test.go
@@ -1,0 +1,138 @@
+package retirement
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// generationDueIndexMigration defines the generation-aware due index that the
+// equality form below is what makes reachable.
+const generationDueIndexMigration = "../metastorage/postgres/db/migrations/20260817000001_add_generation_aware_retention_due_index.sql"
+
+func TestStorageGenerationMatchRendersIndexablePredicates(t *testing.T) {
+	require := require.New(t)
+
+	require.Equal(
+		"metadata.storage_generation = $7",
+		storageGenerationMatch("v2", "$7", "metadata.storage_generation"),
+	)
+	require.True(storageGenerationIsBound("v2"))
+
+	// The legacy generation is stored as NULL, so it needs an IS NULL test and
+	// binds no argument.
+	require.Equal(
+		"metadata.storage_generation IS NULL",
+		storageGenerationMatch("", "$7", "metadata.storage_generation"),
+	)
+	require.False(storageGenerationIsBound(""))
+
+	// Several columns share one placeholder.
+	require.Equal(
+		"a = $7\n\t\t\tAND b = $7",
+		storageGenerationMatch("v2", "$7", "a", "b"),
+	)
+}
+
+// TestSelectorQueriesAvoidIsNotDistinctFrom fails if a generation filter
+// regresses to the null-safe form. `col IS NOT DISTINCT FROM ...` cannot use a
+// btree index — verified against production, where the identical predicate
+// written as `=` plans an Index Only Scan and the IS NOT DISTINCT FROM form
+// falls back to a parallel sequential scan — which silently makes the
+// generation-aware due index useless (INF-1330).
+func TestSelectorQueriesAvoidIsNotDistinctFrom(t *testing.T) {
+	require := require.New(t)
+	source, err := os.ReadFile(filepath.Clean("selector_postgres.go"))
+	require.NoError(err)
+
+	// Scan code only: the doc comment on storageGenerationMatch names the
+	// anti-pattern in order to explain it.
+	offenders := make([]int, 0)
+	for number, line := range strings.Split(string(source), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		if strings.Contains(line, "IS NOT DISTINCT FROM") {
+			offenders = append(offenders, number+1)
+		}
+	}
+	require.Empty(
+		offenders,
+		"selector_postgres.go must match storage generation with = or IS NULL so the due index stays usable; offending lines: %v",
+		offenders,
+	)
+}
+
+// TestGenerationDueIndexMatchesQueryShape pins the migration's index to the
+// columns the probe actually filters, so the index and the query cannot drift
+// apart silently.
+func TestGenerationDueIndexMatchesQueryShape(t *testing.T) {
+	require := require.New(t)
+	source, err := os.ReadFile(filepath.Clean(generationDueIndexMigration))
+	require.NoError(err)
+	definition := regexp.MustCompile(`(?s)CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_due_generation.*?\((.*?)\)\s*WHERE`).
+		FindStringSubmatch(string(source))
+	require.Len(definition, 2, "index definition not found in %s", generationDueIndexMigration)
+
+	columns := make([]string, 0, 4)
+	for _, field := range strings.Split(definition[1], ",") {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			columns = append(columns, trimmed)
+		}
+	}
+	require.Equal(
+		[]string{"tag", "single_block_storage_generation", "single_block_delete_after", "height"},
+		columns,
+		"generation must lead the due index so the probe can seek past superseded generations",
+	)
+}
+
+// TestDueCohortQueryBindsGenerationOnlyWhenReferenced guards the argument list
+// against the placeholder/argument mismatch that conditional SQL invites: a
+// bound-but-unreferenced parameter is a runtime error from the driver.
+func TestDueCohortQueryBindsGenerationOnlyWhenReferenced(t *testing.T) {
+	require := require.New(t)
+	for _, generation := range []string{"v2", ""} {
+		recorder := &recordingCohortQuerier{}
+		_, err := listDueRetentionCohorts(
+			context.Background(), recorder, generation, 2, 0, 0, time.Now().UTC(), 10,
+		)
+		// The recorder never returns rows; the query text and bound arguments
+		// are what this asserts on.
+		require.Error(err)
+		placeholders := regexp.MustCompile(`\$(\d+)`).FindAllStringSubmatch(recorder.query, -1)
+		highest := 0
+		for _, match := range placeholders {
+			index := 0
+			for _, digit := range match[1] {
+				index = index*10 + int(digit-'0')
+			}
+			if index > highest {
+				highest = index
+			}
+		}
+		require.Equal(highest, len(recorder.args),
+			"generation=%q must bind exactly the placeholders the query references", generation)
+	}
+}
+
+type recordingCohortQuerier struct {
+	query string
+	args  []any
+}
+
+var errRecordingQuerier = errors.New("recording querier does not execute")
+
+func (r *recordingCohortQuerier) QueryContext(_ context.Context, query string, args ...any) (*sql.Rows, error) {
+	r.query = query
+	r.args = args
+	return nil, errRecordingQuerier
+}


### PR DESCRIPTION
The durable fix for the probe timeout that stalled retention. monorepo#14913 unblocked it by narrowing the height floor; this removes the underlying cost so the floor is no longer load-bearing.

## The problem

Since 04:00Z the hourly retention probe failed every tick:

```
task=single_block_retention duration=1m0s
error: failed to query due retention cohorts: pq: canceling statement due to statement timeout
```

The due query filters storage generation, but expressed it as `col IS NOT DISTINCT FROM NULLIF($n, '')` for null-safety. **That form cannot use a btree index at all.** Verified against production with a controlled pair — same column, same value:

| predicate | plan |
|---|---|
| `height = 439200000` | **Index Only Scan** |
| `height IS NOT DISTINCT FROM 439200000` | **Parallel Seq Scan** |

So every probe had to examine all **~20.9M legacy-generation shadow rows** to find the ~768k v2 rows that can actually match.

This is why the change touches the query *and* the schema together: a migration adding a generation column to the due index would have been **completely inert** while the query kept that operator. I checked that before writing the migration, having already been caught twice in this incident by a bound that turned out not to be one.

## The change

**Query** — the generation value is known when the query is built, so render an indexable predicate instead of a null-safe one:

- concrete generation → `col = $n`
- legacy generation (stored as `NULL`) → `col IS NULL`

The generation argument is bound only when the rendered SQL references it, so placeholders and arguments cannot drift (a conditional-SQL trap that surfaces as a driver-level "bind message supplies N parameters" error).

**Schema** — `idx_block_consolidation_shadow_retention_due_generation`, leading with `(tag, single_block_storage_generation, single_block_delete_after, height)` and the same partial predicate as the existing due index, so the probe seeks straight to the active write generation instead of walking superseded ones.

The existing due index is deliberately **kept**: it still serves probes that do not constrain generation, and dropping it belongs in a follow-up once production plans confirm the new one is chosen.

## Equivalence, verified before shipping

Both predicate forms run against production over the current probe window return identical results:

| form | cohorts | first key | rows |
|---|---|---|---|
| `IS NOT DISTINCT FROM NULLIF('v2','')` | 146 | `…439111000-439112000-cef9486…` | 145,554 |
| `= 'v2'` | **146** | **same** | **145,554** |
| legacy, old form | 0 | — | — |
| legacy, new form (`IS NULL`) | 0 | — | — |

## Deployment

The migration is **not** applied by running services (`connection.go` deliberately does not migrate at runtime); it needs `admin db-migrate` per database. `CREATE INDEX CONCURRENTLY` under `-- +goose NO TRANSACTION`, so it does not lock writes, and `IF NOT EXISTS` makes re-runs safe.

Order: deploy the image first, then migrate. The rewritten query is correct without the index (it simply keeps today's plan), and the index is inert without the query — so neither half can regress the other regardless of ordering.

Once both are in place and `EXPLAIN` confirms the new index is chosen, `approved_start_height` can go back to 0, which removes the remaining silent-stranding risk for a repaired v2 object below the current floor.

## Testing

- `make test` green; `go test -race` green on `retirement` and `cron`.
- New tests: rendered predicates for both generation modes; a guard that fails if `IS NOT DISTINCT FROM` returns to the selector (scanning code, not comments); the index columns pinned to what the probe filters; and each generation mode binding exactly the placeholders its SQL references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
