### PR TITLE
fix(INF-1416): bound the retention probe by window_blocks

### DIFF
--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -47,7 +47,20 @@ const (
 	autoRetainSuffix                        = "auto_retain"
 	defaultSingleBlockRetentionCronSpec     = "@every 1h"
 	defaultSingleBlockRetentionWindowBlocks = uint64(250_000)
-	singleBlockRetentionOpenPageSize        = 1000
+
+	// maxRetentionProbeAdvances bounds how many consecutive probe windows one
+	// tick may step past when a window's due rows all turn out unselectable
+	// (covered by an active repair, missing canonical membership, and so on —
+	// the due-floor candidate deliberately does not evaluate those; see
+	// RetentionDueFloor). Each advance costs one cheap floor lookup plus one
+	// bounded probe over a window that selects nothing, so the cap bounds
+	// per-tick cost, not correctness: at 4 advances a tick steps over up to
+	// 4 x window_blocks of solidly unselectable due rows, and a dead zone
+	// larger than that (hundreds of consecutive broken consolidated objects)
+	// is an incident to alarm on — probe_advance_exhausted goes to 1 — rather
+	// than something to silently walk past.
+	maxRetentionProbeAdvances        = 4
+	singleBlockRetentionOpenPageSize = 1000
 )
 
 func NewSingleBlockRetention(params SingleBlockRetentionTaskParams) (Task, error) {
@@ -139,6 +152,15 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 		return err
 	}
 	if open {
+		// A no-probe tick writes the probe-only gauges as zero rather than
+		// leaving them holding the previous tick's values: a stale
+		// probe_window_blocks would claim this tick scanned a window it never
+		// ran. oldest_due_age_seconds is deliberately NOT reset here — the
+		// backlog it measures still exists while the open sweep works it, and
+		// zeroing it would silence the age alarm exactly when a sweep is stuck.
+		t.metrics.Gauge("probe_window_blocks").Update(0)
+		t.metrics.Gauge("due_floor_height").Update(0)
+		t.metrics.Gauge("probe_advance_exhausted").Update(0)
 		t.logger.Info(
 			"single_block_retention cron skipped because a retention workflow is already open",
 			zap.String("open_workflow_id", openWorkflowID),
@@ -200,8 +222,14 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	if probeStart >= approvedEnd {
 		// Everything approved has been retired. Report a zero-width range so the
 		// width alarm cannot mistake a finished sweep for unbounded growth.
+		// Every probe-only gauge is reset here as well: a gauge left holding the
+		// previous tick's value would report a scanned window on a tick that
+		// never probed, contradicting the gauge's meaning.
 		t.metrics.Gauge("floor_watermark_height").Update(float64(probeStart))
 		t.metrics.Gauge("probe_range_blocks").Update(0)
+		t.metrics.Gauge("probe_window_blocks").Update(0)
+		t.metrics.Gauge("due_floor_height").Update(0)
+		t.metrics.Gauge("probe_advance_exhausted").Update(0)
 		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
 		t.metrics.Gauge("probe_backlog_truncated").Update(0)
 		t.logger.Info(
@@ -239,6 +267,14 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	// backlog therefore lands past the flip on the very first tick and stays
 	// there (INF-1416; same plan flip as INF-1330 on solana-mainnet).
 	//
+	// The window is anchored on the earliest DUE height, not on the watermark:
+	// the watermark pins to any undeleted row, due or not, and a window anchored
+	// on a not-yet-due row can be empty while due work sits above it — recomputed
+	// identically every tick, forever. The due floor is a candidate rather than a
+	// selectability proof (see RetentionDueFloor), so a window whose due rows all
+	// turn out unselectable advances instead of idling; the advance count is
+	// bounded and its exhaustion is alarmed, never silent.
+	//
 	// probe_range_blocks above deliberately still reports the FULL approved
 	// range, so the backlog remains visible to alerting; probe_window_blocks
 	// reports what was actually scanned.
@@ -246,91 +282,114 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	if windowBlocks == 0 {
 		windowBlocks = defaultSingleBlockRetentionWindowBlocks
 	}
-	// Anchor the window on the earliest DUE height, not on the watermark.
-	//
-	// The watermark is conservative by omission and pins to any undeleted row,
-	// due or not. Windowing the probe from there is unsafe: if a not-yet-due row
-	// sits at the watermark while due work sits above the window, the probe
-	// returns nothing, the tick idles, and the next tick recomputes the same
-	// watermark and idles again -- the due work is never discovered until the low
-	// row matures. The pre-windowed probe spanned the whole approved range and so
-	// could not hide it. Out-of-order backfill and repair promotion set each
-	// row's retention clock independently, so that interleaving is reachable.
-	//
-	// Anchoring here makes an empty window mean "nothing is due", which is the
-	// only reading under which idling is correct.
-	dueFloor, dueFound, err := selector.DueFloor(ctx, storageGeneration, tag, probeStart, eligibilityCutoff)
-	if err != nil {
-		t.metrics.Gauge("probe_failed").Update(1)
-		return xerrors.Errorf("failed to resolve retention due floor: %w", err)
-	}
-	// dueFloor >= probeStart, so it can sit at or above approvedEnd even though
-	// the watermark did not. Treat that as nothing due rather than letting
-	// probeEnd-probeStart underflow into an unbounded window.
-	if dueFound && dueFloor >= approvedEnd {
-		dueFound = false
-	}
-	if !dueFound {
-		t.metrics.Gauge("probe_failed").Update(0)
-		t.metrics.Gauge("probe_window_blocks").Update(0)
-		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
-		t.metrics.Gauge("probe_backlog_truncated").Update(0)
-		t.logger.Info(
-			"single_block_retention cron found nothing due",
-			zap.Uint32("tag", tag),
-			zap.String("bucket", bucket),
-			zap.String("storage_generation", storageGeneration),
-			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
-			zap.Uint64("approved_end_height", approvedEnd),
-			zap.Uint64("floor_watermark_height", probeStart),
-		)
-		return nil
-	}
-	probeStart = dueFloor
-	probeEnd := approvedEnd
-	if probeEnd-probeStart > windowBlocks {
-		probeEnd = probeStart + windowBlocks
-	}
-	t.metrics.Gauge("due_floor_height").Update(float64(probeStart))
-	t.metrics.Gauge("probe_window_blocks").Update(float64(probeEnd - probeStart))
 
+	// probe_duration_seconds covers the whole search — floor lookups, probes,
+	// and advances — so a slow tick is visible no matter which stage is slow.
 	probeStartedAt := time.Now()
-	// Asks for a full workflow batch because the selector sorts pending
-	// (in-flight) cohorts by prepared_at ahead of height-ordered due cohorts:
-	// anchoring on the first cohort alone could hide older due work behind a
-	// stuck pending cohort indefinitely.
-	cohorts, hasMore, err := selector.Select(
-		ctx,
-		bucket,
-		storageGeneration,
-		tag,
-		probeStart,
-		probeEnd,
-		eligibilityCutoff,
-		retirement.MaxRetentionCohortsPerWorkflow,
+	var (
+		cohorts  []retirement.RetentionCohort
+		hasMore  bool
+		probeEnd uint64
 	)
-	t.metrics.Gauge("probe_duration_seconds").Update(time.Since(probeStartedAt).Seconds())
-	if err != nil {
-		return xerrors.Errorf("failed to probe due retention cohorts: %w", err)
+	found := false
+	searchStart := probeStart
+	for attempt := 0; attempt < maxRetentionProbeAdvances; attempt++ {
+		dueFloor, dueFound, err := selector.DueFloor(ctx, storageGeneration, tag, searchStart, approvedEnd, eligibilityCutoff)
+		if err != nil {
+			t.metrics.Gauge("probe_duration_seconds").Update(time.Since(probeStartedAt).Seconds())
+			return xerrors.Errorf("failed to resolve retention due floor: %w", err)
+		}
+		if !dueFound {
+			// Nothing due in [searchStart, approvedEnd). Because the floor
+			// candidate matches a superset of selectable rows, this is proof
+			// there is nothing to select, and idling is correct. Reset every
+			// probe gauge so this tick cannot exhibit the previous tick's
+			// values.
+			t.metrics.Gauge("probe_duration_seconds").Update(time.Since(probeStartedAt).Seconds())
+			t.metrics.Gauge("due_floor_height").Update(0)
+			t.metrics.Gauge("probe_window_blocks").Update(0)
+			t.metrics.Gauge("probe_advance_exhausted").Update(0)
+			t.metrics.Gauge("oldest_due_age_seconds").Update(0)
+			t.metrics.Gauge("probe_backlog_truncated").Update(0)
+			t.logger.Info(
+				"single_block_retention cron found nothing due",
+				zap.Uint32("tag", tag),
+				zap.String("bucket", bucket),
+				zap.String("storage_generation", storageGeneration),
+				zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
+				zap.Uint64("approved_end_height", approvedEnd),
+				zap.Uint64("floor_watermark_height", probeStart),
+				zap.Uint64("search_start_height", searchStart),
+				zap.Int("probe_advances", attempt),
+			)
+			return nil
+		}
+		probeStart = dueFloor
+		probeEnd = approvedEnd
+		if probeEnd-probeStart > windowBlocks {
+			probeEnd = probeStart + windowBlocks
+		}
+		t.metrics.Gauge("due_floor_height").Update(float64(probeStart))
+		t.metrics.Gauge("probe_window_blocks").Update(float64(probeEnd - probeStart))
+
+		// Asks for a full workflow batch because the selector sorts pending
+		// (in-flight) cohorts by prepared_at ahead of height-ordered due cohorts:
+		// anchoring on the first cohort alone could hide older due work behind a
+		// stuck pending cohort indefinitely.
+		cohorts, hasMore, err = selector.Select(
+			ctx,
+			bucket,
+			storageGeneration,
+			tag,
+			probeStart,
+			probeEnd,
+			eligibilityCutoff,
+			retirement.MaxRetentionCohortsPerWorkflow,
+		)
+		if err != nil {
+			t.metrics.Gauge("probe_duration_seconds").Update(time.Since(probeStartedAt).Seconds())
+			return xerrors.Errorf("failed to probe due retention cohorts: %w", err)
+		}
+		if len(cohorts) > 0 {
+			found = true
+			break
+		}
+		// The floor saw due rows in this window but the probe selected none of
+		// them: every due row here is excluded at the join level (active
+		// repair, pending manifest, canonical or metadata mismatch). Step past
+		// the window rather than idling on it — idling would pin the search
+		// here forever, hiding selectable work above.
+		t.logger.Info(
+			"single_block_retention cron advancing past a window with no selectable cohorts",
+			zap.Uint32("tag", tag),
+			zap.Uint64("window_start_height", probeStart),
+			zap.Uint64("window_end_height", probeEnd),
+			zap.Int("probe_advances", attempt+1),
+		)
+		searchStart = probeEnd
 	}
-	if len(cohorts) == 0 {
+	t.metrics.Gauge("probe_duration_seconds").Update(time.Since(probeStartedAt).Seconds())
+	if !found {
+		// Every window we were willing to inspect this tick holds only
+		// unselectable due rows. This is an alarm state, not an idle: due work
+		// exists, nothing was launched, and the next tick will walk the same
+		// windows. A dead zone this wide means a mass of repair-covered or
+		// inconsistent objects that needs a human.
+		t.metrics.Gauge("probe_advance_exhausted").Update(1)
 		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
 		t.metrics.Gauge("probe_backlog_truncated").Update(0)
-		t.logger.Info(
-			"single_block_retention cron found no due cohorts",
+		t.logger.Warn(
+			"single_block_retention cron exhausted probe advances without selectable work",
 			zap.Uint32("tag", tag),
 			zap.String("bucket", bucket),
 			zap.String("storage_generation", storageGeneration),
-			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
 			zap.Uint64("approved_end_height", approvedEnd),
-			zap.Uint64("floor_watermark_height", probeStart),
-			zap.Uint64("probe_range_blocks", approvedEnd-probeStart),
-			zap.Uint64("probe_end_height", probeEnd),
-			zap.Uint64("probe_window_blocks", probeEnd-probeStart),
-			zap.Bool("has_more", hasMore),
+			zap.Uint64("last_window_end_height", probeEnd),
+			zap.Int("probe_advances", maxRetentionProbeAdvances),
 		)
 		return nil
 	}
+	t.metrics.Gauge("probe_advance_exhausted").Update(0)
 	// Anchor at the minimum start height and age the gauge from the oldest
 	// eligibility across the whole probe set, so neither is masked by
 	// pending-cohort ordering. Stuck pending cohorts are themselves overdue,

--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -246,10 +246,52 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	if windowBlocks == 0 {
 		windowBlocks = defaultSingleBlockRetentionWindowBlocks
 	}
+	// Anchor the window on the earliest DUE height, not on the watermark.
+	//
+	// The watermark is conservative by omission and pins to any undeleted row,
+	// due or not. Windowing the probe from there is unsafe: if a not-yet-due row
+	// sits at the watermark while due work sits above the window, the probe
+	// returns nothing, the tick idles, and the next tick recomputes the same
+	// watermark and idles again -- the due work is never discovered until the low
+	// row matures. The pre-windowed probe spanned the whole approved range and so
+	// could not hide it. Out-of-order backfill and repair promotion set each
+	// row's retention clock independently, so that interleaving is reachable.
+	//
+	// Anchoring here makes an empty window mean "nothing is due", which is the
+	// only reading under which idling is correct.
+	dueFloor, dueFound, err := selector.DueFloor(ctx, storageGeneration, tag, probeStart, eligibilityCutoff)
+	if err != nil {
+		t.metrics.Gauge("probe_failed").Update(1)
+		return xerrors.Errorf("failed to resolve retention due floor: %w", err)
+	}
+	// dueFloor >= probeStart, so it can sit at or above approvedEnd even though
+	// the watermark did not. Treat that as nothing due rather than letting
+	// probeEnd-probeStart underflow into an unbounded window.
+	if dueFound && dueFloor >= approvedEnd {
+		dueFound = false
+	}
+	if !dueFound {
+		t.metrics.Gauge("probe_failed").Update(0)
+		t.metrics.Gauge("probe_window_blocks").Update(0)
+		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
+		t.metrics.Gauge("probe_backlog_truncated").Update(0)
+		t.logger.Info(
+			"single_block_retention cron found nothing due",
+			zap.Uint32("tag", tag),
+			zap.String("bucket", bucket),
+			zap.String("storage_generation", storageGeneration),
+			zap.Uint64("approved_start_height", cronConfig.ApprovedStartHeight),
+			zap.Uint64("approved_end_height", approvedEnd),
+			zap.Uint64("floor_watermark_height", probeStart),
+		)
+		return nil
+	}
+	probeStart = dueFloor
 	probeEnd := approvedEnd
 	if probeEnd-probeStart > windowBlocks {
 		probeEnd = probeStart + windowBlocks
 	}
+	t.metrics.Gauge("due_floor_height").Update(float64(probeStart))
 	t.metrics.Gauge("probe_window_blocks").Update(float64(probeEnd - probeStart))
 
 	probeStartedAt := time.Now()

--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -40,6 +41,26 @@ type (
 		singleBlockRetention *workflow.SingleBlockRetention
 
 		selectorFactory func(ctx context.Context) (*retirement.Selector, error)
+
+		// probeResumeHeight is where the next tick's advance walk continues
+		// after a tick exhausts maxRetentionProbeAdvances without finding
+		// selectable work. Without it every tick restarts from the watermark
+		// and re-walks the same dead windows, so selectable work beyond the
+		// advance budget is starved permanently; with it consecutive exhausted
+		// ticks ratchet through the dead zone, budget-sized step by step, and
+		// reach whatever lies beyond.
+		//
+		// Deliberately in-memory, not persisted: a stored cursor would need
+		// its own reconciliation against repairs and completed sweeps (the
+		// same reason the watermark is recomputed every tick), while losing
+		// this one on restart merely restarts the walk from the watermark —
+		// the safe direction, re-inspecting windows rather than skipping any.
+		// It is cleared whenever a tick launches, finds nothing due, or finds
+		// the approved range complete, so dead-prefix rows that later become
+		// selectable are re-inspected on the next full pass of the ring.
+		// Atomic only as insurance against a misconfigured parallelism > 1;
+		// the cron runs this task single-flight.
+		probeResumeHeight atomic.Uint64
 	}
 )
 
@@ -57,8 +78,10 @@ const (
 	// per-tick cost, not correctness: at 4 advances a tick steps over up to
 	// 4 x window_blocks of solidly unselectable due rows, and a dead zone
 	// larger than that (hundreds of consecutive broken consolidated objects)
-	// is an incident to alarm on — probe_advance_exhausted goes to 1 — rather
-	// than something to silently walk past.
+	// is an incident to alarm on — probe_advance_exhausted goes to 1 — but the
+	// walk also RESUMES where it stopped (probeResumeHeight), so consecutive
+	// ticks ratchet through a dead zone of any width instead of retrying the
+	// same prefix forever.
 	maxRetentionProbeAdvances        = 4
 	singleBlockRetentionOpenPageSize = 1000
 )
@@ -232,6 +255,7 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 		t.metrics.Gauge("probe_advance_exhausted").Update(0)
 		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
 		t.metrics.Gauge("probe_backlog_truncated").Update(0)
+		t.probeResumeHeight.Store(0)
 		t.logger.Info(
 			"single_block_retention cron found no outstanding single-block work",
 			zap.Uint32("tag", tag),
@@ -293,6 +317,15 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	)
 	found := false
 	searchStart := probeStart
+	// Resume an exhausted walk. A cursor at or below the watermark is stale
+	// (the watermark caught up past it) and one at or beyond the approved end
+	// has finished the ring; both restart the walk from the watermark so
+	// dead-prefix rows that have since become selectable are re-inspected.
+	if resume := t.probeResumeHeight.Load(); resume > searchStart && resume < approvedEnd {
+		searchStart = resume
+	} else {
+		t.probeResumeHeight.Store(0)
+	}
 	for attempt := 0; attempt < maxRetentionProbeAdvances; attempt++ {
 		dueFloor, dueFound, err := selector.DueFloor(ctx, storageGeneration, tag, searchStart, approvedEnd, eligibilityCutoff)
 		if err != nil {
@@ -311,6 +344,10 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 			t.metrics.Gauge("probe_advance_exhausted").Update(0)
 			t.metrics.Gauge("oldest_due_age_seconds").Update(0)
 			t.metrics.Gauge("probe_backlog_truncated").Update(0)
+			// Wrap the ring: nothing due above searchStart, so the next tick
+			// walks from the watermark again and re-inspects any dead prefix
+			// whose rows may have become selectable since.
+			t.probeResumeHeight.Store(0)
 			t.logger.Info(
 				"single_block_retention cron found nothing due",
 				zap.Uint32("tag", tag),
@@ -378,6 +415,11 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 		t.metrics.Gauge("probe_advance_exhausted").Update(1)
 		t.metrics.Gauge("oldest_due_age_seconds").Update(0)
 		t.metrics.Gauge("probe_backlog_truncated").Update(0)
+		// Resume here next tick instead of re-walking the same dead prefix —
+		// searchStart is the end of the last window inspected. Consecutive
+		// exhausted ticks therefore ratchet forward budget-by-budget until
+		// they reach selectable work, nothing due, or the approved end.
+		t.probeResumeHeight.Store(searchStart)
 		t.logger.Warn(
 			"single_block_retention cron exhausted probe advances without selectable work",
 			zap.Uint32("tag", tag),
@@ -385,11 +427,13 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 			zap.String("storage_generation", storageGeneration),
 			zap.Uint64("approved_end_height", approvedEnd),
 			zap.Uint64("last_window_end_height", probeEnd),
+			zap.Uint64("resume_height", searchStart),
 			zap.Int("probe_advances", maxRetentionProbeAdvances),
 		)
 		return nil
 	}
 	t.metrics.Gauge("probe_advance_exhausted").Update(0)
+	t.probeResumeHeight.Store(0)
 	// Anchor at the minimum start height and age the gauge from the oldest
 	// eligibility across the whole probe set, so neither is masked by
 	// pending-cohort ordering. Stuck pending cohorts are themselves overdue,

--- a/internal/cron/single_block_retention.go
+++ b/internal/cron/single_block_retention.go
@@ -222,6 +222,36 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	t.metrics.Gauge("floor_watermark_height").Update(float64(probeStart))
 	t.metrics.Gauge("probe_range_blocks").Update(float64(approvedEnd - probeStart))
 
+	// Bound the PROBE by the same window that bounds the sweep.
+	//
+	// Without this the probe spans [watermark, approvedEnd] no matter how far
+	// behind retention is, and its cost grows with the backlog rather than with
+	// the work one tick can do. Past roughly 2-3M blocks of width the planner
+	// abandons the index path for the due-cohort expansion join and sequentially
+	// scans the whole block_metadata table, so the probe stops finishing inside
+	// its statement timeout. Measured on robinhood-mainnet prod: 250k blocks of
+	// width runs in 20.7s, 1M in 49.2s, and 6.74M does not complete in 60s.
+	//
+	// That failure cannot clear itself. The watermark is the lowest height still
+	// holding an undeleted single-block object, so it only advances once deletes
+	// land, deletes need the probe to return cohorts, and the frontier keeps
+	// widening the range in the meantime. Enabling retention against a cold
+	// backlog therefore lands past the flip on the very first tick and stays
+	// there (INF-1416; same plan flip as INF-1330 on solana-mainnet).
+	//
+	// probe_range_blocks above deliberately still reports the FULL approved
+	// range, so the backlog remains visible to alerting; probe_window_blocks
+	// reports what was actually scanned.
+	windowBlocks := cronConfig.WindowBlocks
+	if windowBlocks == 0 {
+		windowBlocks = defaultSingleBlockRetentionWindowBlocks
+	}
+	probeEnd := approvedEnd
+	if probeEnd-probeStart > windowBlocks {
+		probeEnd = probeStart + windowBlocks
+	}
+	t.metrics.Gauge("probe_window_blocks").Update(float64(probeEnd - probeStart))
+
 	probeStartedAt := time.Now()
 	// Asks for a full workflow batch because the selector sorts pending
 	// (in-flight) cohorts by prepared_at ahead of height-ordered due cohorts:
@@ -233,7 +263,7 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 		storageGeneration,
 		tag,
 		probeStart,
-		approvedEnd,
+		probeEnd,
 		eligibilityCutoff,
 		retirement.MaxRetentionCohortsPerWorkflow,
 	)
@@ -253,6 +283,8 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 			zap.Uint64("approved_end_height", approvedEnd),
 			zap.Uint64("floor_watermark_height", probeStart),
 			zap.Uint64("probe_range_blocks", approvedEnd-probeStart),
+			zap.Uint64("probe_end_height", probeEnd),
+			zap.Uint64("probe_window_blocks", probeEnd-probeStart),
 			zap.Bool("has_more", hasMore),
 		)
 		return nil
@@ -279,12 +311,13 @@ func (t *singleBlockRetentionTask) Run(ctx context.Context) (err error) {
 	}
 	t.metrics.Gauge("probe_backlog_truncated").Update(backlogTruncated)
 
-	windowBlocks := cronConfig.WindowBlocks
-	if windowBlocks == 0 {
-		windowBlocks = defaultSingleBlockRetentionWindowBlocks
-	}
 	// The selected cohort lies inside the approved range, so the window is
 	// always non-empty; it is clipped to keep each sweep bounded.
+	//
+	// This deliberately still clips to approvedEnd, NOT to probeEnd. The sweep's
+	// authorization is the operator's approved envelope and narrowing the probe
+	// must never change it. Clipping to probeEnd also underflows when the anchor
+	// sits above it, which silently widened the window past approvedEnd.
 	windowStart := anchor.StartHeight
 	windowEnd := approvedEnd
 	if windowEnd-windowStart > windowBlocks {

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -39,18 +39,39 @@ type retentionCronCohortRepository struct {
 	watermarkErr       error
 	watermarkMinHeight uint64
 
-	// dueFloor drives where the windowed probe anchors. found=false means
-	// nothing is due. When rangeAware is set the double derives both the due
-	// floor and the returned cohorts from the requested range instead of
-	// replaying canned values, which is what lets a test observe a window that
-	// hides due work rather than only asserting the arguments (INF-1416).
-	dueFloor          uint64
-	dueFloorFound     bool
-	dueFloorErr       error
-	dueFloorMinArg    uint64
-	noDueWork         bool
-	rangeAware        bool
-	dueFloorCallCount int
+	// The due/pending cohort fixtures are the SELECTABLE universe: what
+	// production's ListRetentionCohorts could return. rawDueHeights models due
+	// shadow rows that the due-floor candidate sees but the cohort query
+	// excludes (active repair, canonical or metadata mismatch) — the gap
+	// between the two is exactly what the cron's advance loop exists for.
+	//
+	// This double honors range semantics UNCONDITIONALLY, in both the floor
+	// and the cohort listing. An earlier version returned every fixture
+	// regardless of the requested window, so a probe searching entirely the
+	// wrong range still looked correct and the INF-1416 starvation bug was
+	// invisible to every test in this file.
+	rawDueHeights  []uint64
+	dueFloorErr    error
+	dueFloorMinArg uint64
+	dueFloorEndArg uint64
+	dueFloorCalls  int
+}
+
+// dueFloorFixtures returns every height the production due-floor candidate
+// would see: raw due rows plus the start height of every due-eligible or
+// pending cohort (pending rows carry a passed delete_after, so the raw floor
+// sees them too).
+func (r *retentionCronCohortRepository) dueFloorFixtures(eligibilityCutoff time.Time) []uint64 {
+	heights := append([]uint64{}, r.rawDueHeights...)
+	for _, cohort := range r.due {
+		if !cohort.EligibleAt.After(eligibilityCutoff) {
+			heights = append(heights, cohort.StartHeight)
+		}
+	}
+	for _, cohort := range r.pending {
+		heights = append(heights, cohort.StartHeight)
+	}
+	return heights
 }
 
 func (r *retentionCronCohortRepository) RetentionDueFloor(
@@ -58,36 +79,24 @@ func (r *retentionCronCohortRepository) RetentionDueFloor(
 	_ string,
 	_ uint32,
 	minHeight uint64,
+	endHeight uint64,
 	eligibilityCutoff time.Time,
 ) (uint64, bool, error) {
-	r.dueFloorCallCount++
+	r.dueFloorCalls++
 	r.dueFloorMinArg = minHeight
+	r.dueFloorEndArg = endHeight
 	if r.dueFloorErr != nil {
 		return 0, false, r.dueFloorErr
 	}
-	if !r.rangeAware {
-		if r.noDueWork {
-			return 0, false, nil
-		}
-		if r.dueFloorFound {
-			return r.dueFloor, true, nil
-		}
-		// Default: due work begins exactly at the probe floor. That is what
-		// every pre-existing case in this file assumes, so they keep probing
-		// from the watermark as before.
-		return minHeight, true, nil
-	}
-	// Range-aware: the lowest DUE cohort at or above minHeight, mirroring what
-	// the SQL does rather than replaying a canned answer.
 	found := false
 	lowest := uint64(0)
-	for _, cohort := range r.due {
-		if cohort.StartHeight < minHeight || cohort.EligibleAt.After(eligibilityCutoff) {
+	for _, height := range r.dueFloorFixtures(eligibilityCutoff) {
+		if height < minHeight || height >= endHeight {
 			continue
 		}
-		if !found || cohort.StartHeight < lowest {
+		if !found || height < lowest {
 			found = true
-			lowest = cohort.StartHeight
+			lowest = height
 		}
 	}
 	return lowest, found, nil
@@ -122,12 +131,10 @@ func (r *retentionCronCohortRepository) ListRetentionCohorts(
 	if r.err != nil {
 		return nil, nil, r.err
 	}
-	if !r.rangeAware {
-		return r.pending, r.due, nil
-	}
-	// Honour the requested height range. Without this the double returns due
-	// cohorts no matter what window was asked for, so a probe that searches the
-	// wrong window still looks correct and the bug is invisible to tests.
+	// Honour the requested height range unconditionally. Without this the
+	// double returns due cohorts no matter what window was asked for, so a
+	// probe that searches the wrong window still looks correct and the bug is
+	// invisible to tests.
 	return filterCohortsToRange(r.pending, startHeight, endHeight),
 		filterCohortsToRange(r.due, startHeight, endHeight),
 		nil
@@ -248,14 +255,18 @@ func TestSingleBlockRetentionCronLaunchesWindowAnchoredAtOldestDueCohort(t *test
 	require.WithinDuration(t, time.Now().UTC(), request.EligibilityCutoff, time.Minute)
 	require.Nil(t, request.Checkpoint)
 	require.Equal(t, cfg.GetEffectiveBlockTag(0), request.Tag)
-	// The probe walks ONE WINDOW of the approved envelope, not the whole
-	// envelope and not an unbounded range, and asks for a full workflow batch so
-	// pending-cohort ordering cannot mask the oldest due work.
-	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
-	require.Equal(t,
-		cfg.Cron.SingleBlockRetention.ApprovedStartHeight+cfg.Cron.SingleBlockRetention.WindowBlocks,
-		cohortRepository.requestedEndHeight,
-		"the probe must be clipped to one window; spanning to ApprovedEndHeight is what times out (INF-1416)")
+	// The probe walks ONE WINDOW anchored at the due floor — not the whole
+	// envelope (that is what times out, INF-1416) and not the watermark (a
+	// not-yet-due row there would hide due work above the window) — and asks
+	// for a full workflow batch so pending-cohort ordering cannot mask the
+	// oldest due work.
+	require.Equal(t, uint64(430_000_000), cohortRepository.requestedStartHeight)
+	require.Equal(t, uint64(431_000_000), cohortRepository.requestedEndHeight,
+		"the probe must be clipped to one window above the due floor")
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.dueFloorMinArg,
+		"the floor candidate search is bounded below by the approved floor")
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, cohortRepository.dueFloorEndArg,
+		"the floor candidate search is bounded above by the approved end")
 	require.Equal(t, retirement.MaxRetentionCohortsPerWorkflow+1, cohortRepository.requestedLimit)
 }
 
@@ -445,8 +456,17 @@ func TestSingleBlockRetentionCronRequiresProductionDeleteEnablementInProduction(
 }
 
 func TestSingleBlockRetentionCronPropagatesProbeErrors(t *testing.T) {
-	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
 	defer ctrl.Finish()
+	// A due row must exist for the cohort probe to run at all; without one the
+	// floor candidate reports nothing due and the tick idles before Select.
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/cold.cscb.zstd",
+		StartHeight:           cfg.Cron.SingleBlockRetention.ApprovedStartHeight,
+		EndHeight:             cfg.Cron.SingleBlockRetention.ApprovedStartHeight + 1_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
 	cohortRepository.err = errors.New("connection reset")
 
 	err := task.Run(context.Background())
@@ -512,8 +532,17 @@ func TestSingleBlockRetentionCronKeepsApprovedFloorWhenWatermarkIsLower(t *testi
 	defer ctrl.Finish()
 	cohortRepository.watermark = 1_000
 	cohortRepository.watermarkFound = true
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/floor.cscb.zstd",
+		StartHeight:           cfg.Cron.SingleBlockRetention.ApprovedStartHeight,
+		EndHeight:             cfg.Cron.SingleBlockRetention.ApprovedStartHeight + 1_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
 
 	require.NoError(t, task.Run(context.Background()))
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.dueFloorMinArg,
+		"a watermark below the approved floor must not lower the floor search")
 	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
 }
 
@@ -668,9 +697,11 @@ func TestSingleBlockRetentionCronBoundsProbeByWindowBlocks(t *testing.T) {
 	defer ctrl.Finish()
 	cfg.Cron.SingleBlockRetention.WindowBlocks = 200_000
 	// A cold backlog: the watermark sits at the approved floor while the
-	// approved end is ~13.7M blocks above it.
+	// approved end is ~13.7M blocks above it, and due work starts right at
+	// the floor.
 	cohortRepository.watermark = cfg.Cron.SingleBlockRetention.ApprovedStartHeight
 	cohortRepository.watermarkFound = true
+	cohortRepository.rawDueHeights = []uint64{cfg.Cron.SingleBlockRetention.ApprovedStartHeight}
 
 	require.NoError(t, task.Run(context.Background()))
 
@@ -694,6 +725,13 @@ func TestSingleBlockRetentionCronProbesWholeRangeWhenNarrowerThanWindow(t *testi
 	cfg.Cron.SingleBlockRetention.WindowBlocks = 1_000_000
 	cohortRepository.watermark = cfg.Cron.SingleBlockRetention.ApprovedEndHeight - 50_000
 	cohortRepository.watermarkFound = true
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/tail.cscb.zstd",
+		StartHeight:           cfg.Cron.SingleBlockRetention.ApprovedEndHeight - 50_000,
+		EndHeight:             cfg.Cron.SingleBlockRetention.ApprovedEndHeight - 50_000 + 1_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
 
 	require.NoError(t, task.Run(context.Background()))
 
@@ -750,7 +788,6 @@ func TestSingleBlockRetentionCronFindsDueWorkBeyondAnEmptyFirstWindow(t *testing
 	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
 	defer ctrl.Finish()
 	cfg.Cron.SingleBlockRetention.WindowBlocks = 200
-	cohortRepository.rangeAware = true
 
 	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
 	// The watermark pins here: undeleted, but NOT due for another hour.
@@ -787,11 +824,114 @@ func TestSingleBlockRetentionCronFindsDueWorkBeyondAnEmptyFirstWindow(t *testing
 func TestSingleBlockRetentionCronIdlesWhenNothingIsDueAnywhere(t *testing.T) {
 	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
 	defer ctrl.Finish()
-	cohortRepository.noDueWork = true
 
 	require.NoError(t, task.Run(context.Background()))
 
 	require.Empty(t, runtime.executions)
 	require.Zero(t, cohortRepository.requestedEndHeight,
 		"with nothing due the cron must not run the expensive due-cohort probe at all")
+}
+
+// TestSingleBlockRetentionCronAdvancesPastUnselectableWindow is the regression
+// guard for the second-round review finding on INF-1416. The due-floor
+// candidate deliberately does not evaluate join-level selectability, so a due
+// row covered by an active repair (or missing canonical membership) can sit at
+// the floor. Anchoring one window there and idling when it selects nothing
+// would pin the search on that row forever — the deeper version of the same
+// starvation the first fix addressed. The cron must step past such a window
+// and find the selectable cohort above it, in the same tick.
+func TestSingleBlockRetentionCronAdvancesPastUnselectableWindow(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200
+	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	// A due shadow row the cohort query cannot return (e.g. repair-covered):
+	// visible to the floor candidate, absent from the selectable fixtures.
+	cohortRepository.rawDueHeights = []uint64{floor}
+	// The selectable cohort sits beyond the first 200-block window.
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/selectable.cscb.zstd",
+		StartHeight:           floor + 300,
+		EndHeight:             floor + 400,
+		RowCount:              100,
+		EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Len(t, runtime.executions, 1,
+		"a due-but-unselectable row at the floor must not hide the selectable cohort above the window")
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.Equal(t, floor+300, request.StartHeight)
+	require.Equal(t, floor+300, cohortRepository.requestedStartHeight,
+		"the second probe attempt must anchor on the next due floor, past the dead window")
+	require.GreaterOrEqual(t, cohortRepository.dueFloorCalls, 2,
+		"stepping past a dead window requires a fresh floor lookup")
+}
+
+// TestSingleBlockRetentionCronAlarmsWhenAdvancesAreExhausted pins that a tick
+// which steps past its full advance budget without finding selectable work
+// raises probe_advance_exhausted instead of idling silently. Due work exists
+// and nothing was launched; the next tick will walk the same dead windows, so
+// this state needs a human, not quiet.
+func TestSingleBlockRetentionCronAlarmsWhenAdvancesAreExhausted(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	scope := newRecordingScope()
+	task.metrics = scope
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200
+	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	// Unselectable due rows in every window the advance budget can reach.
+	for i := uint64(0); i <= uint64(maxRetentionProbeAdvances); i++ {
+		cohortRepository.rawDueHeights = append(cohortRepository.rawDueHeights, floor+i*200)
+	}
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Empty(t, runtime.executions)
+	got, ok := scope.get("probe_advance_exhausted")
+	require.True(t, ok, "an exhausted tick must write the gauge")
+	require.Equal(t, float64(1), got)
+	require.Equal(t, maxRetentionProbeAdvances, cohortRepository.dueFloorCalls)
+}
+
+// TestSingleBlockRetentionCronResetsProbeGaugesOnNoProbeTicks is the two-tick
+// regression for the gauge-staleness review warning: after a tick that probed a
+// real window, a later tick that never probes (approved range fully retired)
+// must not keep exposing the previous tick's scanned width or floor — a stale
+// probe_window_blocks claims a scan that never ran.
+func TestSingleBlockRetentionCronResetsProbeGaugesOnNoProbeTicks(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	scope := newRecordingScope()
+	task.metrics = scope
+	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/a.cscb.zstd",
+		StartHeight:           floor,
+		EndHeight:             floor + 1_000,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
+
+	// Tick 1: a real probe over a real window.
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1)
+	width, ok := scope.get("probe_window_blocks")
+	require.True(t, ok)
+	require.Greater(t, width, float64(0))
+
+	// Tick 2: everything approved is retired — the completed-range early
+	// return, which never probes.
+	cohortRepository.watermark = cfg.Cron.SingleBlockRetention.ApprovedEndHeight
+	cohortRepository.watermarkFound = true
+	runtime.openWorkflowID = nil
+	require.NoError(t, task.Run(context.Background()))
+
+	width, ok = scope.get("probe_window_blocks")
+	require.True(t, ok)
+	require.Zero(t, width, "a no-probe tick must not expose the previous tick's scanned width")
+	dueFloorHeight, ok := scope.get("due_floor_height")
+	require.True(t, ok)
+	require.Zero(t, dueFloorHeight)
 }

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -50,11 +50,12 @@ type retentionCronCohortRepository struct {
 	// regardless of the requested window, so a probe searching entirely the
 	// wrong range still looked correct and the INF-1416 starvation bug was
 	// invisible to every test in this file.
-	rawDueHeights  []uint64
-	dueFloorErr    error
-	dueFloorMinArg uint64
-	dueFloorEndArg uint64
-	dueFloorCalls  int
+	rawDueHeights   []uint64
+	dueFloorErr     error
+	dueFloorMinArg  uint64
+	dueFloorMinArgs []uint64
+	dueFloorEndArg  uint64
+	dueFloorCalls   int
 }
 
 // dueFloorFixtures returns every height the production due-floor candidate
@@ -84,6 +85,7 @@ func (r *retentionCronCohortRepository) RetentionDueFloor(
 ) (uint64, bool, error) {
 	r.dueFloorCalls++
 	r.dueFloorMinArg = minHeight
+	r.dueFloorMinArgs = append(r.dueFloorMinArgs, minHeight)
 	r.dueFloorEndArg = endHeight
 	if r.dueFloorErr != nil {
 		return 0, false, r.dueFloorErr
@@ -934,4 +936,93 @@ func TestSingleBlockRetentionCronResetsProbeGaugesOnNoProbeTicks(t *testing.T) {
 	dueFloorHeight, ok := scope.get("due_floor_height")
 	require.True(t, ok)
 	require.Zero(t, dueFloorHeight)
+}
+
+// TestSingleBlockRetentionCronResumesBeyondDeadPrefixAcrossTicks is the
+// regression guard for the third-round review finding on INF-1416: exhausting
+// the advance budget must not permanently starve selectable work beyond the
+// dead prefix. Without the resume cursor every tick restarts from the
+// watermark, re-walks the same four dead windows, and the selectable cohort in
+// the fifth window is never probed — alarmed, but starved forever. With it,
+// consecutive ticks ratchet through the dead zone and launch.
+func TestSingleBlockRetentionCronResumesBeyondDeadPrefixAcrossTicks(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	scope := newRecordingScope()
+	task.metrics = scope
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200
+	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	// Five consecutive dead windows: due rows the cohort query cannot return.
+	for i := uint64(0); i <= uint64(maxRetentionProbeAdvances); i++ {
+		cohortRepository.rawDueHeights = append(cohortRepository.rawDueHeights, floor+i*200)
+	}
+	// The selectable cohort sits in the window after the dead zone.
+	target := floor + uint64(maxRetentionProbeAdvances+1)*200
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/beyond.cscb.zstd",
+		StartHeight:           target,
+		EndHeight:             target + 100,
+		RowCount:              100,
+		EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+	}}
+
+	// Tick 1: walks the first four dead windows, exhausts, launches nothing.
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+	exhausted, ok := scope.get("probe_advance_exhausted")
+	require.True(t, ok)
+	require.Equal(t, float64(1), exhausted)
+
+	// Tick 2: resumes where tick 1 stopped, steps past the last dead window,
+	// and launches on the selectable cohort.
+	require.NoError(t, task.Run(context.Background()))
+	require.Len(t, runtime.executions, 1,
+		"selectable work beyond the advance budget must be reached by the next tick, not starved")
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.Equal(t, target, request.StartHeight)
+	exhausted, ok = scope.get("probe_advance_exhausted")
+	require.True(t, ok)
+	require.Zero(t, exhausted, "a launching tick clears the exhaustion alarm")
+
+	// Tick 3: the launch reset the ring — the floor search starts from the
+	// watermark again, so dead-prefix rows that later become selectable are
+	// re-inspected rather than skipped forever.
+	runtime.executions = nil
+	cohortRepository.dueFloorMinArgs = nil
+	require.NoError(t, task.Run(context.Background()))
+	require.NotEmpty(t, cohortRepository.dueFloorMinArgs)
+	require.Equal(t, floor, cohortRepository.dueFloorMinArgs[0],
+		"after a launch the walk must restart from the watermark, not the old cursor")
+}
+
+// TestSingleBlockRetentionCronWrapsRingWhenNothingDueBeyondDeadZone pins the
+// other end of the ring: when the walk resumes past the dead zone and finds
+// nothing due above it, the cursor resets so the next tick re-inspects the
+// dead prefix from the watermark — its rows mature (repairs complete, clocks
+// pass) and must not be skipped forever either.
+func TestSingleBlockRetentionCronWrapsRingWhenNothingDueBeyondDeadZone(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200
+	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	// A dead zone one window wider than the advance budget, nothing beyond it.
+	for i := uint64(0); i <= uint64(maxRetentionProbeAdvances); i++ {
+		cohortRepository.rawDueHeights = append(cohortRepository.rawDueHeights, floor+i*200)
+	}
+
+	// Tick 1 exhausts inside the dead zone.
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+
+	// Tick 2 resumes, clears the final dead window, finds nothing due above,
+	// and wraps.
+	require.NoError(t, task.Run(context.Background()))
+	require.Empty(t, runtime.executions)
+
+	// Tick 3 starts from the watermark again.
+	cohortRepository.dueFloorMinArgs = nil
+	require.NoError(t, task.Run(context.Background()))
+	require.NotEmpty(t, cohortRepository.dueFloorMinArgs)
+	require.Equal(t, floor, cohortRepository.dueFloorMinArgs[0],
+		"after the ring wraps, the walk must restart from the watermark")
 }

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -177,11 +177,14 @@ func TestSingleBlockRetentionCronLaunchesWindowAnchoredAtOldestDueCohort(t *test
 	require.WithinDuration(t, time.Now().UTC(), request.EligibilityCutoff, time.Minute)
 	require.Nil(t, request.Checkpoint)
 	require.Equal(t, cfg.GetEffectiveBlockTag(0), request.Tag)
-	// The probe walks the approved envelope, not an unbounded range, and asks
-	// for a full workflow batch so pending-cohort ordering cannot mask the
-	// oldest due work.
+	// The probe walks ONE WINDOW of the approved envelope, not the whole
+	// envelope and not an unbounded range, and asks for a full workflow batch so
+	// pending-cohort ordering cannot mask the oldest due work.
 	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
-	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, cohortRepository.requestedEndHeight)
+	require.Equal(t,
+		cfg.Cron.SingleBlockRetention.ApprovedStartHeight+cfg.Cron.SingleBlockRetention.WindowBlocks,
+		cohortRepository.requestedEndHeight,
+		"the probe must be clipped to one window; spanning to ApprovedEndHeight is what times out (INF-1416)")
 	require.Equal(t, retirement.MaxRetentionCohortsPerWorkflow+1, cohortRepository.requestedLimit)
 }
 
@@ -575,4 +578,82 @@ func TestSingleBlockRetentionCronProbeFailedGaugeTracksOutcome(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, float64(0), got)
 	})
+}
+
+// TestSingleBlockRetentionCronBoundsProbeByWindowBlocks is the regression guard
+// for INF-1416. WindowBlocks used to bound only the launched sweep, so the probe
+// spanned [watermark, approvedEnd] however far behind retention had fallen and
+// its cost grew with the backlog instead of with one tick's work.
+//
+// That is not a tuning nit. Past roughly 2-3M blocks of width the planner
+// abandons the index path for the due-cohort expansion join and sequentially
+// scans the whole block_metadata table; measured on robinhood-mainnet prod, 250k
+// of width ran in 20.7s, 1M in 49.2s, and 6.74M did not finish inside the 60s
+// statement timeout. Nor can it recover on its own: the watermark only advances
+// once deletes land, deletes need the probe to return cohorts, and the frontier
+// keeps widening the range meanwhile.
+func TestSingleBlockRetentionCronBoundsProbeByWindowBlocks(t *testing.T) {
+	task, _, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200_000
+	// A cold backlog: the watermark sits at the approved floor while the
+	// approved end is ~13.7M blocks above it.
+	cohortRepository.watermark = cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	cohortRepository.watermarkFound = true
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, cohortRepository.requestedStartHeight)
+	require.Equal(t,
+		cfg.Cron.SingleBlockRetention.ApprovedStartHeight+200_000,
+		cohortRepository.requestedEndHeight,
+		"probe must span exactly one window regardless of how large the backlog is")
+	require.Less(t,
+		cohortRepository.requestedEndHeight-cohortRepository.requestedStartHeight,
+		cfg.Cron.SingleBlockRetention.ApprovedEndHeight-cfg.Cron.SingleBlockRetention.ApprovedStartHeight,
+		"the whole point is that the probe is narrower than the approved envelope")
+}
+
+// TestSingleBlockRetentionCronProbesWholeRangeWhenNarrowerThanWindow pins the
+// other side: when the remaining range is already smaller than one window the
+// probe must not be padded out past the approved end.
+func TestSingleBlockRetentionCronProbesWholeRangeWhenNarrowerThanWindow(t *testing.T) {
+	task, _, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 1_000_000
+	cohortRepository.watermark = cfg.Cron.SingleBlockRetention.ApprovedEndHeight - 50_000
+	cohortRepository.watermarkFound = true
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight-50_000, cohortRepository.requestedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, cohortRepository.requestedEndHeight,
+		"a range narrower than the window must not be widened past the approved end")
+}
+
+// TestSingleBlockRetentionCronKeepsSweepAuthorizationAtApprovedEnd pins that
+// narrowing the probe never narrows -- or widens -- what the sweep is authorized
+// to delete. An earlier revision of the INF-1416 fix clipped the sweep window to
+// the probe end too; that underflowed when the anchor sat above the probe end
+// and silently pushed the window PAST the approved envelope.
+func TestSingleBlockRetentionCronKeepsSweepAuthorizationAtApprovedEnd(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200_000
+	cohortRepository.due = []retirement.RetentionCohort{{
+		ConsolidatedObjectKey: "consolidated/tail.cscb.zstd",
+		StartHeight:           cfg.Cron.SingleBlockRetention.ApprovedEndHeight - 1_000,
+		EndHeight:             cfg.Cron.SingleBlockRetention.ApprovedEndHeight,
+		RowCount:              1_000,
+		EligibleAt:            time.Now().UTC().Add(-time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Len(t, runtime.executions, 1)
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.LessOrEqual(t, request.EndHeight, cfg.Cron.SingleBlockRetention.ApprovedEndHeight,
+		"the sweep window must never extend past the approved end")
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, request.ApprovedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, request.ApprovedEndHeight)
 }

--- a/internal/cron/single_block_retention_test.go
+++ b/internal/cron/single_block_retention_test.go
@@ -38,6 +38,59 @@ type retentionCronCohortRepository struct {
 	watermarkFound     bool
 	watermarkErr       error
 	watermarkMinHeight uint64
+
+	// dueFloor drives where the windowed probe anchors. found=false means
+	// nothing is due. When rangeAware is set the double derives both the due
+	// floor and the returned cohorts from the requested range instead of
+	// replaying canned values, which is what lets a test observe a window that
+	// hides due work rather than only asserting the arguments (INF-1416).
+	dueFloor          uint64
+	dueFloorFound     bool
+	dueFloorErr       error
+	dueFloorMinArg    uint64
+	noDueWork         bool
+	rangeAware        bool
+	dueFloorCallCount int
+}
+
+func (r *retentionCronCohortRepository) RetentionDueFloor(
+	_ context.Context,
+	_ string,
+	_ uint32,
+	minHeight uint64,
+	eligibilityCutoff time.Time,
+) (uint64, bool, error) {
+	r.dueFloorCallCount++
+	r.dueFloorMinArg = minHeight
+	if r.dueFloorErr != nil {
+		return 0, false, r.dueFloorErr
+	}
+	if !r.rangeAware {
+		if r.noDueWork {
+			return 0, false, nil
+		}
+		if r.dueFloorFound {
+			return r.dueFloor, true, nil
+		}
+		// Default: due work begins exactly at the probe floor. That is what
+		// every pre-existing case in this file assumes, so they keep probing
+		// from the watermark as before.
+		return minHeight, true, nil
+	}
+	// Range-aware: the lowest DUE cohort at or above minHeight, mirroring what
+	// the SQL does rather than replaying a canned answer.
+	found := false
+	lowest := uint64(0)
+	for _, cohort := range r.due {
+		if cohort.StartHeight < minHeight || cohort.EligibleAt.After(eligibilityCutoff) {
+			continue
+		}
+		if !found || cohort.StartHeight < lowest {
+			found = true
+			lowest = cohort.StartHeight
+		}
+	}
+	return lowest, found, nil
 }
 
 func (r *retentionCronCohortRepository) RetentionFloorWatermark(
@@ -69,7 +122,25 @@ func (r *retentionCronCohortRepository) ListRetentionCohorts(
 	if r.err != nil {
 		return nil, nil, r.err
 	}
-	return r.pending, r.due, nil
+	if !r.rangeAware {
+		return r.pending, r.due, nil
+	}
+	// Honour the requested height range. Without this the double returns due
+	// cohorts no matter what window was asked for, so a probe that searches the
+	// wrong window still looks correct and the bug is invisible to tests.
+	return filterCohortsToRange(r.pending, startHeight, endHeight),
+		filterCohortsToRange(r.due, startHeight, endHeight),
+		nil
+}
+
+func filterCohortsToRange(cohorts []retirement.RetentionCohort, startHeight, endHeight uint64) []retirement.RetentionCohort {
+	filtered := make([]retirement.RetentionCohort, 0, len(cohorts))
+	for _, cohort := range cohorts {
+		if cohort.StartHeight >= startHeight && cohort.StartHeight < endHeight {
+			filtered = append(filtered, cohort)
+		}
+	}
+	return filtered
 }
 
 func newSingleBlockRetentionCronTask(t *testing.T, configOpts ...config.ConfigOption) (
@@ -656,4 +727,71 @@ func TestSingleBlockRetentionCronKeepsSweepAuthorizationAtApprovedEnd(t *testing
 		"the sweep window must never extend past the approved end")
 	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, request.ApprovedStartHeight)
 	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, request.ApprovedEndHeight)
+}
+
+// TestSingleBlockRetentionCronFindsDueWorkBeyondAnEmptyFirstWindow is the
+// regression guard for the review finding on INF-1416: a windowed probe must not
+// be able to hide due work behind a not-yet-due row at its floor.
+//
+// RetentionFloorWatermark is the lowest UNDELETED height and deliberately does
+// not filter on due time, so it pins to a row that is not due yet. Anchoring a
+// bounded probe there searches [watermark, watermark+window), finds nothing, and
+// idles -- and because the watermark is recomputed identically every tick, due
+// work above the window is never discovered until the low row matures. The
+// pre-windowed probe spanned the whole approved range and could not hide it.
+//
+// The interleaving is reachable in production: out-of-order backfill and repair
+// promotion set each row's retention clock independently.
+//
+// This case is range-aware on purpose. A double that returns due cohorts
+// regardless of the requested window cannot observe this bug at all -- it would
+// pass while the probe searched entirely the wrong range.
+func TestSingleBlockRetentionCronFindsDueWorkBeyondAnEmptyFirstWindow(t *testing.T) {
+	task, runtime, cohortRepository, _, cfg, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cfg.Cron.SingleBlockRetention.WindowBlocks = 200
+	cohortRepository.rangeAware = true
+
+	floor := cfg.Cron.SingleBlockRetention.ApprovedStartHeight
+	// The watermark pins here: undeleted, but NOT due for another hour.
+	cohortRepository.watermark = floor
+	cohortRepository.watermarkFound = true
+	cohortRepository.due = []retirement.RetentionCohort{{
+		// Due, but 300 blocks up — outside a 200-block window anchored at the
+		// watermark.
+		ConsolidatedObjectKey: "consolidated/later.cscb.zstd",
+		StartHeight:           floor + 300,
+		EndHeight:             floor + 400,
+		RowCount:              100,
+		EligibleAt:            time.Now().UTC().Add(-2 * time.Hour),
+	}}
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Len(t, runtime.executions, 1,
+		"due work 300 blocks above a 200-block window must still be found; anchoring the window on the not-yet-due watermark hides it forever")
+	request := runtime.executions[0].request.(*workflowpkg.SingleBlockRetentionRequest)
+	require.Equal(t, floor+300, request.StartHeight)
+	// The probe anchored on the due floor, not the watermark.
+	require.Equal(t, floor+300, cohortRepository.requestedStartHeight)
+	require.Equal(t, floor+500, cohortRepository.requestedEndHeight)
+	// Authorization is still the operator's envelope, unchanged.
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedStartHeight, request.ApprovedStartHeight)
+	require.Equal(t, cfg.Cron.SingleBlockRetention.ApprovedEndHeight, request.ApprovedEndHeight)
+}
+
+// TestSingleBlockRetentionCronIdlesWhenNothingIsDueAnywhere pins the other
+// reading of an empty probe: with the window anchored on the due floor, "no due
+// floor" genuinely means nothing is due in the whole approved range, and idling
+// is then correct rather than a hidden backlog.
+func TestSingleBlockRetentionCronIdlesWhenNothingIsDueAnywhere(t *testing.T) {
+	task, runtime, cohortRepository, _, _, ctrl := newSingleBlockRetentionCronTask(t)
+	defer ctrl.Finish()
+	cohortRepository.noDueWork = true
+
+	require.NoError(t, task.Run(context.Background()))
+
+	require.Empty(t, runtime.executions)
+	require.Zero(t, cohortRepository.requestedEndHeight,
+		"with nothing due the cron must not run the expensive due-cohort probe at all")
 }

--- a/internal/storage/retirement/selector.go
+++ b/internal/storage/retirement/selector.go
@@ -50,7 +50,7 @@ type (
 			minHeight uint64,
 		) (uint64, bool, error)
 
-		// RetentionDueFloor returns the lowest height at or above minHeight
+		// RetentionDueFloor returns the lowest height in [minHeight, endHeight)
 		// that is actually DUE at eligibilityCutoff, and whether such a row
 		// exists.
 		//
@@ -62,13 +62,20 @@ type (
 		// cohorts, the tick idles, the watermark is recomputed to the same
 		// not-due row next tick, and due work above the window is never
 		// discovered until the low row matures. Anchoring the window here
-		// instead makes an empty window mean "nothing is due", which is the
-		// only reading under which idling is correct.
+		// instead keeps the probe on due work.
+		//
+		// The returned floor is a CANDIDATE: never above the earliest
+		// selectable row, but possibly below it, because join-level
+		// selectability (canonical membership, metadata match, pending and
+		// repair exclusion) is deliberately not evaluated here — see the
+		// implementation for why folding it in reintroduces the timeout. The
+		// cron advances the search window past floors that select nothing.
 		RetentionDueFloor(
 			ctx context.Context,
 			storageGeneration string,
 			tag uint32,
 			minHeight uint64,
+			endHeight uint64,
 			eligibilityCutoff time.Time,
 		) (uint64, bool, error)
 	}
@@ -287,14 +294,18 @@ func (s *Selector) FloorWatermark(
 	return watermark, nil
 }
 
-// DueFloor resolves the lowest height at or above floorHeight that is due at
-// eligibilityCutoff. found is false when nothing is due, which is the caller's
-// signal to idle rather than to probe a window that cannot contain work.
+// DueFloor resolves the lowest height in [floorHeight, endHeight) that is due
+// at eligibilityCutoff. found is false when nothing is due there, which is the
+// caller's signal to idle rather than to probe a window that cannot contain
+// work. The result is clamped into [floorHeight, endHeight): a repository
+// answer outside the requested range is a bug, and failing closed to
+// "nothing due" beats anchoring a window outside the approved envelope.
 func (s *Selector) DueFloor(
 	ctx context.Context,
 	storageGeneration string,
 	tag uint32,
 	floorHeight uint64,
+	endHeight uint64,
 	eligibilityCutoff time.Time,
 ) (uint64, bool, error) {
 	if s == nil || s.repo == nil {
@@ -303,11 +314,14 @@ func (s *Selector) DueFloor(
 	if !isValidStorageGeneration(storageGeneration) {
 		return 0, false, xerrors.Errorf("unsupported retention cohort storage generation %q", storageGeneration)
 	}
-	dueFloor, found, err := s.repo.RetentionDueFloor(ctx, storageGeneration, tag, floorHeight, eligibilityCutoff)
+	if endHeight <= floorHeight {
+		return 0, false, nil
+	}
+	dueFloor, found, err := s.repo.RetentionDueFloor(ctx, storageGeneration, tag, floorHeight, endHeight, eligibilityCutoff)
 	if err != nil {
 		return 0, false, xerrors.Errorf("failed to resolve retention due floor: %w", err)
 	}
-	if !found {
+	if !found || dueFloor >= endHeight {
 		return 0, false, nil
 	}
 	if dueFloor < floorHeight {

--- a/internal/storage/retirement/selector.go
+++ b/internal/storage/retirement/selector.go
@@ -49,6 +49,28 @@ type (
 			tag uint32,
 			minHeight uint64,
 		) (uint64, bool, error)
+
+		// RetentionDueFloor returns the lowest height at or above minHeight
+		// that is actually DUE at eligibilityCutoff, and whether such a row
+		// exists.
+		//
+		// This is not the same question as RetentionFloorWatermark, and the
+		// difference is load-bearing once the probe is windowed. The watermark
+		// is deliberately conservative by omission and pins to any undeleted
+		// row, due or not. A windowed probe anchored on the watermark can
+		// therefore search [notDueRow, notDueRow+window) forever: it returns no
+		// cohorts, the tick idles, the watermark is recomputed to the same
+		// not-due row next tick, and due work above the window is never
+		// discovered until the low row matures. Anchoring the window here
+		// instead makes an empty window mean "nothing is due", which is the
+		// only reading under which idling is correct.
+		RetentionDueFloor(
+			ctx context.Context,
+			storageGeneration string,
+			tag uint32,
+			minHeight uint64,
+			eligibilityCutoff time.Time,
+		) (uint64, bool, error)
 	}
 
 	Selector struct {
@@ -263,4 +285,33 @@ func (s *Selector) FloorWatermark(
 		return approvedStartHeight, nil
 	}
 	return watermark, nil
+}
+
+// DueFloor resolves the lowest height at or above floorHeight that is due at
+// eligibilityCutoff. found is false when nothing is due, which is the caller's
+// signal to idle rather than to probe a window that cannot contain work.
+func (s *Selector) DueFloor(
+	ctx context.Context,
+	storageGeneration string,
+	tag uint32,
+	floorHeight uint64,
+	eligibilityCutoff time.Time,
+) (uint64, bool, error) {
+	if s == nil || s.repo == nil {
+		return 0, false, xerrors.New("retention cohort repository is required")
+	}
+	if !isValidStorageGeneration(storageGeneration) {
+		return 0, false, xerrors.Errorf("unsupported retention cohort storage generation %q", storageGeneration)
+	}
+	dueFloor, found, err := s.repo.RetentionDueFloor(ctx, storageGeneration, tag, floorHeight, eligibilityCutoff)
+	if err != nil {
+		return 0, false, xerrors.Errorf("failed to resolve retention due floor: %w", err)
+	}
+	if !found {
+		return 0, false, nil
+	}
+	if dueFloor < floorHeight {
+		return floorHeight, true, nil
+	}
+	return dueFloor, true, nil
 }

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -448,39 +448,52 @@ func scanRetentionCohorts(rows *sql.Rows, pending bool) ([]RetentionCohort, erro
 //
 // found is false when no such row exists, meaning the generation has no
 // outstanding single-block work at or above minHeight.
-// RetentionDueFloor returns the lowest height at or above minHeight that is DUE
-// at eligibilityCutoff, and whether such a row exists.
+// RetentionDueFloor returns the lowest height in [minHeight, endHeight) that is
+// DUE at eligibilityCutoff, and whether such a row exists.
 //
-// It is the same shape as RetentionFloorWatermark plus the due-time predicate,
-// and it exists because those two questions diverge in a way that matters once
-// the probe is windowed (INF-1416). The watermark pins to any undeleted row,
-// including one that is not due yet; a window anchored there can be empty while
-// due work sits above it, and because the watermark is recomputed identically
-// every tick the cron would idle forever instead of finding that work.
+// It answers a different question from RetentionFloorWatermark, and the
+// difference is load-bearing once the probe is windowed (INF-1416). The
+// watermark pins to any undeleted row, due or not; a window anchored there can
+// be empty while due work sits above it, and because the watermark is
+// recomputed identically every tick the cron would idle forever instead of
+// finding that work.
 //
-// minHeight carries the same load here as it does for the watermark: it bounds
-// the ascending (tag, height) scan to the approved range. MIN() over that index
-// stops at the first row satisfying the predicate, so the healthy case — the
-// oldest undeleted row is also the oldest due row — costs one index descent.
-// The scan only walks further when a run of not-yet-due rows sits below the
-// first due row, which is exactly the interleaving this function exists to see
-// past, and that run is bounded by the retention delay expressed in blocks.
+// This is deliberately a single-table query — a floor CANDIDATE, not a
+// selectability proof. It matches a superset of the rows the due-cohort query
+// can return (every predicate here also appears there), so the returned floor
+// is never above the earliest selectable row. It can, however, be below it: a
+// due row excluded by the cohort query's join-level predicates (canonical
+// membership, metadata match, pending-retention or active-repair exclusion)
+// still matches here. The cron compensates by advancing the search window when
+// a probe at this floor selects nothing — see maxRetentionProbeAdvances. The
+// join-level predicates are deliberately NOT folded in: with them the planner
+// abandons early termination (it estimates one surviving row, materializes
+// every due row through the joins, and sorts — measured >60s on
+// robinhood-mainnet prod), which would reintroduce the very timeout this
+// query exists to avoid.
 //
-// Deliberately NOT filtered on validated_at, skipped metadata, repair state or
-// pending retention state: as with the watermark, each of those is a reason a
-// row is not deleted yet, and a due row held up by one of them must still hold
-// the floor rather than let the probe step over it.
+// Every predicate of idx_block_consolidation_shadow_retention_due_generation's
+// WHERE clause is stated verbatim so the partial index is provable. That gives
+// the planner two good regimes, both measured on robinhood-mainnet prod
+// (47.8M-row shadow table, 6.7M-row due backlog):
+//
+//   - backlog due: ascending (tag, height) first-match — 2.7ms
+//   - nothing due: partial due index finds the empty due set — 0.08ms
+//
+// The [minHeight, endHeight) bound keeps the worst case inside the approved
+// range rather than the table tail.
 func (r *PostgresRepository) RetentionDueFloor(
 	ctx context.Context,
 	storageGeneration string,
 	tag uint32,
 	minHeight uint64,
+	endHeight uint64,
 	eligibilityCutoff time.Time,
 ) (uint64, bool, error) {
 	if r == nil || r.db == nil {
 		return 0, false, xerrors.New("postgres db is required")
 	}
-	return retentionDueFloor(ctx, r.db, storageGeneration, tag, minHeight, eligibilityCutoff)
+	return retentionDueFloor(ctx, r.db, storageGeneration, tag, minHeight, endHeight, eligibilityCutoff)
 }
 
 func retentionDueFloor(
@@ -489,21 +502,34 @@ func retentionDueFloor(
 	storageGeneration string,
 	tag uint32,
 	minHeight uint64,
+	endHeight uint64,
 	eligibilityCutoff time.Time,
 ) (uint64, bool, error) {
+	if endHeight <= minHeight {
+		return 0, false, nil
+	}
 	query := `
 		SELECT MIN(shadow.height)
 		FROM block_consolidation_shadow shadow
 		WHERE shadow.tag = $1
 			AND shadow.height >= $2
+			AND shadow.height < $3
+			AND shadow.validated_at IS NOT NULL
+			AND shadow.single_block_delete_after IS NOT NULL
+			AND shadow.single_block_delete_after <= $4
 			AND shadow.single_block_object_deleted_at IS NULL
 			AND shadow.single_block_object_key_main IS NOT NULL
 			AND shadow.single_block_object_key_main <> ''
-			AND shadow.single_block_delete_after IS NOT NULL
-			AND shadow.single_block_delete_after <= $3
-			AND ` + storageGenerationMatch(storageGeneration, "$4", "shadow.single_block_storage_generation")
+			AND shadow.consolidated_object_key_main IS NOT NULL
+			AND shadow.consolidated_object_key_main <> ''
+			AND ` + storageGenerationMatch(
+		storageGeneration,
+		"$5",
+		"shadow.single_block_storage_generation",
+		"shadow.consolidated_storage_generation",
+	)
 
-	args := []any{tag, minHeight, eligibilityCutoff.UTC()}
+	args := []any{tag, minHeight, endHeight, eligibilityCutoff.UTC()}
 	if storageGenerationIsBound(storageGeneration) {
 		args = append(args, storageGeneration)
 	}

--- a/internal/storage/retirement/selector_postgres.go
+++ b/internal/storage/retirement/selector_postgres.go
@@ -448,6 +448,90 @@ func scanRetentionCohorts(rows *sql.Rows, pending bool) ([]RetentionCohort, erro
 //
 // found is false when no such row exists, meaning the generation has no
 // outstanding single-block work at or above minHeight.
+// RetentionDueFloor returns the lowest height at or above minHeight that is DUE
+// at eligibilityCutoff, and whether such a row exists.
+//
+// It is the same shape as RetentionFloorWatermark plus the due-time predicate,
+// and it exists because those two questions diverge in a way that matters once
+// the probe is windowed (INF-1416). The watermark pins to any undeleted row,
+// including one that is not due yet; a window anchored there can be empty while
+// due work sits above it, and because the watermark is recomputed identically
+// every tick the cron would idle forever instead of finding that work.
+//
+// minHeight carries the same load here as it does for the watermark: it bounds
+// the ascending (tag, height) scan to the approved range. MIN() over that index
+// stops at the first row satisfying the predicate, so the healthy case — the
+// oldest undeleted row is also the oldest due row — costs one index descent.
+// The scan only walks further when a run of not-yet-due rows sits below the
+// first due row, which is exactly the interleaving this function exists to see
+// past, and that run is bounded by the retention delay expressed in blocks.
+//
+// Deliberately NOT filtered on validated_at, skipped metadata, repair state or
+// pending retention state: as with the watermark, each of those is a reason a
+// row is not deleted yet, and a due row held up by one of them must still hold
+// the floor rather than let the probe step over it.
+func (r *PostgresRepository) RetentionDueFloor(
+	ctx context.Context,
+	storageGeneration string,
+	tag uint32,
+	minHeight uint64,
+	eligibilityCutoff time.Time,
+) (uint64, bool, error) {
+	if r == nil || r.db == nil {
+		return 0, false, xerrors.New("postgres db is required")
+	}
+	return retentionDueFloor(ctx, r.db, storageGeneration, tag, minHeight, eligibilityCutoff)
+}
+
+func retentionDueFloor(
+	ctx context.Context,
+	db retentionCohortQuerier,
+	storageGeneration string,
+	tag uint32,
+	minHeight uint64,
+	eligibilityCutoff time.Time,
+) (uint64, bool, error) {
+	query := `
+		SELECT MIN(shadow.height)
+		FROM block_consolidation_shadow shadow
+		WHERE shadow.tag = $1
+			AND shadow.height >= $2
+			AND shadow.single_block_object_deleted_at IS NULL
+			AND shadow.single_block_object_key_main IS NOT NULL
+			AND shadow.single_block_object_key_main <> ''
+			AND shadow.single_block_delete_after IS NOT NULL
+			AND shadow.single_block_delete_after <= $3
+			AND ` + storageGenerationMatch(storageGeneration, "$4", "shadow.single_block_storage_generation")
+
+	args := []any{tag, minHeight, eligibilityCutoff.UTC()}
+	if storageGenerationIsBound(storageGeneration) {
+		args = append(args, storageGeneration)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, false, xerrors.Errorf("failed to query retention due floor: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return 0, false, xerrors.Errorf("failed to iterate retention due floor: %w", err)
+		}
+		return 0, false, nil
+	}
+	var height sql.NullInt64
+	if err := rows.Scan(&height); err != nil {
+		return 0, false, xerrors.Errorf("failed to scan retention due floor: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, false, xerrors.Errorf("failed to iterate retention due floor: %w", err)
+	}
+	if !height.Valid || height.Int64 < 0 {
+		return 0, false, nil
+	}
+	return uint64(height.Int64), true, nil
+}
+
 func (r *PostgresRepository) RetentionFloorWatermark(
 	ctx context.Context,
 	storageGeneration string,

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -31,6 +31,7 @@ type fakeCohortRepository struct {
 	dueFloorFound   bool
 	dueFloorErr     error
 	dueFloorMinArg  uint64
+	dueFloorEndArg  uint64
 	dueFloorCutoff  time.Time
 	dueFloorCallCnt int
 }
@@ -40,10 +41,12 @@ func (r *fakeCohortRepository) RetentionDueFloor(
 	_ string,
 	_ uint32,
 	minHeight uint64,
+	endHeight uint64,
 	eligibilityCutoff time.Time,
 ) (uint64, bool, error) {
 	r.dueFloorCallCnt++
 	r.dueFloorMinArg = minHeight
+	r.dueFloorEndArg = endHeight
 	r.dueFloorCutoff = eligibilityCutoff
 	if r.dueFloorErr != nil {
 		return 0, false, r.dueFloorErr

--- a/internal/storage/retirement/selector_test.go
+++ b/internal/storage/retirement/selector_test.go
@@ -26,6 +26,29 @@ type fakeCohortRepository struct {
 	watermarkGenArg  string
 	watermarkTagArg  uint32
 	watermarkCallCnt int
+
+	dueFloor        uint64
+	dueFloorFound   bool
+	dueFloorErr     error
+	dueFloorMinArg  uint64
+	dueFloorCutoff  time.Time
+	dueFloorCallCnt int
+}
+
+func (r *fakeCohortRepository) RetentionDueFloor(
+	_ context.Context,
+	_ string,
+	_ uint32,
+	minHeight uint64,
+	eligibilityCutoff time.Time,
+) (uint64, bool, error) {
+	r.dueFloorCallCnt++
+	r.dueFloorMinArg = minHeight
+	r.dueFloorCutoff = eligibilityCutoff
+	if r.dueFloorErr != nil {
+		return 0, false, r.dueFloorErr
+	}
+	return r.dueFloor, r.dueFloorFound, nil
 }
 
 func (r *fakeCohortRepository) RetentionFloorWatermark(


### PR DESCRIPTION
## Problem

Robinhood enabled single-block retention (monorepo #15682) against a **6.74M-block cold backlog**, and every hourly tick since died at the 60 s statement timeout in `listDueRetentionCohorts` — 5/5 ticks, zero cohorts selected, zero workflows, zero deletes.

The root cause: `WindowBlocks` bounded the launched **sweep** but not the **probe**. The probe spanned `[floorWatermark, approvedEnd)` however far behind retention had fallen, so its cost grew with the backlog instead of with one tick's work. Past ~2–3M blocks of width the planner abandons the index path for the due-cohort expansion join and sequentially scans all 47.8M rows of `block_metadata` — the same plan flip as INF-1330 on solana-mainnet. Measured on prod:

| probe range | plan cost | measured |
|---|---|---|
| 250k | 476,477 | 20.7 s |
| 1M | 1,621,822 | 49.2 s |
| 3M | 4,859,681 | seq-scans `block_metadata` |
| 6.74M (live) | 5,004,793 | **>60 s, times out** |

And it cannot self-recover: the watermark only advances once deletes land, deletes need the probe to return cohorts, and the frontier widens the range ~860k blocks/day.

Linear: [INF-1416](https://linear.app/cipherowl/issue/INF-1416/bound-the-retention-probe-by-window-blocks-so-its-cost-is-owindow-not)

## The change

Per-tick probing is now: **watermark → due floor → one bounded window → advance if dead → resume next tick.**

**1. The probe is one `window_blocks`-sized window, not the whole backlog** (`c165577`). Probe cost is O(window) and cannot drift back as the chain grows. The sweep window still clips to `approvedEnd` — narrowing the probe never changes what the sweep is *authorized* to delete.

**2. The window anchors on the earliest DUE height, not the watermark** (`42e50f6`, first review round). The watermark deliberately pins to any undeleted row, due or not; a window anchored on a not-yet-due row could be empty while due work sat above it — recomputed identically every tick, forever. A new `RetentionDueFloor` query finds the earliest due row in `[start, approvedEnd)`. It states every predicate of the partial due index verbatim so the index is provable, and is measured on the production-sized table in both regimes:

| regime | plan | measured |
|---|---|---|
| backlog due (6.7M rows) | ascending `(tag,height)` first-match | 2.7 ms |
| nothing due | partial due index, empty set | 0.08 ms |

**3. The floor is a cheap *candidate*, and the cron advances past dead windows** (`25ffd8b`, second round). Selectability is decided at the join level (canonical membership, metadata match, pending/repair exclusion), which the floor query deliberately does **not** evaluate — folding the joins in makes the planner materialize every due row and sort (measured >60 s on prod, the original timeout again). So the floor can land on a due-but-unselectable row; the cron compensates by stepping past up to `maxRetentionProbeAdvances` (4) windows per tick whose due rows all prove unselectable. Each advance is one ~3 ms floor lookup plus one bounded probe that selects nothing. Exhausting the budget raises `probe_advance_exhausted` and warns.

**4. An exhausted walk resumes next tick instead of restarting** (`94cb0a3`, third round). Without this, a dead zone wider than the budget was re-walked identically every tick — alarmed, but starving anything beyond it permanently. An exhausted tick stores where it stopped (`probeResumeHeight`, in-memory); the next tick continues from there, so consecutive ticks ratchet through a dead zone of any width at unchanged per-tick cost. The cursor is a ring: a launch, a nothing-due tick, or a completed range resets it to the watermark, so dead-prefix rows that mature (repairs complete, clocks pass) are re-inspected on the next pass. In-memory by design — a persisted cursor would need reconciliation against repairs and completed sweeps, while losing this one on restart merely re-inspects windows, never skips any.

## Observability

- `probe_range_blocks` still reports the **full** approved backlog (the width alarm keeps seeing it); new `probe_window_blocks` reports what was actually scanned.
- New gauges: `due_floor_height`, `probe_advance_exhausted`; `resume_height` in the exhaustion warn log.
- `probe_duration_seconds` now covers the whole search — floor lookups, probes, advances.
- Probe-only gauges are written on every no-probe path (completed range, nothing due, workflow already open), so no tick exhibits the previous tick's values. `oldest_due_age_seconds` is deliberately not reset on the open-workflow path — zeroing it would silence the age alarm exactly when a sweep is stuck.

## Tests

The cron test double now honors range and floor semantics **unconditionally** — the earlier double returned fixtures regardless of the requested window, which is precisely why the first revision's starvation bug was invisible to its tests. `rawDueHeights` models due-but-unselectable rows (the floor sees them; the cohort listing excludes them).

Each round's starvation mode has a regression test verified to fail with its fix reverted (zero executions where one is expected — the reviewed symptom each time):

- `BoundsProbeByWindowBlocks` — the probe spans one window, not the backlog
- `FindsDueWorkBeyondAnEmptyFirstWindow` — not-yet-due watermark row can't hide due work
- `AdvancesPastUnselectableWindow` — due-but-unselectable floor row can't pin the window
- `ResumesBeyondDeadPrefixAcrossTicks` — a dead zone wider than the budget can't starve work beyond it
- `WrapsRingWhenNothingDueBeyondDeadZone` / `KeepsSweepAuthorizationAtApprovedEnd` / `ResetsProbeGaugesOnNoProbeTicks` — ring wrap, sweep authorization, gauge hygiene

`go build ./...`, `gofmt`, `go vet`, `go test ./internal/cron/... ./internal/storage/retirement/...` all pass.

## Rollout

The effect lands with a monorepo config change after this merges and the image is pinned: robinhood `window_blocks: 200000` → 20 cohorts × 10,000 blocks per hourly tick against a ~35.8k blocks/hour chain rate (~5.6× headroom); the 6.74M backlog drains in ~34 sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wNh6Q1qAX4uDjK8MoCyo6
