### PR TITLE
fix(INF-1330): advance the retention probe floor with a watermark

### DIFF
--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -150,22 +150,69 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 		return err
 	}
 	eligibilityCutoff := time.Now().UTC()
-	// The probe's cost is bounded by the undeleted backlog through the partial
-	// retention-due index, never by the width of the approved range. It asks
-	// for a full workflow batch because the selector sorts pending (in-flight)
-	// cohorts by prepared_at ahead of height-ordered due cohorts: anchoring on
-	// the first cohort alone could hide older due work behind a stuck pending
-	// cohort indefinitely.
+	// Probe from the watermark rather than the operator's approved floor.
+	//
+	// The probe's cost is NOT bounded by the undeleted backlog alone, which is
+	// what an earlier version of this comment claimed and what justified
+	// dropping the floor to 0 in production. The due-cohort query joins its
+	// due_keys CTE back to block_consolidation_shadow to expand each cohort,
+	// and that join is bounded only by the height range: measured on
+	// solana-mainnet prod, past roughly 1.5M heights of width the planner
+	// abandons idx_block_consolidation_shadow_tag_height for a sequential scan
+	// of the whole table and the probe stops finishing inside its 60s statement
+	// timeout. A fixed floor widens at the chain's block rate and reaches that
+	// point unaided (INF-1330).
+	//
+	// The watermark is the lowest height still holding an undeleted single-block
+	// object, so it tracks live work and holds the range at the retention delay
+	// expressed in blocks. It is recomputed every tick rather than persisted:
+	// a stored floor would need its own reconciliation for repairs and failed
+	// sweeps, and a stale one strands data silently.
+	probeStart, err := selector.FloorWatermark(ctx, storageGeneration, tag, cronConfig.ApprovedStartHeight)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve retention floor watermark: %w", err)
+	}
+	if probeStart >= approvedEnd {
+		// Everything approved has been retired. Report a zero-width range so the
+		// width alarm cannot mistake a finished sweep for unbounded growth.
+		t.metrics.Gauge("floor_watermark_height").Update(float64(probeStart))
+		t.metrics.Gauge("probe_range_blocks").Update(0)
+		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
+		t.metrics.Gauge("probe_backlog_truncated").Update(0)
+		t.logger.Info(
+			"single_block_retention cron found no outstanding single-block work",
+			zap.Uint32("tag", tag),
+			zap.String("bucket", bucket),
+			zap.String("storage_generation", storageGeneration),
+			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
+			zap.Uint64("approved_end_height", approvedEnd),
+			zap.Uint64("floor_watermark_height", probeStart),
+		)
+		return nil
+	}
+	// probe_range_blocks is the leading indicator for the plan flip described
+	// above: it is the one number that predicts the timeout before it happens,
+	// where oldest_due_age_seconds cannot — that gauge is derived from this very
+	// probe, so it reads zero exactly when the probe fails.
+	t.metrics.Gauge("floor_watermark_height").Update(float64(probeStart))
+	t.metrics.Gauge("probe_range_blocks").Update(float64(approvedEnd - probeStart))
+
+	probeStartedAt := time.Now()
+	// Asks for a full workflow batch because the selector sorts pending
+	// (in-flight) cohorts by prepared_at ahead of height-ordered due cohorts:
+	// anchoring on the first cohort alone could hide older due work behind a
+	// stuck pending cohort indefinitely.
 	cohorts, hasMore, err := selector.Select(
 		ctx,
 		bucket,
 		storageGeneration,
 		tag,
-		cronConfig.ApprovedStartHeight,
+		probeStart,
 		approvedEnd,
 		eligibilityCutoff,
 		retirement.MaxRetentionCohortsPerWorkflow,
 	)
+	t.metrics.Gauge("probe_duration_seconds").Update(time.Since(probeStartedAt).Seconds())
 	if err != nil {
 		return xerrors.Errorf("failed to probe due retention cohorts: %w", err)
 	}
@@ -179,6 +226,8 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 			zap.String("storage_generation", storageGeneration),
 			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
 			zap.Uint64("approved_end_height", approvedEnd),
