### PR TITLE
feat(INF-1330): emit a probe_failed gauge for the retention cron

### DIFF
--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -96,7 +96,32 @@ func (t *singleBlockRetentionTask) DelayStartDuration() time.Duration {
 // when its retirement is finalized as deleted-and-verified), so anchoring every
 // window at the due minimum guarantees deferred, failed, or repair-re-created
 // rows are re-selected by a later tick instead of skipped past.
-func (t *singleBlockRetentionTask) Run(ctx context.Context) error {
+func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
+	// probe_failed is the only signal that reliably detects a failed tick, and
+	// it has to be a gauge written on EVERY exit path rather than a counter.
+	//
+	// Tally suppresses zero deltas for counters (stats.go: `if delta == 0 {
+	// return }`), so the instrument's result_type="error" counter emits nothing
+	// until the first failure and then falls silent again. A single isolated
+	// sample gives PromQL increase() no delta to compute, so an
+	// increase(...) > 0 alert on it never fires — the first outage, which is
+	// exactly the one worth catching, is missed entirely.
+	//
+	// Gauges report whenever they were updated since the last flush, so writing
+	// 0 on every successful tick keeps a continuous baseline and a plain
+	// `> 0` threshold fires on the first failure with no delta involved.
+	//
+	// Deferred on the named return so every path is covered: the early
+	// non-failure exits (workflow already open, no approved range, nothing due)
+	// report 0, and anything returning an error reports 1.
+	defer func() {
+		failed := float64(0)
+		if err != nil {
+			failed = 1
+		}
+		t.metrics.Gauge("probe_failed").Update(failed)
+	}()
+
 	cronConfig := t.config.Cron.SingleBlockRetention
 	if err := t.validateStandingApproval(cronConfig); err != nil {
 		return err

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -476,4 +477,102 @@ func TestSingleBlockRetentionCronPropagatesWatermarkErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "watermark")
 	require.Empty(t, runtime.executions)
+}
+
+// recordingScope captures gauge writes so the probe_failed contract can be
+// asserted directly rather than inferred.
+type recordingScope struct {
+	tally.Scope
+	mu     sync.Mutex
+	gauges map[string]float64
+}
+
+func newRecordingScope() *recordingScope {
+	return &recordingScope{Scope: tally.NoopScope, gauges: make(map[string]float64)}
+}
+
+func (s *recordingScope) SubScope(string) tally.Scope { return s }
+
+func (s *recordingScope) Gauge(name string) tally.Gauge {
+	return &recordingGauge{scope: s, name: name}
+}
+
+func (s *recordingScope) get(name string) (float64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.gauges[name]
+	return v, ok
+}
+
+type recordingGauge struct {
+	scope *recordingScope
+	name  string
+}
+
+func (g *recordingGauge) Update(v float64) {
+	g.scope.mu.Lock()
+	defer g.scope.mu.Unlock()
+	g.scope.gauges[g.name] = v
+}
+
+// TestSingleBlockRetentionCronProbeFailedGaugeTracksOutcome pins the signal the
+// failure alert depends on.
+//
+// It must be a gauge written on every exit path, not the instrument's
+// result_type="error" counter: tally suppresses zero counter deltas, so that
+// counter emits nothing until the first failure and then goes silent, leaving a
+// single isolated sample that PromQL increase() cannot turn into a delta. The
+// first outage would be missed — the one case the alert exists for.
+func TestSingleBlockRetentionCronProbeFailedGaugeTracksOutcome(t *testing.T) {
+	t.Run("failure reports 1", func(t *testing.T) {
+		task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+		defer ctrl.Finish()
+		scope := newRecordingScope()
+		task.metrics = scope
+		cohortRepository.watermarkErr = errors.New("probe exploded")
+
+		require.Error(t, task.Run(context.Background()))
+		require.Empty(t, runtime.executions)
+
+		got, ok := scope.get("probe_failed")
+		require.True(t, ok, "a failed tick must still write the gauge")
+		require.Equal(t, float64(1), got)
+	})
+
+	t.Run("idle tick reports 0", func(t *testing.T) {
+		// Nothing due is a success, not a failure — otherwise the alert would
+		// fire every time retention has simply caught up.
+		task, runtime, _, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+		defer ctrl.Finish()
+		scope := newRecordingScope()
+		task.metrics = scope
+
+		require.NoError(t, task.Run(context.Background()))
+		require.Empty(t, runtime.executions)
+
+		got, ok := scope.get("probe_failed")
+		require.True(t, ok, "an idle tick must write a 0 baseline, not stay silent")
+		require.Equal(t, float64(0), got)
+	})
+
+	t.Run("successful sweep reports 0", func(t *testing.T) {
+		task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+		defer ctrl.Finish()
+		scope := newRecordingScope()
+		task.metrics = scope
+		cohortRepository.due = []retirement.RetentionCohort{{
+			ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+			StartHeight:           430_000_000,
+			EndHeight:             430_001_000,
+			RowCount:              1_000,
+			EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+		}}
+
+		require.NoError(t, task.Run(context.Background()))
+		require.Len(t, runtime.executions, 1)
+
+		got, ok := scope.get("probe_failed")
+		require.True(t, ok)
+		require.Equal(t, float64(0), got)
+	})
 }


### PR DESCRIPTION
Adds the signal that monorepo#15011's failure alert actually needs. Opened because review on that PR showed the metric it was going to use cannot work.

## Why the counter cannot work

monorepo#15011 planned `increase(chainstorage_cron_single_block_retention{result_type="error"}[30m]) > 0`, using the instrument's error counter. tally v4.1.10 `stats.go:87`:

```go
func (c *counter) report(name string, tags map[string]string, r StatsReporter) {
	delta := c.value()
	if delta == 0 {
		return
	}
	r.ReportCounter(name, tags, delta)
}
```

**Zero deltas are suppressed.** So that counter emits nothing until the first failure, then falls silent again — the series is a lone sample surrounded by gaps. PromQL `increase()` needs two points to compute a delta, so the alert never fires on the **first** outage, which is precisely the one worth catching. With an hourly cron and a 30m window it could be missed entirely.

No amount of PromQL fixes this, and no counter can: while zero deltas are dropped there is no way to give one a baseline. Credit to watch-owl for catching it.

## Why a gauge does

Gauges report whenever they were updated since the last flush (`stats.go:128`), so writing one on **every** tick keeps a continuous series. A plain `> 0` threshold then needs no delta at all.

```go
func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
	defer func() {
		failed := float64(0)
		if err != nil {
			failed = 1
		}
		t.metrics.Gauge("probe_failed").Update(failed)
	}()
```

Deferred on a named return so every exit path is covered — including the non-failure early exits (workflow already open, no approved range, nothing due), which report **0**.

**Writing 0 on idle ticks is the load-bearing part.** Without it the gauge would be exactly as sparse as the counter and the alert would be just as broken. That is why it is a deferred write on all paths rather than a write on the error path only.

## Tests

Three outcomes pinned: failure reports 1, idle tick reports 0, successful sweep reports 0.

The idle case matters as much as the failure case — "nothing due" is a normal successful outcome, and reporting 1 there would make the alert fire every time retention has simply caught up.

`go build`, `go vet`, `go test`, `go test -race` green on `cron` and `retirement`.

## Follow-on

monorepo#15011 switches its failure monitor to
`max by (env, blockchain, network) (chainstorage_cron_single_block_retention_probe_failed) > 0`
once this deploys. Until then that monitor would be inert, so the two should land in order: this, then a pin bump, then #15011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ge3KEUU82pkYvQ1GC1Chi
