### PR TITLE
fix(INF-1330): drop the watermark index, keep the watermark

### DIFF
--- a/internal/storage/metastorage/postgres/db/migrations/20260818000002_drop_retention_floor_watermark_index.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260818000002_drop_retention_floor_watermark_index.sql
@@ -1,0 +1,55 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- Drops idx_block_consolidation_shadow_retention_watermark, added one migration
+-- earlier in 20260818000001. It was a net loss in production and the measurement
+-- that proves it could only be taken with the index in place.
+--
+-- What it was for: MIN(height) over rows that still hold an undeleted
+-- single-block object, so the retention cron can advance its probe floor. That
+-- part worked exactly as designed — on solana-mainnet prod the lookup went from
+-- 44.5s unbounded to 0.058ms, and it removed the sequential-scan cliff from the
+-- due-cohort probe at every range width tested.
+--
+-- Why it still had to go: the planner also picked it up for the *due-cohort
+-- probe*, and there it is much worse in wall clock despite a lower estimated
+-- cost. Measured on prod, same query, same floor, bare execution (no EXPLAIN
+-- instrumentation), three runs each:
+--
+--     with the index      36.8 / 37.1 / 36.8 s   cost   161,219
+--     without the index   14.4 / 14.6 / 16.3 s   cost 1,695,921
+--
+-- The cause is a row misestimate — rows=1 estimated against 138,379 actual —
+-- which makes a serial nested-loop plan look cheap and displaces the parallel
+-- index scan on idx_block_consolidation_shadow_tag_height. Statistics tuning
+-- would not have rescued it: with nested loops disabled the planner fell back to
+-- sequential scans of canonical_blocks (183M rows) and took 91.6s, so the
+-- nested-loop plan was already the best available *while this index existed*.
+-- Its mere presence is what leads the planner astray.
+--
+-- The retention floor watermark does not need it. The watermark query carries
+-- its own `height >= approved_start_height` bound, which is both semantically
+-- right (retention may not delete below the approval floor) and enough to keep
+-- the lookup cheap: 97ms on prod through idx_block_consolidation_shadow_tag_height,
+-- against a probe that costs seconds. That bound is why this is a clean
+-- subtraction rather than a redesign.
+--
+-- If the sequential-scan cliff is worth removing later, it needs an index shape
+-- the due-cohort probe cannot use, or a restructured cohort-expansion join —
+-- designed with both queries measured together rather than one in isolation.
+-- Do not simply re-add this index.
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_retention_watermark;
+
+-- +goose Down
+-- Recreating it restores the regression above. The definition is kept here only
+-- so the migration is reversible; see 20260818000001 for the original rationale.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_watermark
+    ON block_consolidation_shadow (
+        tag,
+        single_block_storage_generation,
+        height
+    )
+    WHERE single_block_object_deleted_at IS NULL
+        AND single_block_object_key_main IS NOT NULL
+        AND single_block_object_key_main <> ''
+        AND single_block_storage_generation IS NOT NULL;

--- a/internal/storage/retirement/floor_watermark_test.go
+++ b/internal/storage/retirement/floor_watermark_test.go
@@ -12,9 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// watermarkIndexMigration defines the partial index the watermark lookup relies
-// on to stay cheap as retired history accumulates.
-const watermarkIndexMigration = "../metastorage/postgres/db/migrations/20260818000001_add_retention_floor_watermark_index.sql"
+// watermarkIndexAddMigration created a partial index for the watermark lookup;
+// watermarkIndexDropMigration removed it again after production measurement
+// showed the planner also applied it to the due-cohort probe and made that 2.5x
+// slower. Both are pinned here so the pair cannot be quietly re-added.
+const (
+	watermarkIndexAddMigration  = "../metastorage/postgres/db/migrations/20260818000001_add_retention_floor_watermark_index.sql"
+	watermarkIndexDropMigration = "../metastorage/postgres/db/migrations/20260818000002_drop_retention_floor_watermark_index.sql"
+)
 
 // TestFloorWatermarkNeverDropsBelowTheApprovedFloor pins the safety property
 // that separates a performance floor from an authorization floor. Retention may