+			zap.Uint64("floor_watermark_height", probeStart),
+			zap.Uint64("probe_range_blocks", approvedEnd-probeStart),
 			zap.Bool("has_more", hasMore),
 		)
 		return nil
@@ -268,6 +317,8 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
 		zap.Uint64("window_end_height", windowEnd),
 		zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
 		zap.Uint64("approved_end_height", approvedEnd),
+		zap.Uint64("floor_watermark_height", probeStart),
+		zap.Uint64("probe_range_blocks", approvedEnd-probeStart),
 		zap.Time("eligibility_cutoff", eligibilityCutoff),
 		zap.Duration("oldest_due_age", oldestDueAge),
 		zap.Int("max_object_ranges", cronConfig.MaxObjectRanges),

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -29,6 +29,27 @@ type retentionCronCohortRepository struct {
 	requestedStartHeight uint64
 	requestedEndHeight   uint64
 	requestedLimit       int
+
+	// watermark drives the probe floor. found=false makes the selector fall
+	// back to the operator's approved_start_height, which is the behaviour
+	// every pre-existing case in this file expects.
+	watermark          uint64
+	watermarkFound     bool
+	watermarkErr       error
+	watermarkMinHeight uint64
+}
+
+func (r *retentionCronCohortRepository) RetentionFloorWatermark(
+	_ context.Context,
+	_ string,
+	_ uint32,
+	minHeight uint64,
+) (uint64, bool, error) {
+	r.watermarkMinHeight = minHeight
+	if r.watermarkErr != nil {
+		return 0, false, r.watermarkErr
+	}
+	return r.watermark, r.watermarkFound, nil
 }
 
 func (r *retentionCronCohortRepository) ListRetentionCohorts(
@@ -369,4 +390,90 @@ func TestSingleBlockRetentionCronDefaults(t *testing.T) {
 	require.True(t, task.Enabled())
 	cfg.Cron.SingleBlockRetention.Enabled = false
 	require.False(t, task.Enabled())
+}
+
+// TestSingleBlockRetentionCronProbesFromTheFloorWatermark is the regression
+// guard for INF-1330. The probe must start at the watermark, not the operator's
+// approved floor: the due-cohort query's cohort-expansion join is bounded only
+// by the height range, and past roughly 1.5M heights of width the planner drops
+// idx_block_consolidation_shadow_tag_height for a sequential scan and the probe
+// stops finishing inside its statement timeout.
+func TestSingleBlockRetentionCronProbesFromTheFloorWatermark(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.watermark = 436_000_000
+	cohortRepository.watermarkFound = true
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+		StartHeight:           436_000_000,
+		EndHeight:             436_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+
+	// The watermark bounds the probe...
+	require.Equal(t, uint64(436_000_000), cohortRepository.requestedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.watermarkMinHeight,
+		"the approved floor must bound the watermark lookup so it stays cheap")
+
+	// ...but authorization is unchanged. The workflow still carries the
+	// operator's approved envelope, so narrowing the probe can never widen what
+	// the sweep is permitted to delete.
+	require.Len(t, runtime.executions, 1)
+	request, ok := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.True(t, ok)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, request.ApprovedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, request.ApprovedEndHeight)
+}
+
+// TestSingleBlockRetentionCronKeepsApprovedFloorWhenWatermarkIsLower pins that
+// a watermark below the approval floor never drags the probe underneath it.
+// Retention may not delete there, so work found below is not the probe's
+// business.
+func TestSingleBlockRetentionCronKeepsApprovedFloorWhenWatermarkIsLower(t *testing.T) {
+	task, _, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.watermark = 1_000
+	cohortRepository.watermarkFound = true
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
+}
+
+// TestSingleBlockRetentionCronIdlesWhenWatermarkPassesApprovedEnd covers the
+// finished-sweep case: with no outstanding work at or below the approved end
+// there is nothing to probe for, so the tick must idle instead of launching a
+// workflow over an empty range.
+func TestSingleBlockRetentionCronIdlesWhenWatermarkPassesApprovedEnd(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.watermark = cfg.Cron.SingleBlockRetention.ApprovedEndHeight
+	cohortRepository.watermarkFound = true
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+		StartHeight:           430_000_000,
+		EndHeight:             430_001_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+	require.Zero(t, cohortRepository.requestedStartHeight, "the probe must not run at all")
+}
+
+// TestSingleBlockRetentionCronPropagatesWatermarkErrors keeps a failing
+// watermark lookup loud. Falling back to the approved floor would work today
+// and quietly reintroduce the unbounded range this mechanism exists to prevent.
+func TestSingleBlockRetentionCronPropagatesWatermarkErrors(t *testing.T) {
+	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.watermarkErr = errors.New("watermark unavailable")
+
+	err := task.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "watermark")
+	require.Empty(t, runtime.executions)
 }

