### PR TITLE
fix(config): honor snake_case endpoint keys in YAML configs

### DIFF
--- a/internal/blockchain/endpoints/endpoint_provider.go
+++ b/internal/blockchain/endpoints/endpoint_provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 
@@ -163,6 +164,8 @@ func newEndpointProvider(logger *zap.Logger, cfg *config.Config, scope tally.Sco
 		primaryPicker, secondaryPicker = secondaryPicker, primaryPicker
 	}
 
+	logEndpointGroup(logger, name, primaryEndpoints, secondaryEndpoints)
+
 	return &endpointProvider{
 		name:               name,
 		endpointGroup:      endpointGroup,
@@ -173,6 +176,42 @@ func newEndpointProvider(logger *zap.Logger, cfg *config.Config, scope tally.Sco
 		secondaryPicker:    secondaryPicker,
 		secondaryEndpoints: secondaryEndpoints,
 	}, nil
+}
+
+// logEndpointGroup records the endpoint settings that are actually in effect,
+// so that a misconfigured deployment can be diagnosed from the startup log
+// instead of by inspecting the provider's rate-limit errors. Note that the rate
+// limiter is per endpoint per group: the same URL configured in several groups
+// gets an independent budget in each of them.
+func logEndpointGroup(logger *zap.Logger, name string, primary []*Endpoint, secondary []*Endpoint) {
+	if len(primary) == 0 {
+		logger.Warn("endpoint group is empty", zap.String("endpoint_group", name))
+		return
+	}
+
+	for _, endpoint := range primary {
+		logger.Info(
+			"endpoint config",
+			zap.String("endpoint_group", name),
+			zap.String("endpoint", endpoint.Name),
+			zap.String("host", endpointHost(endpoint.Config.Url)),
+			zap.Uint8("weight", endpoint.Config.Weight),
+			zap.Int("rps", endpoint.Config.RPS),
+			zap.Bool("rps_count_batch", endpoint.Config.RPSCountBatch),
+			zap.Int("num_failover_endpoints", len(secondary)),
+		)
+	}
+}
+
+// endpointHost strips the path and the userinfo from the url, since providers
+// such as QuickNode embed the API key in them.
+func endpointHost(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return "unknown"
+	}
+
+	return parsed.Host
 }
 
 func newEndpoints(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -379,12 +379,18 @@ type (
 		FromRosetta             bool    `mapstructure:"from_rosetta"`
 	}
 
+	// EndpointGroup is decoded from two different sources, so every field needs
+	// both tags: encoding/json when the group arrives as a JSON string (e.g. the
+	// CHAINSTORAGE_CHAIN_CLIENT_MASTER_ENDPOINT_GROUP env var, see UnmarshalText),
+	// and mapstructure when it arrives as a YAML mapping. mapstructure falls back
+	// to a case-insensitive field-name match, which silently drops any key with
+	// an underscore in it, so the tags are not optional.
 	EndpointGroup struct {
-		Endpoints              []Endpoint     `json:"endpoints"`
-		EndpointsFailover      []Endpoint     `json:"endpoints_failover"`
-		UseFailover            bool           `json:"use_failover"`
-		EndpointConfig         EndpointConfig `json:"endpoint_config"`
-		EndpointConfigFailover EndpointConfig `json:"endpoint_config_failover"`
+		Endpoints              []Endpoint     `json:"endpoints" mapstructure:"endpoints"`
+		EndpointsFailover      []Endpoint     `json:"endpoints_failover" mapstructure:"endpoints_failover"`
+		UseFailover            bool           `json:"use_failover" mapstructure:"use_failover"`
+		EndpointConfig         EndpointConfig `json:"endpoint_config" mapstructure:"endpoint_config"`
+		EndpointConfigFailover EndpointConfig `json:"endpoint_config_failover" mapstructure:"endpoint_config_failover"`
 	}
 
 	// endpointGroup must be in sync with EndpointGroup
@@ -397,34 +403,34 @@ type (
 	}
 
 	Endpoint struct {
-		Name       string            `json:"name"`
-		ProviderID string            `json:"provider_id"`
-		Url        string            `json:"url"`
-		User       string            `json:"user"`
-		Password   string            `json:"password"`
-		Weight     uint8             `json:"weight"`
-		ExtraUrls  map[string]string `json:"extra_urls"`
-		RPS        int               `json:"rps"`
+		Name       string            `json:"name" mapstructure:"name"`
+		ProviderID string            `json:"provider_id" mapstructure:"provider_id"`
+		Url        string            `json:"url" mapstructure:"url"`
+		User       string            `json:"user" mapstructure:"user"`
+		Password   string            `json:"password" mapstructure:"password"`
+		Weight     uint8             `json:"weight" mapstructure:"weight"`
+		ExtraUrls  map[string]string `json:"extra_urls" mapstructure:"extra_urls"`
+		RPS        int               `json:"rps" mapstructure:"rps"`
 		// RPSCountBatch makes the rate limiter charge one token per call inside
 		// a JSON-RPC batch request, for providers whose rate limit counts each
 		// batched call individually. Has no effect unless RPS is set.
-		RPSCountBatch bool `json:"rps_count_batch"`
+		RPSCountBatch bool `json:"rps_count_batch" mapstructure:"rps_count_batch"`
 	}
 
 	EndpointConfig struct {
-		StickySession StickySessionConfig `json:"sticky_session"`
-		Headers       map[string]string   `json:"headers"`
+		StickySession StickySessionConfig `json:"sticky_session" mapstructure:"sticky_session"`
+		Headers       map[string]string   `json:"headers" mapstructure:"headers"`
 	}
 
 	StickySessionConfig struct {
 		// The CookieHash method consistently maps a cookie value to a specific node.
-		CookieHash string `json:"cookie_hash"`
+		CookieHash string `json:"cookie_hash" mapstructure:"cookie_hash"`
 
 		// The CookiePassive method persists the cookie value provided by the server.
-		CookiePassive bool `json:"cookie_passive"`
+		CookiePassive bool `json:"cookie_passive" mapstructure:"cookie_passive"`
 
 		// The HeaderHash method consistently maps a header value to a specific node.
-		HeaderHash string `json:"header_hash"`
+		HeaderHash string `json:"header_hash" mapstructure:"header_hash"`
 	}
 
 	ApiConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -672,6 +673,67 @@ func TestEndpointGroupWithRPSCountBatch(t *testing.T) {
 	var endpointGroupDefault config.EndpointGroup
 	require.NoError(endpointGroupDefault.UnmarshalText([]byte(text)))
 	require.False(endpointGroupDefault.Endpoints[0].RPSCountBatch)
+}
+
+// The endpoint group reaches the config through two decoders: encoding/json
+// when it is supplied as a JSON string (env var), and mapstructure when it is
+// supplied as a YAML mapping. mapstructure only falls back to a
+// case-insensitive field-name match, so a struct field without a mapstructure
+// tag silently loses every snake_case key. Load a YAML config end to end to
+// make sure both decoders agree.
+func TestEndpointGroupParsedFromYAML(t *testing.T) {
+	require := testutil.Require(t)
+
+	const yamlEndpointGroup = `    master:
+      endpoint_group:
+        endpoints:
+          - name: primary
+            provider_id: quicknode
+            url: https://primary.example.com
+            weight: 1
+            rps: 100
+            rps_count_batch: true
+            extra_urls:
+              trace: https://trace.example.com
+        endpoints_failover:
+          - name: backup
+            url: https://backup.example.com
+            weight: 1
+            rps: 50
+        endpoint_config:
+          headers:
+            x-api-key: secret
+`
+
+	base, err := os.ReadFile("../../config/chainstorage/ethereum/mainnet/base.yml")
+	require.NoError(err)
+
+	const placeholder = "    master:\n      endpoint_group: \"\"\n"
+	require.Contains(string(base), placeholder)
+	patched := strings.Replace(string(base), placeholder, yamlEndpointGroup, 1)
+
+	configPath := filepath.Join(t.TempDir(), "base.yml")
+	require.NoError(os.WriteFile(configPath, []byte(patched), 0600))
+	require.NoError(os.Setenv(config.EnvVarConfigPath, configPath))
+	defer os.Unsetenv(config.EnvVarConfigPath)
+
+	cfg, err := config.New()
+	require.NoError(err)
+
+	group := cfg.Chain.Client.Master.EndpointGroup
+	require.Equal(1, len(group.Endpoints))
+
+	endpoint := group.Endpoints[0]
+	require.Equal("primary", endpoint.Name)
+	require.Equal("quicknode", endpoint.ProviderID)
+	require.Equal("https://primary.example.com", endpoint.Url)
+	require.Equal(100, endpoint.RPS)
+	require.True(endpoint.RPSCountBatch)
+	require.Equal(map[string]string{"trace": "https://trace.example.com"}, endpoint.ExtraUrls)
+
+	require.Equal(1, len(group.EndpointsFailover))
+	require.Equal("backup", group.EndpointsFailover[0].Name)
+	require.Equal(map[string]string{"x-api-key": "secret"}, group.EndpointConfig.Headers)
 }
 
 func TestEndpointGroup(t *testing.T) {

--- a/internal/config/dump_endpoints_test.go
+++ b/internal/config/dump_endpoints_test.go
@@ -1,0 +1,55 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coinbase/chainstorage/internal/config"
+)
+
+// TestDumpEndpoints prints the endpoint settings that config.New produces after
+// viper has merged base.yml, <env>.yml, .secrets.yml and the CHAINSTORAGE_*
+// environment variables. It is a diagnostic tool rather than an assertion: run
+// it with the same environment as a deployment to see which rps and
+// rps_count_batch values that deployment actually ends up with.
+//
+//	DUMP_ENDPOINTS=1 CHAINSTORAGE_CONFIG=story-mainnet CHAINSTORAGE_ENVIRONMENT=production \
+//	  go test ./internal/config -run TestDumpEndpoints -v
+func TestDumpEndpoints(t *testing.T) {
+	if os.Getenv("DUMP_ENDPOINTS") == "" {
+		t.Skip("set DUMP_ENDPOINTS=1 to dump the effective endpoint config")
+	}
+
+	cfg, err := config.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := cfg.Chain.Client
+	groups := []struct {
+		name  string
+		group *config.EndpointGroup
+	}{
+		{"master", &client.Master.EndpointGroup},
+		{"slave", &client.Slave.EndpointGroup},
+		{"validator", &client.Validator.EndpointGroup},
+		{"consensus", &client.Consensus.EndpointGroup},
+		{"additional", &client.Additional.EndpointGroup},
+	}
+
+	fmt.Printf("config=%v env=%v tx_batch_size=%v\n", cfg.ConfigName, cfg.Env(), client.TxBatchSize)
+	for _, g := range groups {
+		if len(g.group.Endpoints) == 0 {
+			fmt.Printf("group=%-10v <empty>\n", g.name)
+			continue
+		}
+
+		for _, endpoint := range g.group.Endpoints {
+			fmt.Printf(
+				"group=%-10v name=%-16v rps=%-6v rps_count_batch=%-6v weight=%v use_failover=%v\n",
+				g.name, endpoint.Name, endpoint.RPS, endpoint.RPSCountBatch, endpoint.Weight, g.group.UseFailover,
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

An endpoint configured in YAML with

```yaml
endpoints:
  - name: quicknode
    url: https://...
    rps: 100
    rps_count_batch: true
```

still trips the provider's rate limit. `rps` takes effect but `rps_count_batch` does not, so the limiter charges one token per HTTP request instead of one per call inside a JSON-RPC batch — up to `rps * tx_batch_size` provider-side calls per second.

## Root cause

`Endpoint`, `EndpointGroup`, `EndpointConfig` and `StickySessionConfig` only carried `json` tags. Those cover the path where a group arrives as a JSON **string** (`CHAINSTORAGE_CHAIN_CLIENT_SLAVE_ENDPOINT_GROUP`, decoded by `EndpointGroup.UnmarshalText`). A group written as a YAML **mapping** is decoded by mapstructure, which without a tag only falls back to a case-insensitive field-name match — so `rps` matched `RPS` but every snake_case key was silently dropped:

`rps_count_batch`, `provider_id`, `extra_urls`, `endpoints_failover`, `use_failover`, `endpoint_config`.

## Changes

- Add `mapstructure` tags to the four structs so the JSON and YAML decoders agree.
- Log the endpoint settings actually in effect at startup — host only, since providers such as QuickNode embed the API key in the url path — plus a `WARN` when a group ends up empty:

  ```
  INFO endpoint config {"endpoint_group":"slave","endpoint":"quicknode","host":"...","weight":1,"rps":100,"rps_count_batch":true,"num_failover_endpoints":0}
  ```

- `TestEndpointGroupParsedFromYAML`: writes a YAML config and loads it end to end through `config.New`, asserting all of the above keys land. Verified non-vacuous — it fails when the tags are removed.
- `TestDumpEndpoints`: opt-in diagnostic (`DUMP_ENDPOINTS=1`) that prints the effective endpoint settings for a given environment, for checking what a deployment actually resolved to.

## Note on rate-limit sizing

The limiter is **per endpoint per group** (`NewEndpointProvider` builds master / slave / validator / consensus / additional, and consensus clones the slave group when unset), each with its own `rate.Limiter`. The same url configured in several groups gets an independent budget in each, so with this fix live, `rps` still needs to be divided across the groups that share a provider.

## Testing

- `go build ./...`, `go vet` clean.
- `./internal/blockchain/endpoints`, `./internal/blockchain/jsonrpc` pass.
- `TestValidateConfigs` has 64 pre-existing failures on this working tree (`require.True(cfg.AWS.IsLocalStack)`), unrelated to this change — identical count with the change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)