@@ -82,11 +87,11 @@ func TestFloorWatermarkRejectsBadInput(t *testing.T) {
 	require.Error(err, "an unsupported generation must not silently return the approved floor")
 }
 
-// TestRetentionFloorWatermarkSQLIsIndexable pins the three properties the
-// partial watermark index depends on. Any of them silently regressing turns a
-// front-of-index lookup back into a walk over every already-retired row, which
-// is invisible until the probe budget is gone.
-func TestRetentionFloorWatermarkSQLIsIndexable(t *testing.T) {
+// TestRetentionFloorWatermarkSQLIsBoundedAndIndexable pins the two properties
+// that keep this lookup affordable without a dedicated index. The height bound
+// is load-bearing: unbounded, the same query took 58s on production against 97ms
+// bounded at the approval floor.
+func TestRetentionFloorWatermarkSQLIsBoundedAndIndexable(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
@@ -94,20 +99,14 @@ func TestRetentionFloorWatermarkSQLIsIndexable(t *testing.T) {
 	_, _, err := retentionFloorWatermark(ctx, recorder, "v2", 2, 439_000_000)
 	require.ErrorIs(err, errRecordingQuerier)
 
-	// 1. The height bound is present, so the lookup is cheap even before the
-	//    migration is applied. This is what makes the code safe to deploy ahead
-	//    of its index.
+	// 1. The height bound must be present. Removing it is the one change that
+	//    turns this from a 97ms lookup into a full walk of retired history.
 	require.Contains(recorder.query, "shadow.height >= $2")
 
 	// 2. Generation is matched with equality, never the null-safe form that
 	//    cannot use a btree index at all.
 	require.Contains(recorder.query, "shadow.single_block_storage_generation = $3")
 	require.NotContains(recorder.query, "IS NOT DISTINCT FROM")
-
-	// 3. The partial predicate's IS NOT NULL clause is repeated verbatim so the
-	//    planner matches the index syntactically instead of having to infer it
-	//    from the equality test.
-	require.Contains(recorder.query, "shadow.single_block_storage_generation IS NOT NULL")
 
 	require.Equal([]any{uint32(2), uint64(439_000_000), "v2"}, recorder.args)
 }
@@ -125,9 +124,6 @@ func TestRetentionFloorWatermarkSQLLegacyGenerationBindsNoArgument(t *testing.T)
 	require.ErrorIs(err, errRecordingQuerier)
 
 	require.Contains(recorder.query, "shadow.single_block_storage_generation IS NULL")
-	// The partial index deliberately excludes legacy rows, so this form must not
-	// claim to match it.
-	require.NotContains(recorder.query, "shadow.single_block_storage_generation IS NOT NULL")
 	require.Equal([]any{uint32(2), uint64(10)}, recorder.args)
 
 	highest := 0
@@ -147,50 +143,74 @@ func TestRetentionFloorWatermarkSQLLegacyGenerationBindsNoArgument(t *testing.T)
 		"the legacy form must bind exactly the placeholders it references")
 }
 