--- a/internal/storage/metastorage/postgres/db/migrations/20260818000001_add_retention_floor_watermark_index.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260818000001_add_retention_floor_watermark_index.sql
@@ -1,0 +1,51 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- Supports the retention floor watermark: the lowest height that still holds an
+-- undeleted single-block object for a storage generation. The cron probes from
+-- that height instead of from the operator's approved_start_height, which keeps
+-- the probe's height range narrow as the chain grows (INF-1330).
+--
+-- Why the range has to stay narrow: the due-cohort query joins its due_keys CTE
+-- back to block_consolidation_shadow to expand each cohort, and that join is
+-- bounded only by the height range. Measured on solana-mainnet prod, upper
+-- bound pinned at the consolidation cursor:
+--
+--     range width   plan
+--     ------------  ----------------------------------------------
+--       549,000     Parallel Index Scan (idx_..._tag_height)
+--     1,400,000     Parallel Index Scan
+--     1,600,000     Parallel Seq Scan     <- planner abandons the index
+--   439,880,000     Parallel Seq Scan, aborted past 150s
+--
+-- The flip happens where the two plans are near-equal in cost, so there is no
+-- warning shoulder. With a fixed floor the range grows at the chain's block
+-- rate (~216k/day on Solana) and crosses that threshold on its own; a watermark
+-- floor holds it at the retention delay expressed in blocks (~650k at 72h).
+--
+-- The partial predicate keeps only rows that still have work, so entries leave
+-- the index as retention deletes them and MIN(height) is answered from the
+-- front of the index rather than by walking already-deleted history. That is
+-- what stops the watermark lookup itself from degrading over time: bounded by
+-- approved_start_height but without this index, the same lookup has to skip
+-- every row retention has already finished with.
+--
+-- single_block_storage_generation IS NOT NULL is part of the predicate so
+-- legacy-generation rows stay out. They are never retired individually — the v1
+-- bucket is dropped wholesale — and including them would hold ~21M permanently
+-- undeleted entries in the index forever. The watermark query repeats that
+-- clause verbatim so the planner matches the partial predicate syntactically
+-- rather than having to infer it from the equality test.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_watermark
+    ON block_consolidation_shadow (
+        tag,
+        single_block_storage_generation,
+        height
+    )
+    WHERE single_block_object_deleted_at IS NULL
+        AND single_block_object_key_main IS NOT NULL
+        AND single_block_object_key_main <> ''
+        AND single_block_storage_generation IS NOT NULL;
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_retention_watermark;

