### PR TITLE
chore(INF-1330): drop the superseded retention due index

### DIFF
--- a/internal/storage/metastorage/postgres/db/migrations/20260818000003_drop_unused_retention_due_index.sql
+++ b/internal/storage/metastorage/postgres/db/migrations/20260818000003_drop_unused_retention_due_index.sql
@@ -1,0 +1,48 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- Drops idx_block_consolidation_shadow_retention_due, superseded by
+-- idx_block_consolidation_shadow_retention_due_generation in 20260817000001.
+--
+-- That migration deliberately kept this one, on the reasoning that it still
+-- served probes which do not constrain storage generation, and said dropping it
+-- "belongs in a follow-up once production plans confirm the new one is chosen."
+-- This is that follow-up. Measured on solana-mainnet prod:
+--
+--     index                                   size     scans   tuples read
+--     --------------------------------------  -------  ------  -----------
+--     ..._retention_due             (this)     1732 MB       0            0
+--     ..._retention_due_generation             1389 MB     120    2,838,841
+--
+-- pg_stat_database.stats_reset is NULL on this database, so those counters are
+-- lifetime rather than a recent window: nothing has ever used this index. The
+-- reading was also taken after the watermark index was dropped in
+-- 20260818000002, so it reflects the planner's current choices rather than a
+-- state where some other index was crowding it out.
+--
+-- Both indexes carry the same partial predicate; the survivor simply leads with
+-- (tag, single_block_storage_generation, ...) instead of (tag, ...), which is
+-- what makes the retention probe able to seek straight to the active write
+-- generation rather than walking superseded ones.
+--
+-- Worth noting this is not only 1.7 GB of disk. Every insert into
+-- block_consolidation_shadow has been maintaining it, and historical backfill
+-- writes those rows in bulk — so this also removes write amplification from the
+-- hottest path on the table.
+DROP INDEX CONCURRENTLY IF EXISTS idx_block_consolidation_shadow_retention_due;
+
+-- +goose Down
+-- Definition preserved verbatim from 20260723000001 so the rollback is exact.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_block_consolidation_shadow_retention_due
+    ON block_consolidation_shadow (
+        tag,
+        single_block_delete_after,
+        height
+    )
+    WHERE validated_at IS NOT NULL
+        AND single_block_delete_after IS NOT NULL
+        AND single_block_object_deleted_at IS NULL
+        AND single_block_object_key_main IS NOT NULL
+        AND single_block_object_key_main <> ''
+        AND consolidated_object_key_main IS NOT NULL
+        AND consolidated_object_key_main <> '';


### PR DESCRIPTION
Drops `idx_block_consolidation_shadow_retention_due`, superseded by `idx_block_consolidation_shadow_retention_due_generation` in #196.

That migration deliberately kept it, reasoning it still served probes that do not constrain storage generation, and said dropping it *"belongs in a follow-up once production plans confirm the new one is chosen."* **This is that follow-up, and the confirmation now exists.**

## The evidence

Measured on solana-mainnet prod:

| index | size | scans | tuples read |
|---|---|---|---|
| `..._retention_due` **(this one)** | **1732 MB** | **0** | **0** |
| `..._retention_due_generation` | 1389 MB | 120 | 2,838,841 |

Two things make that zero trustworthy rather than a sampling artifact:

- **`pg_stat_database.stats_reset` is NULL** on this database, so the counters are *lifetime*, not a recent window. Nothing has ever used this index.
- The reading was taken **after** `20260818000002` removed the watermark index, so it reflects the planner's current choices — not a state where some other index was crowding this one out. Taking it before that drop would have proved much less.

Both indexes carry the same partial predicate. The survivor simply leads with `(tag, single_block_storage_generation, ...)` instead of `(tag, ...)`, which is what lets the retention probe seek straight to the active write generation instead of walking superseded ones.

## Why this is worth more than 1.7 GB

Every insert into `block_consolidation_shadow` maintains this index, and historical backfill writes those rows in bulk — chainstorage#197 exists precisely because that path was hot enough to cause lock contention. So this also removes write amplification from the busiest path on the table, which should show up as a small speedup in backfill throughput.

## Verification

Round-tripped on a real Postgres with the full migration set applied by goose:

- forward run leaves **only** `..._retention_due_generation`
- `goose down` restores both
- `goose up` drops it again — idempotent

`go build` and `go test` green on `retirement` and `cron`. No Go code references this index; the only test that mentions a due index pins the `_generation` one, which is unaffected.

## Deployment

`DROP INDEX CONCURRENTLY IF EXISTS`, so no `ACCESS EXCLUSIVE` lock on the table and safe to run while consolidation and backfill are live. Applied per database by `admin db-migrate` after the image ships.

All 26 chainstorage databases (12 prod, 14 dev) are currently at `20260818000002`, so this will be the single pending migration everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
