### PR TITLE
fix(INF-1374): enforce strict CSCB chunk cap

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -802,6 +802,9 @@ func New(opts ...ConfigOption) (*Config, error) {
 	v.SetDefault("aws.storage.consolidation.multipart_threshold", 134217728)
 	v.SetDefault("aws.storage.consolidation.read_shadow_first", false)
 	v.SetDefault("aws.storage.consolidation.single_block_object_retention", DefaultSingleBlockObjectRetention.String())
+	if err := v.BindEnv("aws.storage.consolidation.max_chunk_uncompressed_bytes"); err != nil {
+		return nil, xerrors.Errorf("failed to bind max_chunk_uncompressed_bytes env: %w", err)
+	}
 	if err := v.BindEnv("aws.storage.consolidation.promotion_gate_height"); err != nil {
 		return nil, xerrors.Errorf("failed to bind promotion_gate_height env: %w", err)
 	}
@@ -1053,6 +1056,9 @@ func (c *Config) validateConsolidationConfig() error {
 	}
 	if consolidation.CompressionChunkBlocks == 0 {
 		return xerrors.New("consolidation compression_chunk_blocks must be positive")
+	}
+	if consolidation.MaxChunkUncompressedBytes != nil && *consolidation.MaxChunkUncompressedBytes == 0 {
+		return xerrors.New("consolidation max_chunk_uncompressed_bytes must be positive when set")
 	}
 	if consolidation.ShardSize == 0 {
 		return xerrors.New("consolidation shard_size must be positive")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1099,6 +1099,19 @@ func TestConsolidationSingleBlockObjectRetentionMustBePositiveWhenEnabled(t *tes
 	require.Contains(err.Error(), "single_block_object_retention must be positive")
 }
 
+func TestConsolidationMaxChunkUncompressedBytesMustBePositiveWhenEnabled(t *testing.T) {
+	require := testutil.Require(t)
+
+	t.Setenv("CHAINSTORAGE_STORAGE_TYPE_META", "POSTGRES")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_ENABLED", "true")
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_MODE", string(config.ConsolidationModeAutoConsolidate))
+	t.Setenv("CHAINSTORAGE_AWS_STORAGE_CONSOLIDATION_MAX_CHUNK_UNCOMPRESSED_BYTES", "0")
+
+	_, err := config.New()
+	require.Error(err)
+	require.Contains(err.Error(), "max_chunk_uncompressed_bytes must be positive when set")
+}
+
 func TestConsolidationPromoteFinalizedRequiresSafePromotionLag(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/storage/blobstorage/cscb/encoder.go
+++ b/internal/storage/blobstorage/cscb/encoder.go
@@ -222,6 +222,14 @@ func Encode(ctx context.Context, cfg EncodeConfig, blocks []internal.Consolidate
 		if err != nil {
 			return nil, xerrors.Errorf("invalid CSCB payload at height %d: %w", metadata.Height, err)
 		}
+		if cfg.MaxChunkUncompressedBytes != nil && payloadLength > *cfg.MaxChunkUncompressedBytes {
+			return nil, xerrors.Errorf(
+				"CSCB block payload length %d exceeds max_chunk_uncompressed_bytes %d at height %d",
+				payloadLength,
+				*cfg.MaxChunkUncompressedBytes,
+				metadata.Height,
+			)
+		}
 		if err := validateAdd(totalUncompressed, payloadLength, uint64(len(blocks)), cfg.MaxUncompressedBytes); err != nil {
 			return nil, err
 		}
@@ -431,7 +439,9 @@ func shouldFlushChunk(chunk *chunkBuilder, nextPayloadLength uint64, cfg EncodeC
 	if chunk.blockCount == 0 {
 		return false
 	}
-	return chunk.uncompressedLength+nextPayloadLength > *cfg.MaxChunkUncompressedBytes
+	maxChunkUncompressedBytes := *cfg.MaxChunkUncompressedBytes
+	return chunk.uncompressedLength > maxChunkUncompressedBytes ||
+		nextPayloadLength > maxChunkUncompressedBytes-chunk.uncompressedLength
 }
 
 func newChunkBuilder(index uint32, startHeight uint64, uncompressedOffset uint64, compressedPayloadOffset uint64, dst io.Writer, cfg EncodeConfig) (*chunkBuilder, error) {

--- a/internal/storage/blobstorage/cscb/encoder_test.go
+++ b/internal/storage/blobstorage/cscb/encoder_test.go
@@ -167,6 +167,65 @@ func TestEncodeCSCB_SpillsWhenMemoryBudgetExceeded(t *testing.T) {
 	require.True(os.IsNotExist(err))
 }
 
+func TestEncodeCSCB_EnforcesMaxChunkUncompressedBytesForSingleBlock(t *testing.T) {
+	require := testutil.Require(t)
+
+	maxChunkUncompressedBytes := uint64(4)
+	cfg := testEncodeConfig(api.Compression_ZSTD)
+	cfg.MaxChunkUncompressedBytes = &maxChunkUncompressedBytes
+	_, err := Encode(context.Background(), cfg, testPayloads())
+	require.Error(err)
+	require.Contains(err.Error(), "CSCB block payload length 5 exceeds max_chunk_uncompressed_bytes 4 at height 100")
+}
+
+func TestEncodeCSCB_SplitsAtMaxChunkUncompressedBytes(t *testing.T) {
+	require := testutil.Require(t)
+
+	maxChunkUncompressedBytes := uint64(11)
+	cfg := testEncodeConfig(api.Compression_ZSTD)
+	cfg.MaxChunkUncompressedBytes = &maxChunkUncompressedBytes
+	object, err := Encode(context.Background(), cfg, testPayloads())
+	require.NoError(err)
+	defer object.Close()
+
+	data, ok := object.Bytes()
+	require.True(ok)
+	index, err := ParseIndex(data)
+	require.NoError(err)
+	require.Len(index.Chunks, 3)
+	require.Equal([]uint64{5, 11, 7}, []uint64{
+		index.Chunks[0].UncompressedLength,
+		index.Chunks[1].UncompressedLength,
+		index.Chunks[2].UncompressedLength,
+	})
+	for _, chunk := range index.Chunks {
+		require.LessOrEqual(chunk.UncompressedLength, maxChunkUncompressedBytes)
+	}
+}
+
+func TestEncodeCSCB_MaxChunkUncompressedBytesDoesNotChangeObjectsBelowCap(t *testing.T) {
+	require := testutil.Require(t)
+
+	legacyObject, err := Encode(context.Background(), testEncodeConfig(api.Compression_ZSTD), testPayloads())
+	require.NoError(err)
+	defer legacyObject.Close()
+	legacyData, ok := legacyObject.Bytes()
+	require.True(ok)
+
+	maxChunkUncompressedBytes := uint64(16)
+	cappedCfg := testEncodeConfig(api.Compression_ZSTD)
+	cappedCfg.MaxChunkUncompressedBytes = &maxChunkUncompressedBytes
+	cappedObject, err := Encode(context.Background(), cappedCfg, testPayloads())
+	require.NoError(err)
+	defer cappedObject.Close()
+	cappedData, ok := cappedObject.Bytes()
+	require.True(ok)
+
+	require.Equal(legacyData, cappedData)
+	require.Equal(legacyObject.Key, cappedObject.Key)
+	require.Equal(legacyObject.Placements, cappedObject.Placements)
+}
+
 func TestEncodeCSCB_EnforcesLocalSpillMaxBytes(t *testing.T) {
 	require := testutil.Require(t)
 

--- a/internal/storage/blobstorage/cscb/reader_test.go
+++ b/internal/storage/blobstorage/cscb/reader_test.go
@@ -207,3 +207,37 @@ func TestDecodeChunkFrameSupportsMaxAllowedZstdWindow(t *testing.T) {
 	require.NoError(ValidateChunkPayload(chunkPayload, chunk))
 	require.Equal(payload, chunkPayload)
 }
+
+func TestReaderSupportsExistingChunkAboveNewEncoderCap(t *testing.T) {
+	require := testutil.Require(t)
+
+	// A nil cap reproduces an object produced before max_chunk_uncompressed_bytes
+	// was configured. Its first chunk is deliberately larger than the simulated
+	// new encoder cap; readers must continue to use the persisted CSCB index.
+	legacyObject, err := Encode(context.Background(), testEncodeConfig(api.Compression_ZSTD), testPayloads())
+	require.NoError(err)
+	defer legacyObject.Close()
+	data, ok := legacyObject.Bytes()
+	require.True(ok)
+
+	index, err := ParseIndex(data)
+	require.NoError(err)
+	require.Len(index.Chunks, 2)
+	newEncoderCap := uint64(15)
+	chunk := &index.Chunks[0]
+	require.Greater(chunk.UncompressedLength, newEncoderCap)
+
+	block := &index.Blocks[1]
+	frame := data[chunk.CompressedPayloadOffset : chunk.CompressedPayloadOffset+chunk.CompressedLength]
+	stream, err := OpenBlockPayloadFromChunkFrame(
+		io.NopCloser(bytes.NewReader(frame)),
+		index.Header.Codec,
+		chunk,
+		block,
+	)
+	require.NoError(err)
+	payload, err := io.ReadAll(stream)
+	require.NoError(err)
+	require.NoError(stream.Close())
+	require.Equal([]byte("bravo-bravo"), payload)
+}


### PR DESCRIPTION
## Summary

- reject an individual CSCB block payload above max_chunk_uncompressed_bytes
- split multi-block chunks with overflow-safe boundary arithmetic
- preserve byte-identical output below the cap and keep legacy CSCB objects readable

## Rollout

Deploy this encoder change before enabling the dependent Solana Helm cap. This only constrains newly encoded objects; it does not rewrite objects or change the CSCB reader/format.

## Testing

- PATH=/Users/boyangxu/go/bin:$PATH make test

[INF-1374](https://linear.app/cipherowl/issue/INF-1374)