--- a/internal/storage/retirement/floor_watermark_test.go
+++ b/internal/storage/retirement/floor_watermark_test.go
@@ -1,0 +1,196 @@
+package retirement
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// watermarkIndexMigration defines the partial index the watermark lookup relies
+// on to stay cheap as retired history accumulates.
+const watermarkIndexMigration = "../metastorage/postgres/db/migrations/20260818000001_add_retention_floor_watermark_index.sql"
+
+// TestFloorWatermarkNeverDropsBelowTheApprovedFloor pins the safety property
+// that separates a performance floor from an authorization floor. Retention may
+// not delete below approved_start_height, so work discovered underneath it —
+// a repair promoted into an old height, for instance — must not drag the probe
+// down there.
+func TestFloorWatermarkNeverDropsBelowTheApprovedFloor(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	repo := &fakeCohortRepository{watermark: 100, watermarkFound: true}
+	selector := NewSelector(repo)
+
+	got, err := selector.FloorWatermark(ctx, "", 2, 500)
+	require.NoError(err)
+	require.Equal(uint64(500), got, "a watermark below the approved floor must not lower the probe start")
+	require.Equal(uint64(500), repo.watermarkMinArg, "the approved floor bounds the lookup")
+}
+
+// TestFloorWatermarkAdvancesPastRetiredHistory is the whole point of the
+// mechanism: everything under the watermark is already retired, so the probe
+// starts there and the height range stops growing with the chain.
+func TestFloorWatermarkAdvancesPastRetiredHistory(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	repo := &fakeCohortRepository{watermark: 439_331_000, watermarkFound: true}
+	selector := NewSelector(repo)
+
+	got, err := selector.FloorWatermark(ctx, "", 2, 439_000_000)
+	require.NoError(err)
+	require.Equal(uint64(439_331_000), got)
+}
+
+// TestFloorWatermarkHoldsWhenNoWorkRemains guards the stranding case. With no
+// outstanding work the floor stays put rather than jumping to some higher
+// height, because rows consolidated moments ago are not due yet and advancing
+// past them would put them permanently below the floor.
+func TestFloorWatermarkHoldsWhenNoWorkRemains(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	repo := &fakeCohortRepository{watermarkFound: false}
+	selector := NewSelector(repo)
+
+	got, err := selector.FloorWatermark(ctx, "", 2, 439_000_000)
+	require.NoError(err)
+	require.Equal(uint64(439_000_000), got)
+}
+
+func TestFloorWatermarkRejectsBadInput(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	repo := &fakeCohortRepository{watermarkErr: errors.New("boom")}
+	_, err := NewSelector(repo).FloorWatermark(ctx, "", 2, 1)
+	require.Error(err)
+	require.Contains(err.Error(), "boom")
+
+	var nilSelector *Selector
+	_, err = nilSelector.FloorWatermark(ctx, "", 2, 1)
+	require.Error(err)
+
+	_, err = NewSelector(&fakeCohortRepository{}).FloorWatermark(ctx, "nope", 2, 1)
+	require.Error(err, "an unsupported generation must not silently return the approved floor")
+}
+
+// TestRetentionFloorWatermarkSQLIsIndexable pins the three properties the
+// partial watermark index depends on. Any of them silently regressing turns a
+// front-of-index lookup back into a walk over every already-retired row, which
+// is invisible until the probe budget is gone.
+func TestRetentionFloorWatermarkSQLIsIndexable(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	recorder := &recordingCohortQuerier{}
+	_, _, err := retentionFloorWatermark(ctx, recorder, "v2", 2, 439_000_000)
+	require.ErrorIs(err, errRecordingQuerier)
+
+	// 1. The height bound is present, so the lookup is cheap even before the
+	//    migration is applied. This is what makes the code safe to deploy ahead
+	//    of its index.
+	require.Contains(recorder.query, "shadow.height >= $2")
+
+	// 2. Generation is matched with equality, never the null-safe form that
+	//    cannot use a btree index at all.
+	require.Contains(recorder.query, "shadow.single_block_storage_generation = $3")
+	require.NotContains(recorder.query, "IS NOT DISTINCT FROM")
+
+	// 3. The partial predicate's IS NOT NULL clause is repeated verbatim so the
+	//    planner matches the index syntactically instead of having to infer it
+	//    from the equality test.
+	require.Contains(recorder.query, "shadow.single_block_storage_generation IS NOT NULL")
+
+	require.Equal([]any{uint32(2), uint64(439_000_000), "v2"}, recorder.args)
+}
+
+// TestRetentionFloorWatermarkSQLLegacyGenerationBindsNoArgument mirrors the
+// selector's handling of the legacy generation, which is stored as NULL. It
+// binds no generation argument, so a mismatch here surfaces as a driver-level
+// "bind message supplies N parameters" error rather than a wrong result.
+func TestRetentionFloorWatermarkSQLLegacyGenerationBindsNoArgument(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	recorder := &recordingCohortQuerier{}
+	_, _, err := retentionFloorWatermark(ctx, recorder, "", 2, 10)
+	require.ErrorIs(err, errRecordingQuerier)
+
+	require.Contains(recorder.query, "shadow.single_block_storage_generation IS NULL")
+	// The partial index deliberately excludes legacy rows, so this form must not
+	// claim to match it.
+	require.NotContains(recorder.query, "shadow.single_block_storage_generation IS NOT NULL")
+	require.Equal([]any{uint32(2), uint64(10)}, recorder.args)
+
+	highest := 0
+	for _, match := range regexp.MustCompile(`\$(\d+)`).FindAllStringSubmatch(recorder.query, -1) {
+		if n := len(match[1]); n > 0 {
+			switch match[1] {
+			case "1":
+				highest = max(highest, 1)
+			case "2":
+				highest = max(highest, 2)
+			case "3":
+				highest = max(highest, 3)
+			}
+		}
+	}
+	require.Equal(highest, len(recorder.args),
+		"the legacy form must bind exactly the placeholders it references")
+}
+
+// TestWatermarkIndexMatchesTheWatermarkQuery keeps the migration and the query
+// describing the same row set. They are separate files and drift between them
+// is silent: the index simply stops being chosen.
+func TestWatermarkIndexMatchesTheWatermarkQuery(t *testing.T) {
+	require := require.New(t)
+
+	source, err := os.ReadFile(filepath.Clean(watermarkIndexMigration))
+	require.NoError(err)
+	migration := string(source)
+
+	require.Contains(migration, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_watermark")
+	require.Contains(migration, "-- +goose NO TRANSACTION",
+		"CREATE INDEX CONCURRENTLY cannot run inside goose's transaction")
+
+	// Key order matters: tag and generation are equality-matched, height is the
+	// ordered column the MIN() is answered from.
+	keyStart := strings.Index(migration, "ON block_consolidation_shadow (")
+	require.Positive(keyStart)
+	keys := migration[keyStart : strings.Index(migration[keyStart:], ")")+keyStart]
+	for _, column := range []string{"tag", "single_block_storage_generation", "height"} {
+		require.Contains(keys, column)
+	}
+	require.Less(strings.Index(keys, "tag"), strings.Index(keys, "single_block_storage_generation"))
+	require.Less(strings.Index(keys, "single_block_storage_generation"), strings.Index(keys, "height"))
+
+	// Every clause of the partial predicate must also appear in the query, or
+	// the planner cannot prove the index covers it.
+	recorder := &recordingCohortQuerier{}
+	_, _, err = retentionFloorWatermark(context.Background(), recorder, "v2", 2, 1)
+	require.ErrorIs(err, errRecordingQuerier)
+	for _, clause := range []string{
+		"single_block_object_deleted_at IS NULL",
+		"single_block_object_key_main IS NOT NULL",
+		"single_block_object_key_main <> ''",
+		"single_block_storage_generation IS NOT NULL",
+	} {
+		require.Contains(migration, clause, "migration predicate")
+		require.Contains(recorder.query, clause, "query must repeat the index predicate clause %q", clause)
+	}
+
+	// The watermark must not filter on due time or validation state. Both are
+	// reasons a row is not deleted *yet*, so including them would let the floor
+	// step over live work.
+	require.NotContains(migration, "single_block_delete_after")
+	require.NotContains(recorder.query, "single_block_delete_after")
+	require.NotContains(recorder.query, "validated_at")
+}

--- a/internal/storage/retirement/selector.go
+++ b/internal/storage/retirement/selector.go
@@ -34,6 +34,21 @@ type (
 			eligibilityCutoff time.Time,
 			limit int,
 		) ([]RetentionCohort, []RetentionCohort, error)
+
+		// RetentionFloorWatermark returns the lowest height at or above
+		// minHeight that still holds an undeleted single-block object, and
+		// whether such a row exists. It is part of this interface rather than
+		// an optional one the implementation may satisfy: a missing watermark
+		// silently stops the probe floor from advancing, and the resulting
+		// range growth is exactly the failure this mechanism exists to
+		// prevent. Compile-time enforcement is cheaper than discovering it in
+		// production.
+		RetentionFloorWatermark(
+			ctx context.Context,
+			storageGeneration string,
+			tag uint32,
+			minHeight uint64,
+		) (uint64, bool, error)
 	}
 
 	Selector struct {
@@ -213,4 +228,39 @@ func (s *Selector) LookaheadKeys(
 		}
 	}
 	return keys, nil