-// TestWatermarkIndexMatchesTheWatermarkQuery keeps the migration and the query
-// describing the same row set. They are separate files and drift between them
-// is silent: the index simply stops being chosen.
-func TestWatermarkIndexMatchesTheWatermarkQuery(t *testing.T) {
+// TestWatermarkIndexWasAddedAndDropped is a tripwire, not a schema check. The
+// partial index for this query was added in 20260818000001 and dropped in
+// 20260818000002 after production measurement: the planner also applied it to
+// the due-cohort probe, which went from 14.4s to 36.8s in bare execution while
+// its estimated cost *fell* tenfold. Disabling nested loops made it 91.6s, so
+// the nested-loop plan was already the best available while the index existed —
+// statistics tuning could not have saved it.
+//
+// This test exists so a future change cannot quietly re-add that index and
+// reintroduce the regression without reading why it went away.
+func TestWatermarkIndexWasAddedAndDropped(t *testing.T) {
 	require := require.New(t)
 
-	source, err := os.ReadFile(filepath.Clean(watermarkIndexMigration))
+	add, err := os.ReadFile(filepath.Clean(watermarkIndexAddMigration))
 	require.NoError(err)
-	migration := string(source)
+	drop, err := os.ReadFile(filepath.Clean(watermarkIndexDropMigration))
+	require.NoError(err)
 
-	require.Contains(migration, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_watermark")
-	require.Contains(migration, "-- +goose NO TRANSACTION",
-		"CREATE INDEX CONCURRENTLY cannot run inside goose's transaction")
+	const indexName = "idx_block_consolidation_shadow_retention_watermark"
+	require.Contains(string(add), "CREATE INDEX CONCURRENTLY IF NOT EXISTS "+indexName)
+	require.Contains(string(drop), "DROP INDEX CONCURRENTLY IF EXISTS "+indexName)
+	require.Contains(string(drop), "-- +goose NO TRANSACTION",
+		"DROP INDEX CONCURRENTLY cannot run inside goose's transaction")
 
-	// Key order matters: tag and generation are equality-matched, height is the
-	// ordered column the MIN() is answered from.
-	keyStart := strings.Index(migration, "ON block_consolidation_shadow (")
-	require.Positive(keyStart)
-	keys := migration[keyStart : strings.Index(migration[keyStart:], ")")+keyStart]
-	for _, column := range []string{"tag", "single_block_storage_generation", "height"} {
-		require.Contains(keys, column)
+	// The drop must be the later migration, or a fresh database would end up
+	// with the index still in place.
+	require.Less(
+		filepath.Base(watermarkIndexAddMigration),
+		filepath.Base(watermarkIndexDropMigration),
+		"the drop migration must sort after the add migration",
+	)
+
+	// No live migration may leave this index behind. Scan every migration for a
+	// CREATE of it other than the original and the down-section of the drop.
+	dir := filepath.Dir(watermarkIndexAddMigration)
+	entries, err := os.ReadDir(dir)
+	require.NoError(err)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		if entry.Name() == filepath.Base(watermarkIndexAddMigration) ||
+			entry.Name() == filepath.Base(watermarkIndexDropMigration) {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Clean(filepath.Join(dir, entry.Name())))
+		require.NoError(err)
+		require.NotContains(string(body), indexName,
+			"%s references %s; see 20260818000002 for why it was dropped", entry.Name(), indexName)
 	}
-	require.Less(strings.Index(keys, "tag"), strings.Index(keys, "single_block_storage_generation"))
-	require.Less(strings.Index(keys, "single_block_storage_generation"), strings.Index(keys, "height"))
+}
 
-	// Every clause of the partial predicate must also appear in the query, or
-	// the planner cannot prove the index covers it.
+// TestRetentionFloorWatermarkQueryNeedsNoIndex documents the consequence of the
+// drop: the query must not assume any index exists beyond the pre-existing
+// (tag, height) one it now rides.
+func TestRetentionFloorWatermarkQueryNeedsNoIndex(t *testing.T) {
+	require := require.New(t)
+
 	recorder := &recordingCohortQuerier{}
-	_, _, err = retentionFloorWatermark(context.Background(), recorder, "v2", 2, 1)
+	_, _, err := retentionFloorWatermark(context.Background(), recorder, "v2", 2, 439_000_000)
 	require.ErrorIs(err, errRecordingQuerier)
-	for _, clause := range []string{
-		"single_block_object_deleted_at IS NULL",
-		"single_block_object_key_main IS NOT NULL",
-		"single_block_object_key_main <> ''",
-		"single_block_storage_generation IS NOT NULL",
-	} {
-		require.Contains(migration, clause, "migration predicate")
-		require.Contains(recorder.query, clause, "query must repeat the index predicate clause %q", clause)
-	}
+
+	// The clause that existed only to match the dropped partial index is gone.
+	require.NotContains(recorder.query, "single_block_storage_generation IS NOT NULL")
 
 	// The watermark must not filter on due time or validation state. Both are
 	// reasons a row is not deleted *yet*, so including them would let the floor
 	// step over live work.
-	require.NotContains(migration, "single_block_delete_after")
 	require.NotContains(recorder.query, "single_block_delete_after")
 	require.NotContains(recorder.query, "validated_at")
 }

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -427,11 +427,16 @@ func scanRetentionCohorts(rows *sql.Rows, pending bool) ([]RetentionCohort, erro
 // Everything below the returned height has already been retired, so the probe
 // can start there instead of at the operator's approved_start_height. That
 // matters because the due-cohort query's cohort-expansion join is bounded only
-// by the height range: past roughly 1.5M heights of width the planner abandons
+// by the height range: past roughly 1.8M heights of width the planner abandons
 // idx_block_consolidation_shadow_tag_height for a sequential scan of the whole
 // table, and the probe stops finishing inside its statement timeout. A fixed
 // floor widens at the chain's block rate and reaches that point on its own; the
 // watermark holds the range at the retention delay expressed in blocks.
+//
+// Measured on solana-mainnet prod: watermark 439,331,000 against an approval
+// floor of 439,000,000 and a consolidation cursor of 439,880,000, so the probe
+// range narrows from 880,000 to 549,000 — plan cost 1,004,709 rather than
+// 1,695,921 — and stays there as the chain advances.
 //
 // The predicate is deliberately conservative by omission. It does not filter on
 // due time, validated_at, skipped metadata, repair state or pending retention
@@ -462,16 +467,19 @@ func retentionFloorWatermark(
 	tag uint32,
 	minHeight uint64,
 ) (uint64, bool, error) {
-	// minHeight keeps this lookup cheap even before the watermark index exists,
-	// so the code is safe to deploy ahead of its migration: without the bound it
-	// walks (tag, height) from the bottom of the table through every legacy and
-	// already-deleted row. Bounding it at the approval floor is also exactly
-	// right semantically — retention may not delete below that height, so work
-	// underneath it can never change where the probe should start.
+	// minHeight is what keeps this lookup affordable, and it is the load-bearing
+	// part of this query rather than an optimisation. Without it the scan walks
+	// (tag, height) from the bottom of the table through every legacy and
+	// already-retired row: 58s on solana-mainnet prod versus 97ms bounded at the
+	// approval floor.
 	//
-	// The generation clause is repeated as an explicit IS NOT NULL for a
-	// concrete generation so the partial watermark index is matched
-	// syntactically rather than by inference from the equality test.
+	// The bound is also exactly right semantically — retention may not delete
+	// below approved_start_height, so work underneath it can never change where
+	// the probe should start. That is why no dedicated index is needed here: a
+	// partial index for this query was tried (migration 20260818000001) and
+	// dropped in 20260818000002 because the planner also applied it to the
+	// due-cohort probe and made that 2.5x slower. See those migrations before
+	// reaching for an index again.
 	query := `
 		SELECT MIN(shadow.height)
 		FROM block_consolidation_shadow shadow
@@ -481,9 +489,6 @@ func retentionFloorWatermark(
 			AND shadow.single_block_object_key_main IS NOT NULL
 			AND shadow.single_block_object_key_main <> ''
 			AND ` + storageGenerationMatch(storageGeneration, "$3", "shadow.single_block_storage_generation")
-	if storageGenerationIsBound(storageGeneration) {
-		query += "\n\t\t\tAND shadow.single_block_storage_generation IS NOT NULL"
-	}
 
 	args := []any{tag, minHeight}
 	if storageGenerationIsBound(storageGeneration) {


### PR DESCRIPTION
Migration `20260818000001` (chainstorage#198) added a partial index for the retention watermark lookup. It did that job exactly as designed, but it was a **net loss** in production, so this drops it in `20260818000002`.

The measurement that proves this could only be taken with the index in place — which is why applying the migration to prod *before* deploying the code was the right order. The effect is cleanly attributable to the index alone.

## The numbers

Same query, same floor, on prod. **Bare execution, no `EXPLAIN` instrumentation** (which was inflating it by ~8s), three runs each:

| | plan cost | execution |
|---|---|---|
| with the index | 161,219 | **36.8 / 37.1 / 36.8 s** |
| without the index | 1,695,921 | **14.4 / 14.6 / 16.3 s** |

Note the cost went *down* tenfold while wall-clock went up 2.5×.

## Why

The planner also applied the new index to the **due-cohort probe**, where a row misestimate — `rows=1` estimated against **138,379** actual — makes a serial nested-loop plan look cheap and displaces the parallel scan on `idx_block_consolidation_shadow_tag_height`. 53.7M buffer accesses per execution, measured with the database at **1 active connection and 0 lock waits**, so this is the plan and not contention.

**Statistics tuning would not have rescued it.** I tested that before concluding: with `enable_nestloop = off` the planner fell back to sequential scans of `canonical_blocks` (183M rows) and took **91.6 s**. The nested-loop plan was already the best available *while this index existed* — its mere presence is what misleads the planner, so there was no tuning path that keeps it.

## The watermark itself is unaffected

The query carries its own `height >= approved_start_height` bound. That bound is both semantically required — retention may not delete below the approval floor — and sufficient on its own:

| watermark lookup | |
|---|---|
| bounded at the approval floor (what the cron runs) | **97 ms** |
| unbounded (never executed by the cron) | 58 s |

97 ms against a probe measured in seconds. That bound is why this is a clean subtraction rather than a redesign.

**And the mechanism still delivers.** Prod watermark is **439,331,000** against an approval floor of 439,000,000 and a cursor of 439,880,000, so the probe range narrows from **880,000 → 549,000** (cost 1,004,709 rather than 1,695,921) and stays there as the chain advances. The sequential-scan cliff now sits at **~1.8M**, leaving ~3× headroom that no longer grows with chain age.

## Verification

**On prod** — index dropped with `DROP INDEX CONCURRENTLY` (no `ACCESS EXCLUSIVE` lock), then confirmed:

- index absent
- due probe back to **parallel** `idx_..._tag_height` + `idx_..._retention_due_generation`
- watermark returns **439,331,000**, unchanged from the with-index result
- cliff sweep: index scan through 1.6M width, seq scan at 2.0M

**On a real Postgres via goose**, full migration set applied:

- full forward run leaves the index **absent**
- `goose down` recreates it, `goose up` drops it again — idempotent, round-trips
- watermark returns **900,001** on a seeded 1M-row set (600k legacy / 300k retired v2 / 100k outstanding v2), **bounded and unbounded alike**, so correctness is index-independent
- bounded lookup plans as an Index Scan on `tag_height`, 14.4 ms

`go build`, `go vet`, `go test`, `go test -race` green on `cron` and `retirement`.

## Tests

The index-shape test is replaced by a **tripwire**: it fails if any migration re-adds this index, so a future change cannot reintroduce the regression without first reading why it went away. Plus a guard that the `height >= $2` bound stays in the query — that bound is now the only thing keeping the lookup affordable, so losing it silently would cost 58 s.

## Follow-up, deliberately not here

If the sequential-scan cliff is worth removing, it needs an index shape the due-cohort probe **cannot** use, or a restructured cohort-expansion join — designed with both queries measured together rather than one in isolation. That is the mistake this PR corrects: I measured the new query and never checked its effect on the neighbouring one.

Also noted while investigating: `idx_block_consolidation_shadow_retention_due` has **0 scans and occupies 1685 MB**, superseded by the generation variant in #196 whose migration comment flagged dropping it as a follow-up. That confirmation now exists. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