+}
+
+// FloorWatermark resolves the height the next probe should start from, given
+// the operator's approved floor.
+//
+// The returned height is never below approvedStartHeight: that value is the
+// authorization boundary and retention may not delete underneath it, so work
+// found below it — a repair promoted into an old height, say — must not pull
+// the probe down there. Everything between approvedStartHeight and the
+// watermark has already been retired, so skipping it loses nothing.
+//
+// When the generation has no outstanding work at all, the approved floor is
+// returned unchanged rather than some higher value. Advancing past the end of
+// known work would put freshly consolidated rows below the floor before their
+// retention delay expires, which is precisely how a floor strands data.
+func (s *Selector) FloorWatermark(
+	ctx context.Context,
+	storageGeneration string,
+	tag uint32,
+	approvedStartHeight uint64,
+) (uint64, error) {
+	if s == nil || s.repo == nil {
+		return 0, xerrors.New("retention cohort repository is required")
+	}
+	if !isValidStorageGeneration(storageGeneration) {
+		return 0, xerrors.Errorf("unsupported retention cohort storage generation %q", storageGeneration)
+	}
+	watermark, found, err := s.repo.RetentionFloorWatermark(ctx, storageGeneration, tag, approvedStartHeight)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to resolve retention floor watermark: %w", err)
+	}
+	if !found || watermark < approvedStartHeight {
+		return approvedStartHeight, nil
+	}
+	return watermark, nil
 }

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -420,3 +420,101 @@ func scanRetentionCohorts(rows *sql.Rows, pending bool) ([]RetentionCohort, erro
 	}
 	return result, nil
 }
+
+// RetentionFloorWatermark returns the lowest height at or above minHeight that
+// still holds an undeleted single-block object for storageGeneration.
+//
+// Everything below the returned height has already been retired, so the probe
+// can start there instead of at the operator's approved_start_height. That
+// matters because the due-cohort query's cohort-expansion join is bounded only
+// by the height range: past roughly 1.5M heights of width the planner abandons
+// idx_block_consolidation_shadow_tag_height for a sequential scan of the whole
+// table, and the probe stops finishing inside its statement timeout. A fixed
+// floor widens at the chain's block rate and reaches that point on its own; the
+// watermark holds the range at the retention delay expressed in blocks.
+//
+// The predicate is deliberately conservative by omission. It does not filter on
+// due time, validated_at, skipped metadata, repair state or pending retention
+// state, because each of those is a reason a row is *not deleted yet* and must
+// therefore hold the floor down rather than let it pass. Anything that leaves
+// an undeleted single-block object blocks the watermark — including a crash
+// between the S3 delete and the database update, which stalls the floor instead
+// of stepping over the row. It fails safe in the only direction that matters.
+//
+// found is false when no such row exists, meaning the generation has no
+// outstanding single-block work at or above minHeight.
+func (r *PostgresRepository) RetentionFloorWatermark(
+	ctx context.Context,
+	storageGeneration string,
+	tag uint32,
+	minHeight uint64,
+) (uint64, bool, error) {
+	if r == nil || r.db == nil {
+		return 0, false, xerrors.New("postgres db is required")
+	}
+	return retentionFloorWatermark(ctx, r.db, storageGeneration, tag, minHeight)
+}
+
+func retentionFloorWatermark(
+	ctx context.Context,
+	db retentionCohortQuerier,
+	storageGeneration string,
+	tag uint32,
+	minHeight uint64,
+) (uint64, bool, error) {
+	// minHeight keeps this lookup cheap even before the watermark index exists,
+	// so the code is safe to deploy ahead of its migration: without the bound it
+	// walks (tag, height) from the bottom of the table through every legacy and
+	// already-deleted row. Bounding it at the approval floor is also exactly
+	// right semantically — retention may not delete below that height, so work
+	// underneath it can never change where the probe should start.
+	//
+	// The generation clause is repeated as an explicit IS NOT NULL for a
+	// concrete generation so the partial watermark index is matched
+	// syntactically rather than by inference from the equality test.
+	query := `
+		SELECT MIN(shadow.height)
+		FROM block_consolidation_shadow shadow
+		WHERE shadow.tag = $1
+			AND shadow.height >= $2
+			AND shadow.single_block_object_deleted_at IS NULL
+			AND shadow.single_block_object_key_main IS NOT NULL
+			AND shadow.single_block_object_key_main <> ''
+			AND ` + storageGenerationMatch(storageGeneration, "$3", "shadow.single_block_storage_generation")
+	if storageGenerationIsBound(storageGeneration) {
+		query += "\n\t\t\tAND shadow.single_block_storage_generation IS NOT NULL"
+	}
+
+	args := []any{tag, minHeight}
+	if storageGenerationIsBound(storageGeneration) {
+		args = append(args, storageGeneration)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, false, xerrors.Errorf("failed to query retention floor watermark: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return 0, false, xerrors.Errorf("failed to read retention floor watermark: %w", err)
+		}
+		return 0, false, nil
+	}
+	// MIN over an empty set is SQL NULL, which is the no-outstanding-work case.
+	var watermark sql.NullInt64
+	if err := rows.Scan(&watermark); err != nil {
+		return 0, false, xerrors.Errorf("failed to scan retention floor watermark: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, false, xerrors.Errorf("failed to iterate retention floor watermark: %w", err)
+	}
+	if !watermark.Valid {
+		return 0, false, nil
+	}
+	if watermark.Int64 < 0 {
+		return 0, false, xerrors.Errorf("retention floor watermark returned a negative height %d", watermark.Int64)
+	}
+	return uint64(watermark.Int64), true, nil
+}

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -18,6 +18,30 @@ type fakeCohortRepository struct {
 	dueErr        error
 	pendingCutoff time.Time
 	dueCutoff     time.Time
+
+	watermark        uint64
+	watermarkFound   bool
+	watermarkErr     error
+	watermarkMinArg  uint64
+	watermarkGenArg  string
+	watermarkTagArg  uint32
+	watermarkCallCnt int
+}
+
+func (r *fakeCohortRepository) RetentionFloorWatermark(
+	_ context.Context,
+	storageGeneration string,
+	tag uint32,
+	minHeight uint64,
+) (uint64, bool, error) {
+	r.watermarkCallCnt++
+	r.watermarkGenArg = storageGeneration
+	r.watermarkTagArg = tag
+	r.watermarkMinArg = minHeight
+	if r.watermarkErr != nil {
+		return 0, false, r.watermarkErr
+	}
+	return r.watermark, r.watermarkFound, nil
 }
 
 func (r *fakeCohortRepository) ListRetentionCohorts(


### PR DESCRIPTION
Makes the retention probe's cost independent of chain age. Without this the hourly probe stalls again on its own in roughly three days.

## The problem

The probe's cost is governed by the **width of its height range**, not by the undeleted backlog — which is the opposite of what the comment above `Select` claimed, and is what justified setting `approved_start_height` to 0 in production earlier today.

The due-cohort query has two halves. The `due_keys` CTE uses `idx_..._retention_due_generation` at every floor, so the INF-1330 index does its job. The **cohort-expansion join** back to `block_consolidation_shadow` is bounded only by the height range. Measured on solana-mainnet prod, upper bound pinned at the consolidation cursor:

| range width | plan | cost |
|---|---|---|
| 549,000 | Parallel Index Scan (`tag_height`) | 1,008,453 |
| 1,400,000 | Parallel Index Scan | 2,310,621 |
| **1,600,000** | **Parallel Seq Scan** | 2,371,037 |
| 439,880,000 | Parallel Seq Scan | 4,256,449 — aborted past 150s |

With a fixed floor the range widens at the chain's block rate (~216k/day on Solana) and crosses that threshold unaided. Current width is 880,000, so **~3 days**. The flip lands where the two plans are near-equal in cost, so there is no warning shoulder — the probe just changes character between one tick and the next, and a 60s `statement_timeout` turns that into an outage rather than a slowdown.

## The change

Probe from a **watermark**: the lowest height still holding an undeleted single-block object. Everything below it is already retired, so the range holds at the retention delay expressed in blocks (~650k at 72h) instead of growing with chain age.

The two floors are now separate concerns, which the old code conflated:

- `approved_start_height` remains the **operator's authorization boundary** and is still what the workflow request carries. The watermark never drags the probe below it, so narrowing the probe cannot widen what a sweep may delete.
- the watermark is purely a **performance floor**.

**Why not advance to the sweep's `end_height`.** A sweep deletes what was *due*, not what was *in range*. The 01:42Z production run completed cleanly over a 250,000-wide window and deleted 24 cohorts / 23,977 blocks — the other ~226,000 blocks were consolidated under 72h ago and were not yet due. Advancing to `end_height` would have put them permanently below the floor, invisible to the sweep *and* to `oldest_due_age_seconds`, which derives from the same probe.

The watermark predicate is therefore **conservative by omission**: no filter on due time, `validated_at`, `skipped`, repair state or pending retention state, because each of those is a reason a row is *not deleted yet* and must hold the floor down. Anything leaving an undeleted single-block object blocks the floor — including a crash between the S3 delete and the DB update, which stalls the watermark rather than stepping over the row. With no outstanding work at all the floor stays put rather than jumping ahead.

It is recomputed every tick rather than persisted: a stored floor needs its own reconciliation for repairs and failed sweeps, and a stale one strands data silently.

## Verified on a real Postgres

Seeded to the production shape — 600k legacy rows, 300k retired v2, 100k outstanding v2 — with the full migration set applied:

| | result |
|---|---|
| correctness | returns **900,001**, the first outstanding v2 height |
| with the new index | **Index Only Scan**, 0.276 ms, even at `height >= 0` |
| without the index | falls back to `tag_height`, **330 ms** — correct, 1,200× slower |

That last row is why the query also carries its own `height >= $2` bound: the code is safe to deploy **ahead of** its migration, because the fallback is merely slower, not wrong. Index size was 6 MB against a 133 MB table, since retired rows leave the partial index as retention finishes with them.

## Notes for review

- `RetentionFloorWatermark` is on `CohortRepository` rather than an optional interface a repository may satisfy. A missing watermark silently stops the floor advancing, and the resulting range growth is the exact failure this prevents — compile-time enforcement is cheaper than finding it in production. That is why two test fakes gain a method.
- The migration excludes legacy-generation rows (`single_block_storage_generation IS NOT NULL`). They are never retired individually — the v1 bucket is dropped wholesale — and including them would pin ~21M permanently-undeleted entries in the index. The query repeats that clause verbatim so the planner matches the partial predicate syntactically rather than inferring it from the equality test.
- New gauges: `floor_watermark_height`, `probe_range_blocks`, `probe_duration_seconds`. `probe_range_blocks` is the leading indicator for the plan flip; `oldest_due_age_seconds` structurally cannot be, since it is derived from this probe and reads zero exactly when the probe fails.

## Deployment

The migration ships inside the image and is applied by `admin db-migrate`, not at runtime. Order is safe either way — the query is correct without the index, and the index is inert without the query.

## Testing

`go build`, `go vet`, `go test` and `go test -race` green on `cron` and `retirement`. 11 new tests cover: the floor never dropping below the approval boundary, advancing past retired history, holding when no work remains, error propagation, the SQL's indexability and parameter binding for both generation modes, and a migration/query drift guard that fails if the index predicate and the query stop describing the same row set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
